### PR TITLE
Crash fix for when row has 1 element

### DIFF
--- a/iosMath/lib/MTMathAtomFactory.m
+++ b/iosMath/lib/MTMathAtomFactory.m
@@ -342,7 +342,7 @@ NSString *const MTSymbolDegree = @"\u00B0"; // \circ
         MTMathAtom* spacer = [MTMathAtom atomWithType:kMTMathAtomOrdinary value:@""];
         for (int i = 0; i < table.cells.count; i++) {
             NSArray<MTMathList*>* row = table.cells[i];
-            if (row.count > 1) {
+            if (row.count > 2) {
                 [row[1] insertAtom:spacer atIndex:0];
             }
         }


### PR DESCRIPTION
Not sure when it happens, could not reproduce but we have this crashlog:
```
Incident Identifier: 0dcd6888-08a7-48da-8f54-958f637fa81c
CrashReporter Key:   CB87EE12-3CD0-4A0C-8647-A214D8C59C8F
Hardware Model:      iPad8,11
Process:         <removed>
Path:            /private/var/containers/Bundle/Application/D35D7EDB-8E9C-4A7B-8F62-D264EC97B3EC/Craft.app/Craft
Identifier:     <removed>
Version:         1.7 (268)
Code Type:       arm64
Parent Process:   [1]

Date/Time:       2021-10-10T10:34:30.999Z
Launch Time:     2021-10-10T10:32:00Z
OS Version:      iPhone OS 14.7.1 (18G82)
Report Version:  104

Exception Type:  SIGABRT
Exception Codes: #0 at 0x1c344f334
Crashed Thread:  0

Application Specific Information:
*** Terminating app due to uncaught exception 'NSRangeException', reason: '*** -[__NSArrayM objectAtIndexedSubscript:]: index 1 beyond bounds [0 .. 0]'

Last Exception Backtrace:
0   CoreFoundation                       0x000000019585f708 __exceptionPreprocess + 220
1   libobjc.A.dylib                      0x00000001aa3697a8 objc_exception_throw + 56
2   CoreFoundation                       0x00000001958d19c8 _CFThrowFormattedException + 112
3   CoreFoundation                       0x0000000195749e98 -[__NSArrayM objectAtIndexedSubscript:] + 216
4   iosMath                              0x00000001036874f8 +[MTMathAtomFactory tableWithEnvironment:rows:error:] (MTMathAtomFactory.m:341)
5   iosMath                              0x0000000103693864 -[MTMathListBuilder buildTable:firstList:row:] (MTMathListBuilder.m:661)
6   iosMath                              0x0000000103692a28 -[MTMathListBuilder atomForCommand:] (MTMathListBuilder.m:495)
7   iosMath                              0x0000000103691774 -[MTMathListBuilder buildInternal:stopChar:] (MTMathListBuilder.m:205)
8   iosMath                              0x000000010369114c -[MTMathListBuilder build] (MTMathListBuilder.m:89)
9   iosMath                              0x0000000103693d74 +[MTMathListBuilder buildFromString:error:] (MTMathListBuilder.m:710)
10  iosMath                              0x000000010369a978 -[MTMathUILabel setLatex:] (MTMathUILabel.m:115)
```