### PR TITLE
Fix memory leak in MTFont

### DIFF
--- a/iosMath/render/MTFont.m
+++ b/iosMath/render/MTFont.m
@@ -33,10 +33,10 @@
         NSBundle* bundle = [MTFont fontBundle];
         NSString* fontPath = [bundle pathForResource:name ofType:@"otf"];
         CGDataProviderRef fontDataProvider = CGDataProviderCreateWithFilename(fontPath.UTF8String);
-        self.defaultCGFont = CGFontCreateWithDataProvider(fontDataProvider);
+        _defaultCGFont = CGFontCreateWithDataProvider(fontDataProvider);
         CFRelease(fontDataProvider);
 
-        self.ctFont = CTFontCreateWithGraphicsFont(self.defaultCGFont, size, nil, nil);
+        _ctFont = CTFontCreateWithGraphicsFont(self.defaultCGFont, size, nil, nil);
 
         NSString* mathTablePlist = [bundle pathForResource:name ofType:@"plist"];
         NSDictionary* dict = [NSDictionary dictionaryWithContentsOfFile:mathTablePlist];
@@ -77,11 +77,11 @@
 {
     MTFont* copyFont = [[[self class] alloc] init];
     copyFont.defaultCGFont = self.defaultCGFont;
-    // Retain the font as we are adding another reference to it.
-    CGFontRetain(copyFont.defaultCGFont);
-    copyFont.ctFont = CTFontCreateWithGraphicsFont(self.defaultCGFont, size, nil, nil);
+    CTFontRef newCtFont = CTFontCreateWithGraphicsFont(self.defaultCGFont, size, nil, nil);
+    copyFont.ctFont = newCtFont;
     copyFont.rawMathTable = self.rawMathTable;
     copyFont.mathTable = [[MTFontMathTable alloc] initWithFont:copyFont mathTable:copyFont.rawMathTable];
+    CFRelease(newCtFont);
     return copyFont;
 }
 


### PR DESCRIPTION
MTFont doesn't handle memory management correctly for `CTFontRef` and `CGFontRef`. The [ownership policy](https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFMemoryMgmt/Concepts/Ownership.html#//apple_ref/doc/uid/20001148-CJBEJBHH) for Core Foundation as following:

> **Foundation**:
> 
> - If you create an object (either directly or by making a copy of another object—see [The Create Rule](https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFMemoryMgmt/Concepts/Ownership.html#//apple_ref/doc/uid/20001148-103029)), you own it.
> - If you get an object from somewhere else, you do not own it. If you want to prevent it being disposed of, you must add yourself as an owner (using [CFRetain](https://developer.apple.com/documentation/corefoundation/1521269-cfretain)).
> - If you are an owner of an object, you must relinquish ownership when you have finished using it (using [CFRelease](https://developer.apple.com/documentation/corefoundation/1521153-cfrelease)).
> 
> **The Create Rule**:
> 
> Core Foundation functions have names that indicate when you own a returned object:
> - Object-creation functions that have “Create” embedded in the name
> - Object-duplication functions that have “Copy” embedded in the name

Per the above policy, MTFont shouldn't call `CFRetain` after `CTFontCreateWithGraphicsFont` or `CGFontCreateWithDataProvider` since `CFRetain` is already invoked when creating the objects. 