### PR TITLE
Feature: Color

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - iosMath (0.9.2)
+  - iosMath (0.9.3)
 
 DEPENDENCIES:
   - iosMath (from `./`)
@@ -9,8 +9,8 @@ EXTERNAL SOURCES:
     :path: ./
 
 SPEC CHECKSUMS:
-  iosMath: 0f978bf5528620d3fc585c33ff969839cfe611c1
+  iosMath: 619e53c34dfa19ac3062869f9974747b44507083
 
 PODFILE CHECKSUM: bade56080a0531a08830155fc215a0a5b44dd183
 
-COCOAPODS: 1.1.1
+COCOAPODS: 1.2.0

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ This is a list of formula types that the library currently supports:
 * Equation alignment
 * Change bold, roman, caligraphic and other font styles (\\bf, \\text, etc.)
 * Most commonly used math symbols
+* Colors
 
 ### Example
 

--- a/iosMath/lib/MTMathList.h
+++ b/iosMath/lib/MTMathList.h
@@ -72,6 +72,7 @@ typedef NS_ENUM(NSUInteger, MTMathAtomType)
     kMTMathAtomSpace = 201,
     /// Denotes style changes during rendering.
     kMTMathAtomStyle,
+    kMTMathAtomColor,
     
     // Atoms after this point are not part of TeX and do not have the usual structure.
     
@@ -145,7 +146,6 @@ typedef NS_ENUM(NSUInteger, MTFontStyle)
 @property (nonatomic, nullable) MTMathList* subScript;
 /** The font style to be used for the atom. */
 @property (nonatomic) MTFontStyle fontStyle;
-@property (nonatomic) NSString* colorString;
 
 /** Returns true if this atom allows scripts (sub or super). */
 - (bool) scriptsAllowed;
