### PR TITLE
renamed MTFontManager singleton name to allow usage in swift

### DIFF
--- a/iosMath/render/MTFontManager.h
+++ b/iosMath/render/MTFontManager.h
@@ -18,7 +18,7 @@
 @interface MTFontManager : NSObject
 
 /** Get the singleton instance of MTFontManager. */
-+ (nonnull instancetype) fontManager;
++ (nonnull instancetype) sharedInstance;
 
 /** Returns the default font, which is Latin Modern Math with 20pt */
 - (nonnull MTFont*) defaultFont;

--- a/iosMath/render/MTFontManager.m
+++ b/iosMath/render/MTFontManager.m
@@ -22,7 +22,7 @@ const int kDefaultFontSize = 20;
 
 @implementation MTFontManager
 
-+ (instancetype) fontManager
++ (instancetype) sharedInstance 
 {
     static MTFontManager* manager = nil;
     if (manager == nil) {

--- a/iosMath/render/MTMathUILabel.m
+++ b/iosMath/render/MTMathUILabel.m
@@ -44,7 +44,7 @@
     _fontSize = 20;
     _contentInsets = MTEdgeInsetsZero;
     _labelMode = kMTMathUILabelModeDisplay;
-    MTFont* font = [MTFontManager fontManager].defaultFont;
+    MTFont* font = [MTFontManager sharedInstance].defaultFont;
     self.font = font;
     _textAlignment = kMTTextAlignmentLeft;
     _displayList = nil;


### PR DESCRIPTION
Because of the way Swift sets up initializers, the **MTFontManager** class singleton (aka fontManager) becomes unavailable.  To allow the singleton to become visible to Swift users, I've renamed the variable from '**fontManager**' to '**sharedInstance**'.

