### PR TITLE
on macOS 10.13, NSSegmentItemImageView returns nil for layer.backgrou…

### DIFF
--- a/iosMath/render/NSView+backgroundColor.m
+++ b/iosMath/render/NSView+backgroundColor.m
@@ -15,6 +15,9 @@
 
 - (NSColor *)backgroundColor
 {
+	if (self.layer.backgroundColor == nil) {
+		return [NSColor clearColor];
+	}
     return [NSColor colorWithCGColor:self.layer.backgroundColor];
 }
 


### PR DESCRIPTION
on macOS 10.13, NSSegmentItemImageView returns nil for layer.backgroundColor which causes a crash. Need to check for this and return a default color (clear)