### PR TITLE
Fixing Invalid Syntax Crash.

### DIFF
--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -651,7 +651,11 @@ NSString *const MTParseError = @"ParseError";
         currentCol++;
         if (_currentEnv.numRows > currentRow) {
             currentRow = _currentEnv.numRows;
-            rows[currentRow] = [NSMutableArray array];
+            if (rows.count > currentRow) {
+                rows[currentRow] = [NSMutableArray array];
+            } else {
+                [rows addObject:[NSMutableArray array]];
+            }
             currentCol = 0;
         }
     }


### PR DESCRIPTION
There is no check for rows count which is unsafe currently.
If this is not changed the builder crashes for this example:
```
Pr(H | E) \text{ is the probability that the the hypothesis } H \text{ is true given evidence } E \text{ is true} \\
Pr(H) \text{ is the probability that the hypthesis } H \text{ is true prior to } E \\
Pr(\neg H) \text{ is the probability that } H \text{ is false prior to } E \\
Pr(E\vert H) \text{ is the probability ) E \text{ is true given } H \text{ is true} \\
Pr(E\vert\neg H) \text{ is the probability } E \text{ is true given } H \text{ is false} \\```