### PR TITLE
Fixes a check for generating a large op with with scripts under and o…

### DIFF
--- a/iosMath/render/internal/MTTypesetter.m
+++ b/iosMath/render/internal/MTTypesetter.m
@@ -1424,7 +1424,7 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
 
 - (MTDisplay*) makeLargeOp:(MTLargeOperator*) op
 {
-    bool limits = (op.limits && _style == kMTLineStyleDisplay);
+    bool limits = op.limits;
     CGFloat delta = 0;
     if (op.nucleus.length == 1) {
         CGGlyph glyph = [self findGlyphForCharacterAtIndex:0 inString:op.nucleus];
@@ -1470,7 +1470,7 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
         _currentPosition.x += display.width;
         return display;
     }
-    if (op.limits && _style == kMTLineStyleDisplay) {
+    if (op.limits) {
         // make limits
         MTMathListDisplay *superScript = nil, *subScript = nil;
         if (op.superScript) {


### PR DESCRIPTION
…ver when in fractions and other displays not in the main level

@kostub This seems to work fine with all the generated math in the example app. The use case is to have the following:

<img width="57" alt="Screen Shot 2019-08-28 at 8 44 17 PM" src="https://user-images.githubusercontent.com/3393221/63901922-cfea4f80-c9d4-11e9-8be6-2120dfcd5a74.png">

instead of this:

<img width="70" alt="Screen Shot 2019-08-28 at 8 46 03 PM" src="https://user-images.githubusercontent.com/3393221/63901973-0922bf80-c9d5-11e9-8f06-b21afe3d4720.png">