@@ -320,6 +320,23 @@ typedef NS_ENUM(unsigned int, MTLineStyle)  {
 
 /** The style represented by this object. */
 @property (nonatomic, readonly) MTLineStyle style;
+
+@end
+
+/** An atom representing an color element.
+ @note None of the usual fields of the `MTMathAtom` apply even though this
+ class inherits from `MTMathAtom`. i.e. it is meaningless to have a value
+ in the nucleus, subscript or superscript fields. */
+@interface MTMathColor : MTMathAtom
+
+/// Creates an empty color with a nil environment
+- (instancetype) init NS_DESIGNATED_INITIALIZER;
+
+/** The style represented by this object. */
+@property (nonatomic, nullable) NSString* colorString;
+
+/// The inner math list
+@property (nonatomic, nullable) MTMathList* innerList;
 
 @end
 

--- a/iosMath/lib/MTMathList.h
+++ b/iosMath/lib/MTMathList.h
@@ -145,6 +145,7 @@ typedef NS_ENUM(NSUInteger, MTFontStyle)
 @property (nonatomic, nullable) MTMathList* subScript;
 /** The font style to be used for the atom. */
 @property (nonatomic) MTFontStyle fontStyle;
+@property (nonatomic) NSString* colorString;
 
 /** Returns true if this atom allows scripts (sub or super). */
 - (bool) scriptsAllowed;

--- a/iosMath/lib/MTMathList.m
+++ b/iosMath/lib/MTMathList.m
@@ -66,6 +66,8 @@ static NSString* typeToText(MTMathAtomType type) {
             return @"Space";
         case kMTMathAtomStyle:
             return @"Style";
+        case kMTMathAtomColor:
+            return @"Color";
         case kMTMathAtomTable:
             return @"Table";
     }
@@ -116,6 +118,9 @@ static NSString* typeToText(MTMathAtomType type) {
             
         case kMTMathAtomSpace:
             return [[MTMathSpace alloc] initWithSpace:0];
+        
+        case kMTMathAtomColor:
+            return [[MTMathColor alloc] init];
             
         default:
             return [[MTMathAtom alloc] initWithType:type value:value];
@@ -161,7 +166,6 @@ static NSString* typeToText(MTMathAtomType type) {
     atom.superScript = [self.superScript copyWithZone:zone];
     atom.indexRange = self.indexRange;
     atom.fontStyle = self.fontStyle;
-    atom.colorString = self.colorString;
     return atom;
 }
 
@@ -649,6 +653,51 @@ static NSString* typeToText(MTMathAtomType type) {
     MTMathStyle* op = [super copyWithZone:zone];
     op->_style = self.style;
     return op;
+}
+
+@end
+
+#pragma mark - MTMathColor
+
+@implementation MTMathColor
+
+
+- (instancetype)init
+{
+    self = [super initWithType:kMTMathAtomColor value:@""];
+    return self;
+}
+
+- (instancetype)initWithType:(MTMathAtomType)type value:(NSString *)value
+{
+    if (type == kMTMathAtomColor) {
+        return [self init];
+    }
+    @throw [NSException exceptionWithName:@"InvalidMethod"
+                                   reason:@"[MTMathColor initWithType:value:] cannot be called. Use [MTMathColor init] instead."
+                                 userInfo:nil];
+}
+
+- (NSString *)stringValue
+{
+    NSMutableString* str = [NSMutableString stringWithString:@"\\color"];
+    [str appendFormat:@"{%@}{%@}", self.colorString, self.innerList.stringValue];
+    return str;
+}
+
+- (id)copyWithZone:(NSZone *)zone
+{
+    MTMathColor* op = [super copyWithZone:zone];
+    op.innerList = [self.innerList copyWithZone:zone];
+    op->_colorString = self.colorString;
+    return op;
+}
+
+- (instancetype)finalized
+{
+    MTMathColor *newInner = [super finalized];
+    newInner.innerList = newInner.innerList.finalized;
+    return newInner;
 }
 
 @end

--- a/iosMath/lib/MTMathList.m
+++ b/iosMath/lib/MTMathList.m
@@ -161,6 +161,7 @@ static NSString* typeToText(MTMathAtomType type) {
     atom.superScript = [self.superScript copyWithZone:zone];
     atom.indexRange = self.indexRange;
     atom.fontStyle = self.fontStyle;
+    atom.colorString = self.colorString;
     return atom;
 }
 

--- a/iosMath/render/MTConfig.h
+++ b/iosMath/render/MTConfig.h
@@ -11,11 +11,13 @@
 // Make TARGET_OS_IPHONE macro visible.
 #include <TargetConditionals.h>
 
+
 // Type definitions.
 #if TARGET_OS_IPHONE
 // TARGET_OS_MAC is defined as 1 for both Mac OS and iOS,
 // so TARGET_OS_IPHONE is reliable.
 @import UIKit;
+#import "UIColor+HexString.h"
 
 typedef UIView          MTView;
 typedef UIColor         MTColor;
@@ -31,6 +33,7 @@ typedef CGRect          MTRect;
 @import AppKit;
 #import "NSBezierPath+addLineToPoint.h"
 #import "NSView+backgroundColor.h"
+#import "NSColor+HexString.h"
 #import "MTLabel.h"
 
 typedef NSView          MTView;

--- a/iosMath/render/MTConfig.h
+++ b/iosMath/render/MTConfig.h
@@ -11,7 +11,6 @@
 // Make TARGET_OS_IPHONE macro visible.
 #include <TargetConditionals.h>
 
-
 // Type definitions.
 #if TARGET_OS_IPHONE
 // TARGET_OS_MAC is defined as 1 for both Mac OS and iOS,

--- a/iosMath/render/MTMathListDisplay.h
+++ b/iosMath/render/MTMathListDisplay.h
@@ -51,6 +51,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) BOOL hasScript;
 /// The text color for this display
 @property (nonatomic, nullable) MTColor *textColor;
+// The local color, if the color was mutated local with the color
+// command
+@property (nonatomic, nullable) MTColor *localTextColor;
 
 @end
 

--- a/iosMath/render/MTMathListDisplay.h
+++ b/iosMath/render/MTMathListDisplay.h
@@ -25,8 +25,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// The base class for rendering a math equation.
 @interface MTDisplay : NSObject
 
-- (void) addColor:(NSString*) colorString;
-
 /// Draws itself in the given graphics context.
 - (void) draw:(CGContextRef) context;
 /// Gets the bounding rectangle for the MTDisplay

--- a/iosMath/render/MTMathListDisplay.h
+++ b/iosMath/render/MTMathListDisplay.h
@@ -25,6 +25,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// The base class for rendering a math equation.
 @interface MTDisplay : NSObject
 
+- (void) addColor:(NSString*) colorString;
+
 /// Draws itself in the given graphics context.
 - (void) draw:(CGContextRef) context;
 /// Gets the bounding rectangle for the MTDisplay

--- a/iosMath/render/MTMathListDisplay.m
+++ b/iosMath/render/MTMathListDisplay.m
@@ -47,6 +47,14 @@ static BOOL isIos6Supported() {
 {
 }
 
+- (void) addColor:(NSString*) colorString
+{
+    MTColor* nativeColor = [MTColor colorFromHexString:colorString];
+    if(nativeColor != nil) {
+        self.textColor = nativeColor;
+    }
+}
+
 - (CGRect) displayBounds
 {
     return CGRectMake(self.position.x, self.position.y - self.descent, self.width, self.ascent + self.descent);
@@ -200,7 +208,9 @@ static BOOL isIos6Supported() {
     // Set the color on all subdisplays
     [super setTextColor:textColor];
     for (MTDisplay* displayAtom in self.subDisplays) {
-        displayAtom.textColor = textColor;
+        if (displayAtom == nil) {
+            displayAtom.textColor = textColor;
+        }
     }
 }
 

--- a/iosMath/render/MTMathListDisplay.m
+++ b/iosMath/render/MTMathListDisplay.m
@@ -47,14 +47,6 @@ static BOOL isIos6Supported() {
 {
 }
 
-- (void) addColor:(NSString*) colorString
-{
-    MTColor* nativeColor = [MTColor colorFromHexString:colorString];
-    if(nativeColor != nil) {
-        self.localTextColor = nativeColor;
-    }
-}
-
 - (CGRect) displayBounds
 {
     return CGRectMake(self.position.x, self.position.y - self.descent, self.width, self.ascent + self.descent);
@@ -129,22 +121,8 @@ static BOOL isIos6Supported() {
 {
     [super setTextColor:textColor];
     NSMutableAttributedString* attrStr = self.attributedString.mutableCopy;
-    
-    // (1) set the color for the complete string
     [attrStr addAttribute:(NSString*)kCTForegroundColorAttributeName value:(id)self.textColor.CGColor
                     range:NSMakeRange(0, attrStr.length)];
-    
-    // (2) overwrite (1), if there was a (local)color before
-    [self.attributedString enumerateAttributesInRange: NSMakeRange(0, self.attributedString.string.length)
-                                              options:NSAttributedStringEnumerationReverse usingBlock:
-     ^(NSDictionary *attributes, NSRange range, BOOL *stop) {
-         if(attributes[NSForegroundColorAttributeName] != nil) {
-             UIColor* col = attributes[NSForegroundColorAttributeName];
-             [attrStr addAttribute:(NSString*)kCTForegroundColorAttributeName value:(id)col.CGColor
-                             range:range];
-         }
-     }];
-    
     self.attributedString = attrStr;
 }
 

--- a/iosMath/render/NSColor+HexString.h
+++ b/iosMath/render/NSColor+HexString.h
@@ -1,0 +1,19 @@
+//
+//  NSColor+HexString.h
+//  iosMath
+//
+//  Created by Markus Sähn on 21/03/2017.
+//
+//
+
+#include <TargetConditionals.h>
+
+#if !TARGET_OS_IPHONE
+#import <Cocoa/Cocoa.h>
+
+@interface NSColor (HexString)
+
++ (NSColor *)colorFromHexString:(NSString *)hexString;
+
+@end
+#endif

--- a/iosMath/render/NSColor+HexString.m
+++ b/iosMath/render/NSColor+HexString.m
@@ -1,0 +1,35 @@
+//
+//  NSColor+HexString.m
+//  iosMath
+//
+//  Created by Markus Sähn on 21/03/2017.
+//
+//
+
+#import "NSColor+HexString.h"
+
+#if !TARGET_OS_IPHONE
+@implementation NSColor (HexString)
+
++ (NSColor *)colorFromHexString:(NSString *)hexString {
+    if ([hexString isEqualToString:@""]) {
+        return nil;
+    }
+    
+    if ([hexString characterAtIndex:0] != '#') {
+        return nil;
+    }
+    
+    unsigned rgbValue = 0;
+    
+    NSScanner *scanner = [NSScanner scannerWithString:hexString];
+    if ([hexString characterAtIndex:0] == '#') {
+        [scanner setScanLocation:1];
+    }
+    
+    [scanner scanHexInt:&rgbValue];
+    return [NSColor colorWithRed:((rgbValue & 0xFF0000) >> 16)/255.0 green:((rgbValue & 0xFF00) >> 8)/255.0 blue:(rgbValue & 0xFF)/255.0 alpha:1.0];
+}
+
+@end
+#endif

--- a/iosMath/render/UIColor+HexString.h
+++ b/iosMath/render/UIColor+HexString.h
@@ -1,0 +1,16 @@
+//
+//  UIColor+HexString.h
+//  iosMath
+//
+//  Created by Markus Sähn on 21/03/2017.
+//
+//
+
+#if TARGET_OS_IPHONE
+
+@interface UIColor (HexString)
+
++ (UIColor *)colorFromHexString:(NSString *)hexString;
+
+@end
+#endif

--- a/iosMath/render/UIColor+HexString.m
+++ b/iosMath/render/UIColor+HexString.m
@@ -1,0 +1,36 @@
+//
+//  UIColor+HexString.m
+//  iosMath
+//
+//  Created by Markus Sähn on 21/03/2017.
+//
+//
+
+#import "UIColor+HexString.h"
+
+#if TARGET_OS_IPHONE
+
+@implementation UIColor (HexString)
+
++ (UIColor *)colorFromHexString:(NSString *)hexString {
+    if ([hexString isEqualToString:@""]) {
+        return nil;
+    }
+    
+    if ([hexString characterAtIndex:0] != '#') {
+        return nil;
+    }
+    
+    unsigned rgbValue = 0;
+    
+    NSScanner *scanner = [NSScanner scannerWithString:hexString];
+    if ([hexString characterAtIndex:0] == '#') {
+        [scanner setScanLocation:1];
+    }
+    
+    [scanner scanHexInt:&rgbValue];
+    return [UIColor colorWithRed:((rgbValue & 0xFF0000) >> 16)/255.0 green:((rgbValue & 0xFF00) >> 8)/255.0 blue:(rgbValue & 0xFF)/255.0 alpha:1.0];
+}
+
+@end
+#endif

--- a/iosMath/render/internal/MTTypesetter.m
+++ b/iosMath/render/internal/MTTypesetter.m
@@ -628,6 +628,7 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
                     MTMathListDisplay* degree = [MTTypesetter createLineForMathList:rad.degree font:_font style:kMTLineStyleScriptScript];
                     [displayRad setDegree:degree fontMetrics:_styleFont.mathTable];
                 }
+                [displayRad addColor: atom.colorString];
                 [_displayAtoms addObject:displayRad];
                 _currentPosition.x += displayRad.width;
                 
@@ -648,6 +649,7 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
                 MTFraction* frac = (MTFraction*) atom;
                 [self addInterElementSpace:prevNode currentType:atom.type];
                 MTDisplay* display = [self makeFraction:frac];
+                [display addColor: atom.colorString];
                 [_displayAtoms addObject:display];
                 _currentPosition.x += display.width;
                 // add super scripts || subscripts
@@ -665,6 +667,7 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
                 [self addInterElementSpace:prevNode currentType:atom.type];
                 MTLargeOperator* op = (MTLargeOperator*) atom;
                 MTDisplay* display = [self makeLargeOp:op];
+                [display addColor: atom.colorString];
                 [_displayAtoms addObject:display];
                 break;
             }
@@ -684,6 +687,7 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
                 }
                 display.position = _currentPosition;
                 _currentPosition.x += display.width;
+                [display addColor: atom.colorString];
                 [_displayAtoms addObject:display];
                 // add super scripts || subscripts
                 if (atom.subScript || atom.superScript) {
@@ -703,6 +707,7 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
                 
                 MTUnderLine* under = (MTUnderLine*) atom;
                 MTDisplay* display = [self makeUnderline:under];
+                [display addColor: atom.colorString];
                 [_displayAtoms addObject:display];
                 _currentPosition.x += display.width;
                 // add super scripts || subscripts
@@ -723,6 +728,7 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
                 
                 MTOverLine* over = (MTOverLine*) atom;
                 MTDisplay* display = [self makeOverline:over];
+                [display addColor: atom.colorString];
                 [_displayAtoms addObject:display];
                 _currentPosition.x += display.width;
                 // add super scripts || subscripts
@@ -743,6 +749,7 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
                 
                 MTAccent* accent = (MTAccent*) atom;
                 MTDisplay* display = [self makeAccent:accent];
+                [display addColor: atom.colorString];
                 [_displayAtoms addObject:display];
                 _currentPosition.x += display.width;
                 
@@ -764,6 +771,7 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
                 
                 MTMathTable* table = (MTMathTable*) atom;
                 MTDisplay* display = [self makeTable:table];
+                [display addColor: atom.colorString];
                 [_displayAtoms addObject:display];
                 _currentPosition.x += display.width;
                 // A table doesn't have subscripts or superscripts
@@ -849,6 +857,7 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
     }
 }
 
+
 - (MTCTLineDisplay*) addDisplayLine
 {
     // add the font
@@ -856,7 +865,28 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
     /*NSAssert(_currentLineIndexRange.length == numCodePoints(_currentLine.string),
      @"The length of the current line: %@ does not match the length of the range (%d, %d)",
      _currentLine, _currentLineIndexRange.location, _currentLineIndexRange.length);*/
-    
+
+    // add the color
+    NSString *immutLine = [_currentLine string];
+    NSUInteger realLength = [immutLine lengthOfBytesUsingEncoding:NSUTF32StringEncoding] / 4;
+    if(_currentAtoms.count == realLength) {
+        __block int i = 0;
+        NSRange fullRange = NSMakeRange(0, [immutLine length]);
+        [immutLine enumerateSubstringsInRange:fullRange
+                              options:NSStringEnumerationByComposedCharacterSequences
+                           usingBlock:^(NSString *substring, NSRange substringRange,
+                                        NSRange enclosingRange, BOOL *stop)
+        {
+            MTMathAtom* item = (MTMathAtom *)_currentAtoms[i];
+            MTColor* nativeColor = [MTColor colorFromHexString:item.colorString];
+            if(nativeColor != nil) {
+                NSDictionary *attrDict = @{ NSForegroundColorAttributeName : nativeColor };
+                [_currentLine addAttributes:attrDict range: substringRange];
+            }
+            i++;
+        }];
+    }
+
     MTCTLineDisplay* displayAtom = [[MTCTLineDisplay alloc] initWithString:_currentLine position:_currentPosition range:_currentLineIndexRange font:_styleFont atoms:_currentAtoms];
     [_displayAtoms addObject:displayAtom];
     // update the position
@@ -1500,6 +1530,7 @@ static const NSInteger kDelimiterShortfallPoints = 5;
         MTDisplay* leftGlyph = [self findGlyphForBoundary:inner.leftBoundary.nucleus withHeight:glyphHeight];
         leftGlyph.position = position;
         position.x += leftGlyph.width;
+        [leftGlyph addColor: inner.colorString];
         [innerElements addObject:leftGlyph];
     }
     
@@ -1511,6 +1542,7 @@ static const NSInteger kDelimiterShortfallPoints = 5;
         MTDisplay* rightGlyph = [self findGlyphForBoundary:inner.rightBoundary.nucleus withHeight:glyphHeight];
         rightGlyph.position = position;
         position.x += rightGlyph.width;
+        [rightGlyph addColor: inner.colorString];
         [innerElements addObject:rightGlyph];
     }
     MTMathListDisplay* innerDisplay = [[MTMathListDisplay alloc] initWithDisplays:innerElements range:inner.indexRange];

--- a/iosMath/render/internal/MTTypesetter.m
+++ b/iosMath/render/internal/MTTypesetter.m
@@ -622,7 +622,7 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
                 }
                 MTMathColor* colorAtom = (MTMathColor*) atom;
                 MTDisplay* display = [MTTypesetter createLineForMathList:colorAtom.innerList font:_font style:_style];
