### PR TITLE
Adds a special type for inner displays.

### DIFF
--- a/iosMath/lib/MTMathListIndex.h
+++ b/iosMath/lib/MTMathListIndex.h
@@ -49,7 +49,9 @@ typedef NS_ENUM(unsigned int, MTMathListSubIndexType) {
     /// The subindex indexes into the radicand (only valid for radicals)
     kMTSubIndexTypeRadicand,
     /// The subindex indexes into the degree (only valid for radicals)
-    kMTSubIndexTypeDegree
+    kMTSubIndexTypeDegree,
+    /// The subindex indexes into the inner list (only valid for inner)
+    kMTSubIndexTypeInner
 };
 
 

--- a/iosMath/render/MTMathListDisplay.h
+++ b/iosMath/render/MTMathListDisplay.h
@@ -88,7 +88,9 @@ typedef NS_ENUM(unsigned int, MTLinePosition)  {
     /// Positioned at a subscript
     kMTLinePositionSubscript,
     /// Positioned at a superscript
-    kMTLinePositionSuperscript
+    kMTLinePositionSuperscript,
+    /// Positioned at an inner
+    kMTLinePositionInner
 };
 
 /// Where the line is positioned
@@ -182,6 +184,27 @@ typedef NS_ENUM(unsigned int, MTLinePosition)  {
 /** A display representing the accent. It's position is relative to the current display.
  */
 @property (nonatomic, readonly) MTGlyphDisplay* accent;
+
+@end
+
+/// Rendering of an list with delimiters
+@interface MTInnerDisplay : MTDisplay
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/** A display representing the inner list that can be wrapped in delimiters.
+ It's position is relative to the parent is not treated as a sub-display.
+ */
+@property (nonatomic, readonly) MTMathListDisplay* inner;
+
+/** A display representing the delimiters. Their position is relative
+ to the parent are not treated as a sub-display.
+ */
+@property (nonatomic, readonly, nullable) MTDisplay* leftDelimiter;
+@property (nonatomic, readonly, nullable) MTDisplay* rightDelimiter;
+
+/// Denotes the location in the parent MTList.
+@property (nonatomic, readonly) NSUInteger index;
 
 @end
 

--- a/iosMath/render/MTMathListDisplay.m
+++ b/iosMath/render/MTMathListDisplay.m
@@ -798,3 +798,108 @@ static BOOL isIos6Supported() {
     CGContextRestoreGState(context);
 }
 @end
+
+#pragma mark - MTInnerDisplay
+
+@implementation MTInnerDisplay {
+  MTMathListDisplay *_inner;
+}
+
+- (instancetype) initWithInner:(MTMathListDisplay*) inner leftDelimiter:(MTDisplay*) leftDelimiter rightDelimiter:(MTDisplay*) rightDelimiter atIndex:(NSUInteger) index
+{
+  self = [super init];
+  if (self) {
+    _leftDelimiter = leftDelimiter;
+    _rightDelimiter = rightDelimiter;
+    _inner = inner;
+    _index = index;
+    self.range = NSMakeRange(_index, 1);
+    
+    self.width = leftDelimiter.width + inner.width + rightDelimiter.width;
+  }
+  return self;
+}
+
+- (void)setPosition:(CGPoint)position
+{
+  super.position = position;
+  [self updateLeftDelimiterPosition];
+  [self updateInnerPosition];
+  [self updateRightDelimiterPosition];
+}
+
+- (void) updateLeftDelimiterPosition
+{
+  if (_leftDelimiter) {
+    _leftDelimiter.position = self.position;
+  }
+}
+
+- (void) updateRightDelimiterPosition
+{
+  if (_rightDelimiter) {
+    _rightDelimiter.position = CGPointMake(_inner.position.x + _inner.width, self.position.y);    
+  }
+}
+
+- (void) updateInnerPosition
+{
+  if (_leftDelimiter) {
+    _inner.position = CGPointMake(_leftDelimiter.position.x + _leftDelimiter.width, self.position.y);
+  } else {
+    _inner.position = self.position;
+  }
+}
+
+- (CGFloat)ascent
+{
+  if (_leftDelimiter) {
+    return _leftDelimiter.ascent;
+  }
+  if (_rightDelimiter) {
+    return _rightDelimiter.ascent;
+  }
+  return _inner.ascent;
+}
+
+- (CGFloat)descent
+{
+  if (_leftDelimiter) {
+    return _leftDelimiter.descent;
+  }
+  if (_rightDelimiter) {
+    return _rightDelimiter.descent;
+  }
+  return _inner.descent;
+}
+
+- (CGFloat)width
+{
+  CGFloat w = _inner.width;
+  if (_leftDelimiter) {
+    w += _leftDelimiter.width;
+  }
+  if (_rightDelimiter) {
+    w += _rightDelimiter.width;
+  }
+  return w;
+}
+
+- (void)setTextColor:(MTColor *)textColor
+{
+  [super setTextColor:textColor];
+  self.leftDelimiter.textColor = textColor;
+  self.rightDelimiter.textColor = textColor;
+  _inner.textColor = textColor;
+}
+
+- (void)draw:(CGContextRef)context
+{
+  [super draw:context];
+  // Draw the elements.
+  [self.leftDelimiter draw:context];
+  [self.rightDelimiter draw:context];
+  [_inner draw:context];
+}
+
+@end

--- a/iosMath/render/internal/MTMathListDisplayInternal.h
+++ b/iosMath/render/internal/MTMathListDisplayInternal.h
@@ -111,3 +111,17 @@
 - (instancetype)initWithAccent:(MTGlyphDisplay*) glyph accentee:(MTMathListDisplay*) accentee range:(NSRange) range NS_DESIGNATED_INITIALIZER;
 
 @end
+
+
+@interface MTInnerDisplay ()
+
+- (instancetype) initWithInner:(MTMathListDisplay*) inner leftDelimiter:(MTDisplay*) leftDelimiter rightDelimiter:(MTDisplay*) rightDelimiter atIndex:(NSUInteger) index NS_DESIGNATED_INITIALIZER;
+
+@property (nonatomic) MTMathListDisplay* inner;
+
+@property (nonatomic, nullable) MTDisplay* leftDelimiter;
+@property (nonatomic, nullable) MTDisplay* rightDelimiter;
+
+@property (nonatomic) NSUInteger index;
+
+@end

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -993,33 +993,27 @@
     XCTAssertEqual(display.subDisplays.count, 1);
     
     MTDisplay* sub0 = display.subDisplays[0];
-    XCTAssertTrue([sub0 isKindOfClass:[MTMathListDisplay class]]);
-    MTMathListDisplay* display2 = (MTMathListDisplay*) sub0;
-    XCTAssertEqual(display2.type, kMTLinePositionRegular);
+    XCTAssertTrue([sub0 isKindOfClass:[MTInnerDisplay class]]);
+    MTInnerDisplay* display2 = (MTInnerDisplay*) sub0;
     XCTAssertTrue(CGPointEqualToPoint(display2.position, CGPointZero));
     XCTAssertTrue(NSEqualRanges(display2.range, NSMakeRange(0, 1)));
     XCTAssertFalse(display2.hasScript);
-    XCTAssertEqual(display2.index, NSNotFound);
-    XCTAssertEqual(display2.subDisplays.count, 3);
-    
-    MTDisplay* subLeft = display2.subDisplays[0];
-    XCTAssertTrue([subLeft isKindOfClass:[MTGlyphDisplay class]]);
-    MTGlyphDisplay* glyph = (MTGlyphDisplay*) subLeft;
+    XCTAssertTrue([display2.leftDelimiter isKindOfClass:[MTGlyphDisplay class]]);
+
+    MTGlyphDisplay* glyph = (MTGlyphDisplay*) display2.leftDelimiter;
     XCTAssertTrue(CGPointEqualToPoint(glyph.position, CGPointZero));
     XCTAssertTrue(NSEqualRanges(glyph.range, NSMakeRange(NSNotFound, 0)));
     XCTAssertFalse(glyph.hasScript);
-    
-    MTDisplay* sub3 = display2.subDisplays[1];
-    XCTAssertTrue([sub3 isKindOfClass:[MTMathListDisplay class]]);
-    MTMathListDisplay* display3 = (MTMathListDisplay*) sub3;
-    XCTAssertEqual(display3.type, kMTLinePositionRegular);
-    XCTAssertEqualsCGPoint(display3.position, CGPointMake(7.78, 0), 0.01);
-    XCTAssertTrue(NSEqualRanges(display3.range, NSMakeRange(0, 1)));
-    XCTAssertFalse(display3.hasScript);
-    XCTAssertEqual(display3.index, NSNotFound);
-    XCTAssertEqual(display3.subDisplays.count, 1);
-    
-    MTDisplay* subsub3 = display3.subDisplays[0];
+  
+    XCTAssertTrue([display2.inner isKindOfClass:[MTMathListDisplay class]]);
+    MTMathListDisplay* innerMathListDisplay = (MTMathListDisplay*) display2.inner;
+    XCTAssertEqualsCGPoint(innerMathListDisplay.position, CGPointMake(7.78, 0), 0.001);
+    XCTAssertTrue(NSEqualRanges(innerMathListDisplay.range, NSMakeRange(0, 1)));
+    XCTAssertFalse(innerMathListDisplay.hasScript);
+    XCTAssertEqual(innerMathListDisplay.index, NSNotFound);
+    XCTAssertEqual(innerMathListDisplay.subDisplays.count, 1);
+
+    MTDisplay* subsub3 = innerMathListDisplay.subDisplays[0];
     XCTAssertTrue([subsub3 isKindOfClass:[MTCTLineDisplay class]]);
     MTCTLineDisplay* line = (MTCTLineDisplay*) subsub3;
     XCTAssertEqual(line.atoms.count, 1);
@@ -1027,19 +1021,18 @@
     XCTAssertEqualObjects(line.attributedString.string, @"𝑥");
     XCTAssertTrue(CGPointEqualToPoint(line.position, CGPointZero));
     XCTAssertFalse(line.hasScript);
-    
-    MTDisplay* subRight = display2.subDisplays[2];
-    XCTAssertTrue([subRight isKindOfClass:[MTGlyphDisplay class]]);
-    MTGlyphDisplay* glyph2 = (MTGlyphDisplay*) subRight;
-    XCTAssertEqualsCGPoint(glyph2.position, CGPointMake(19.22, 0), 0.01);
+
+    XCTAssertTrue([display2.rightDelimiter isKindOfClass:[MTGlyphDisplay class]]);
+    MTGlyphDisplay* glyph2 = (MTGlyphDisplay*) display2.rightDelimiter;
+    XCTAssertEqualsCGPoint(glyph2.position, CGPointMake(19.22, 0), 0.001);
     XCTAssertTrue(NSEqualRanges(glyph2.range, NSMakeRange(NSNotFound, 0)), "Got %@ instead", NSStringFromRange(glyph2.range));
     XCTAssertFalse(glyph2.hasScript);
-    
+
     // dimensions
     XCTAssertEqual(display.ascent, display2.ascent);
     XCTAssertEqual(display.descent, display2.descent);
     XCTAssertEqual(display.width, display2.width);
-    
+
     XCTAssertEqualWithAccuracy(display.ascent, 14.97, 0.001);
     XCTAssertEqualWithAccuracy(display.descent, 4.97, 0.001);
     XCTAssertEqualWithAccuracy(display.width, 27, 0.01);


### PR DESCRIPTION
This will allow to reference the positions of the inner display more easily and point math list indexes to them.
While it is not particularly useful within the context of iosMath as a project, it is incredibly useful when implementing inter atom navigation in MathEditor.