-                display.localTextColor = [UIColor colorFromHexString:colorAtom.colorString];
+                display.localTextColor = [MTColor colorFromHexString:colorAtom.colorString];
                 display.position = _currentPosition;
                 _currentPosition.x += display.width;
                 [_displayAtoms addObject:display];

--- a/iosMathExample/example/ViewController.m
+++ b/iosMathExample/example/ViewController.m
@@ -99,7 +99,7 @@
                                                                                       views:views]];
 
 
-    self.demoLabels[1] = [self createMathLabel:@"(a_1+a_2)^2=a_1^2+2a_1a_2+a_2^2" withHeight:40];
+    self.demoLabels[1] = [self createMathLabel:@"\\color{#ff3399}{(a_1+a_2)^2}=a_1^2+2a_1a_2+a_2^2" withHeight:40];
 
     self.demoLabels[2] = [self createMathLabel:@"\\cos(\\theta + \\varphi) = \
                                  \\cos(\\theta)\\cos(\\varphi) - \\sin(\\theta)\\sin(\\varphi)"
@@ -175,6 +175,8 @@
                            "\\frac{e^x}{2} & x \\geq 0 \\\\"
                            "1 & x < 0"
                            "\\end{cases}" withHeight:60];
+    
+    self.demoLabels[21] = [self createMathLabel:@"\\color{#ff3333}{c}\\color{#9933ff}{o}\\color{#ff0080}{l}+\\color{#99ff33}{\\frac{\\color{#33ff33}{o}}{\\color{#33ff99}{r}}}-\\color{#33ffff}{\\sqrt[\\color{#3399ff}{e}]{\\color{#3333ff}{d}}}" withHeight:60];
 
 
     for (NSUInteger i = 1; i < self.demoLabels.count; i++) {

--- a/iosMathExample/example/ViewController.m
+++ b/iosMathExample/example/ViewController.m
@@ -176,7 +176,7 @@
                            "1 & x < 0"
                            "\\end{cases}" withHeight:60];
     
-    self.demoLabels[21] = [self createMathLabel:@"\\color{#ff3333}{c}\\color{#9933ff}{o}\\color{#ff0080}{l}+\\color{#99ff33}{\\frac{\\color{#33ff33}{o}}{\\color{#33ff99}{r}}}-\\color{#33ffff}{\\sqrt[\\color{#3399ff}{e}]{\\color{#3333ff}{d}}}" withHeight:60];
+    self.demoLabels[21] = [self createMathLabel:@"\\color{#ff3333}{c}\\color{#9933ff}{o}\\color{#ff0080}{l}+\\color{#99ff33}{\\frac{\\color{#ff99ff}{o}}{\\color{#990099}{r}}}-\\color{#33ffff}{\\sqrt[\\color{#3399ff}{e}]{\\color{#3333ff}{d}}}" withHeight:60];
 
 
     for (NSUInteger i = 1; i < self.demoLabels.count; i++) {


### PR DESCRIPTION
**Overview:**
* [x] Support for `color` command
* [x] Add Example to the iosMathExample-App
* [ ] Write Tests

Example:
`a\color{#cccccc}{b}c`

**Note:**
The `color` command is used in Latex in a different way (compare \textcolor<->\color), but this implementation has the same behavior like Katex.