### PR TITLE
Non-Latin text support via MTTextAtom

### DIFF
--- a/MacOSMathExample/AppDelegate.m
+++ b/MacOSMathExample/AppDelegate.m
@@ -58,7 +58,8 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
 
     // --- Demo formulae — LaTeX strings from MathExamples.h ---
     static const CGFloat demoHeights[] = {
-        60, 40, 40, 80, 60, 40, 40, 40, 40, 60, 40, 40, 60, 60, 60, 70, 70, 140, 60, 90, 60, 60, 70
+        60, 40, 40, 80, 60, 40, 40, 40, 40, 60, 40, 40, 60, 60, 60, 70, 70, 140, 60, 90, 60, 60, 70,
+        60, 60, 60, 70, 60, 60, 60, 60
     };
     NSArray<NSString*>* demoFormulas = MathDemoFormulas();
     for (NSUInteger i = 0; i < demoFormulas.count; i++) {

--- a/MacOSMathExample/AppDelegate.m
+++ b/MacOSMathExample/AppDelegate.m
@@ -59,7 +59,7 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
     // --- Demo formulae — LaTeX strings from MathExamples.h ---
     static const CGFloat demoHeights[] = {
         60, 40, 40, 80, 60, 40, 40, 40, 40, 60, 40, 40, 60, 60, 60, 70, 70, 140, 60, 90, 60, 60, 70,
-        60, 60, 60, 70, 60, 60, 60, 60
+        70, 60, 60, 70, 60, 60, 60, 60
     };
     NSArray<NSString*>* demoFormulas = MathDemoFormulas();
     for (NSUInteger i = 0; i < demoFormulas.count; i++) {

--- a/MathExamples.h
+++ b/MathExamples.h
@@ -90,22 +90,23 @@ static inline NSArray<NSString*>* MathDemoFormulas(void) {
          "-\\color{#33ffff}{\\sqrt[\\color{#3399ff}{e}]{\\color{#3333ff}{d}}}",
         // 22: Explicit-sized vs content-sized delimiters
         @"\\left( \\frac{a}{b} \\right) \\quad \\text{vs.} \\quad \\bigl( \\frac{a}{b} \\bigr)",
-        // 23: Mixed text + math - Latin baseline
-        @"x + \\text{input} + y = \\sum_{i=1}^n x_i",
-        // 24: Mixed text + math - Cyrillic
-        @"x + \\text{Привет} + y = x^2 + 1",
-        // 25: Mixed text + math - CJK
-        @"x + \\text{你好} + y = x^2 + 1",
-        // 26: Mixed text + math - Devanagari
-        @"x + \\text{नमस्ते} + y = x^2 + 1",
-        // 27: Mixed text + math - Arabic
-        @"x + \\text{مرحبا} + y = x^2 + 1",
-        // 28: Mixed text + math - Hebrew
-        @"x + \\text{שלום} + y = x^2 + 1",
-        // 29: All five \\text* styles in one math row
-        @"x + \\textrm{rm} + \\textbf{bf} + \\textit{it} + \\textsf{sf} + \\texttt{tt} = y",
-        // 30: Styled non-Latin text blocks
-        @"\\textbf{Привет} + \\textit{नमस्ते} + \\textsf{你好} + \\texttt{abc}",
+        // 23: Mixed text + math — labelled definition with a fraction
+        @"\\text{velocity} = \\frac{d\\vec{x}}{dt}",
+        // 24: Russian-labelled area-of-a-circle formula
+        @"\\text{Площадь круга} = \\pi r^2",
+        // 25: Chinese-labelled area formula
+        @"\\text{面积} = \\pi r^2",
+        // 26: Hindi-labelled area formula (Devanagari conjuncts + top matras)
+        @"\\text{क्षेत्रफल} = \\pi r^2",
+        // 27: Arabic-labelled area formula (RTL run inside an LTR equation)
+        @"\\text{المساحة} = \\pi r^2",
+        // 28: Hebrew-labelled area formula
+        @"\\text{שטח} = \\pi r^2",
+        // 29: Textbook-style definition exercising all five \\text* styles
+        @"\\textbf{Def.}\\textit{ Let } \\textsf{f}: \\textsf{R} \\to \\textsf{R}, "
+         "\\textrm{ where } \\texttt{f}(x) = x^2",
+        // 30: Styled non-Latin theorem label preceding a math statement
+        @"\\textbf{Теорема:} \\; a^2 + b^2 = c^2 \\quad (\\textit{Пифагор})",
     ];
 }
 

--- a/MathExamples.h
+++ b/MathExamples.h
@@ -17,7 +17,7 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wobjc-string-concatenation"
 
-/// 23 showcase formulae demonstrating the breadth of what iosMath can render.
+/// Gallery demo formulae: math showcase rows followed by mixed text and style checks.
 static inline NSArray<NSString*>* MathDemoFormulas(void) {
     return @[
         // 0: Quadratic formula
@@ -90,22 +90,22 @@ static inline NSArray<NSString*>* MathDemoFormulas(void) {
          "-\\color{#33ffff}{\\sqrt[\\color{#3399ff}{e}]{\\color{#3333ff}{d}}}",
         // 22: Explicit-sized vs content-sized delimiters
         @"\\left( \\frac{a}{b} \\right) \\quad \\text{vs.} \\quad \\bigl( \\frac{a}{b} \\bigr)",
-        // 23: Mixed text + math — Latin
-        @"f(\\text{input}) = \\sum_{i=1}^n x_i",
-        // 24: Mixed text + math — Cyrillic
-        @"\\textbf{Сумма}: \\sum_{i=1}^n a_i = S",
-        // 25: Mixed text + math — Chinese
-        @"\\text{设} f(x) = x^2 + 1",
-        // 26: Mixed text + math — Devanagari
-        @"\\text{योग}: \\sum_{i=1}^n a_i",
-        // 27: Mixed text + math — Hebrew
-        @"\\text{סכום}: \\sum_{i=1}^n a_i",
-        // 28: Mixed text + math — Arabic
-        @"\\text{مجموع}: \\sum_{i=1}^n a_i",
-        // 29: All five \\text* styles in one line
-        @"\\textrm{rm} \\textbf{bf} \\textit{it} \\textsf{sf} \\texttt{tt}",
-        // 30: Text block carrying scripts
-        @"\\textbf{abc}^{2} + \\textit{def}_{0}",
+        // 23: Mixed text + math - Latin baseline
+        @"x + \\text{input} + y = \\sum_{i=1}^n x_i",
+        // 24: Mixed text + math - Cyrillic
+        @"x + \\text{Привет} + y = x^2 + 1",
+        // 25: Mixed text + math - CJK
+        @"x + \\text{你好} + y = x^2 + 1",
+        // 26: Mixed text + math - Devanagari
+        @"x + \\text{नमस्ते} + y = x^2 + 1",
+        // 27: Mixed text + math - Arabic
+        @"x + \\text{مرحبا} + y = x^2 + 1",
+        // 28: Mixed text + math - Hebrew
+        @"x + \\text{שלום} + y = x^2 + 1",
+        // 29: All five \\text* styles in one math row
+        @"x + \\textrm{rm} + \\textbf{bf} + \\textit{it} + \\textsf{sf} + \\texttt{tt} = y",
+        // 30: Styled non-Latin text blocks
+        @"\\textbf{Привет} + \\textit{नमस्ते} + \\textsf{你好} + \\texttt{abc}",
     ];
 }
 

--- a/MathExamples.h
+++ b/MathExamples.h
@@ -90,6 +90,22 @@ static inline NSArray<NSString*>* MathDemoFormulas(void) {
          "-\\color{#33ffff}{\\sqrt[\\color{#3399ff}{e}]{\\color{#3333ff}{d}}}",
         // 22: Explicit-sized vs content-sized delimiters
         @"\\left( \\frac{a}{b} \\right) \\quad \\text{vs.} \\quad \\bigl( \\frac{a}{b} \\bigr)",
+        // 23: Mixed text + math — Latin
+        @"f(\\text{input}) = \\sum_{i=1}^n x_i",
+        // 24: Mixed text + math — Cyrillic
+        @"\\textbf{Сумма}: \\sum_{i=1}^n a_i = S",
+        // 25: Mixed text + math — Chinese
+        @"\\text{设} f(x) = x^2 + 1",
+        // 26: Mixed text + math — Devanagari
+        @"\\text{योग}: \\sum_{i=1}^n a_i",
+        // 27: Mixed text + math — Hebrew
+        @"\\text{סכום}: \\sum_{i=1}^n a_i",
+        // 28: Mixed text + math — Arabic
+        @"\\text{مجموع}: \\sum_{i=1}^n a_i",
+        // 29: All five \\text* styles in one line
+        @"\\textrm{rm} \\textbf{bf} \\textit{it} \\textsf{sf} \\texttt{tt}",
+        // 30: Text block carrying scripts
+        @"\\textbf{abc}^{2} + \\textit{def}_{0}",
     ];
 }
 

--- a/SwiftMathExample/ContentView.swift
+++ b/SwiftMathExample/ContentView.swift
@@ -98,6 +98,21 @@ private let namedExamples: [NamedFormula] = [
         latex: #"\frak Q(\lambda,\hat{\lambda}) = -\frac{1}{2}\mathbb P(O \mid \lambda)\sum_s\sum_m\sum_t \gamma_m^{(s)}(t) +\\ \quad \left(\log(2\pi) + \log\left|\cal C_m^{(s)}\right| + \left(o_t - \hat{\mu}_m^{(s)}\right)^T \cal C_m^{(s)-1}\right)"#,
         height: 130
     ),
+    NamedFormula(
+        title: "Mixed text & math (Latin)",
+        latex: #"f(\text{input}) = \sum_{i=1}^n x_i"#,
+        height: 80
+    ),
+    NamedFormula(
+        title: "Mixed text & math (CJK)",
+        latex: #"\text{设} f(x) = x^2 + 1"#,
+        height: 80
+    ),
+    NamedFormula(
+        title: "Text styles",
+        latex: #"\textrm{rm}\ \textbf{bf}\ \textit{it}\ \textsf{sf}\ \texttt{tt}"#,
+        height: 60
+    ),
 ]
 
 /// Curated, named examples — suitable as a quick-start reference.

--- a/SwiftMathExample/ContentView.swift
+++ b/SwiftMathExample/ContentView.swift
@@ -6,14 +6,13 @@
 //  useful for verifying correctness but not as a beginner reference. This file
 //  restructures the app into two tabs:
 //
-//   • Examples — 10 named, curated formulae (quadratic formula, Euler's
-//     identity, matrices, …) that mirror the README quick-start snippets.
+//   • Examples — named, curated formulae (quadratic formula, Euler's
+//     identity, matrices, ...) that mirror the README quick-start snippets.
 //     Each formula is displayed in a card with a human-readable title, making
 //     the app usable as a first-look reference alongside the documentation.
 //
-//   • Gallery — the original full rendering test suite (22 demo formulae +
-//     48 typesetter cases) preserved verbatim so regression coverage is not
-//     lost.
+//   • Gallery — the full rendering test suite plus visual regression cases
+//     for parser and typesetter features.
 //
 //  This software may be modified and distributed under the terms of the
 //  MIT license. See the LICENSE file for details.
@@ -98,21 +97,6 @@ private let namedExamples: [NamedFormula] = [
         latex: #"\frak Q(\lambda,\hat{\lambda}) = -\frac{1}{2}\mathbb P(O \mid \lambda)\sum_s\sum_m\sum_t \gamma_m^{(s)}(t) +\\ \quad \left(\log(2\pi) + \log\left|\cal C_m^{(s)}\right| + \left(o_t - \hat{\mu}_m^{(s)}\right)^T \cal C_m^{(s)-1}\right)"#,
         height: 130
     ),
-    NamedFormula(
-        title: "Mixed text & math (Latin)",
-        latex: #"f(\text{input}) = \sum_{i=1}^n x_i"#,
-        height: 80
-    ),
-    NamedFormula(
-        title: "Mixed text & math (CJK)",
-        latex: #"\text{设} f(x) = x^2 + 1"#,
-        height: 80
-    ),
-    NamedFormula(
-        title: "Text styles",
-        latex: #"\textrm{rm}\ \textbf{bf}\ \textit{it}\ \textsf{sf}\ \texttt{tt}"#,
-        height: 60
-    ),
 ]
 
 /// Curated, named examples — suitable as a quick-start reference.
@@ -162,7 +146,8 @@ private struct ExampleCard: View {
 private struct GalleryTab: View {
 
     private static let demoHeights: [CGFloat] = [
-        60, 40, 40, 80, 60, 40, 40, 40, 40, 60, 40, 40, 60, 60, 60, 70, 70, 140, 60, 90, 60, 60, 70
+        60, 40, 40, 80, 60, 40, 40, 40, 40, 60, 40, 40, 60, 60, 60, 70, 70, 140, 60, 90, 60, 60, 70,
+        60, 60, 60, 70, 60, 60, 60, 60
     ]
     private static let testHeights: [CGFloat] = [
         40, 40, 40, 40, 40, 60, 60, 60, 90, 30, 40, 90, 40, 60, 60, 60,

--- a/iosMath/lib/MTMathAtomFactory.h
+++ b/iosMath/lib/MTMathAtomFactory.h
@@ -148,6 +148,17 @@ FOUNDATION_EXPORT NSString *const MTSymbolDegree;
 /** Returns the latex font name for a given style. */
 + (NSString*) fontNameForStyle:(MTFontStyle) fontStyle;
 
+/** Look up a text-mode command name (`text`, `textrm`, `textbf`, …) and
+ return the matching `MTTextStyle`. Returns `NSNotFound` for unknown names.
+ */
++ (MTTextStyle) textStyleWithName:(NSString*) name;
+
+/** Inverse of `+textStyleWithName:`. Returns the canonical command name
+ for a given style: `kMTTextStyleRoman` → `@"text"`,
+ `kMTTextStyleBold` → `@"textbf"`, etc.
+ */
++ (NSString*) commandNameForTextStyle:(MTTextStyle) style;
+
 /** Returns a fraction with the given numerator and denominator. */
 + (MTFraction*) fractionWithNumerator:(MTMathList*) num denominator:(MTMathList*) denom
     NS_SWIFT_NAME(fraction(numerator:denominator:));

--- a/iosMath/lib/MTMathAtomFactory.m
+++ b/iosMath/lib/MTMathAtomFactory.m
@@ -103,11 +103,9 @@ NSString *const MTSymbolDegree = @"\u00B0"; // \circ
 + (nullable MTMathAtom *)atomForCharacter:(unichar)ch
 {
     NSString *chStr = [NSString stringWithCharacters:&ch length:1];
-    if (ch > 0x0410 && ch < 0x044F){
-        // show basic cyrillic alphabet. Latin Modern Math font is not good for cyrillic symbols
-        return [MTMathAtom atomWithType:kMTMathAtomOrdinary value:chStr];
-    } else if (ch < 0x21 || ch > 0x7E) {
-        // skip non ascii characters and spaces
+    if (ch < 0x21 || ch > 0x7E) {
+        // skip non ascii characters and spaces. Non-Latin text must be
+        // wrapped in \text*, \textbf{...}, etc.
         return nil;
     } else if (ch == '$' || ch == '%' || ch == '#' || ch == '&' || ch == '~' || ch == '\'') {
         // These are latex control characters that have special meanings. We don't support them.

--- a/iosMath/lib/MTMathAtomFactory.m
+++ b/iosMath/lib/MTMathAtomFactory.m
@@ -253,6 +253,44 @@ NSString *const MTSymbolDegree = @"\u00B0"; // \circ
     return style.integerValue;
 }
 
++ (NSDictionary<NSString*, NSNumber*>*) textStyles
+{
+    static NSDictionary<NSString*, NSNumber*>* textStyles = nil;
+    if (!textStyles) {
+        textStyles = @{
+            @"text":   @(kMTTextStyleRoman),
+            @"textrm": @(kMTTextStyleRoman),
+            @"textbf": @(kMTTextStyleBold),
+            @"textit": @(kMTTextStyleItalic),
+            @"textsf": @(kMTTextStyleSansSerif),
+            @"texttt": @(kMTTextStyleTypewriter),
+        };
+    }
+    return textStyles;
+}
+
++ (MTTextStyle) textStyleWithName:(NSString *)name
+{
+    NSNumber* boxed = [self textStyles][name];
+    if (!boxed) {
+        return (MTTextStyle)NSNotFound;
+    }
+    return (MTTextStyle)boxed.unsignedIntegerValue;
+}
+
++ (NSString*) commandNameForTextStyle:(MTTextStyle)style
+{
+    switch (style) {
+        case kMTTextStyleRoman:      return @"text";
+        case kMTTextStyleBold:       return @"textbf";
+        case kMTTextStyleItalic:     return @"textit";
+        case kMTTextStyleSansSerif:  return @"textsf";
+        case kMTTextStyleTypewriter: return @"texttt";
+    }
+    NSAssert(NO, @"Unknown MTTextStyle %lu", (unsigned long)style);
+    return @"text";
+}
+
 + (NSString *)fontNameForStyle:(MTFontStyle)fontStyle
 {
     switch (fontStyle) {

--- a/iosMath/lib/MTMathAtomFactory.m
+++ b/iosMath/lib/MTMathAtomFactory.m
@@ -924,29 +924,25 @@ NSString *const MTSymbolDegree = @"\u00B0"; // \circ
 {
     static NSDictionary<NSString*, NSNumber*>* fontStyles = nil;
     if (!fontStyles) {
+        // \text* commands are handled by the parser via the textStyles
+        // dictionary, so they do NOT appear here.
         fontStyles = @{
                        @"mathnormal" : @(kMTFontStyleDefault),
                        @"mathrm": @(kMTFontStyleRoman),
-                       @"textrm": @(kMTFontStyleRoman),
                        @"rm": @(kMTFontStyleRoman),
                        @"mathbf": @(kMTFontStyleBold),
                        @"bf": @(kMTFontStyleBold),
-                       @"textbf": @(kMTFontStyleBold),
                        @"mathcal": @(kMTFontStyleCaligraphic),
                        @"cal": @(kMTFontStyleCaligraphic),
                        @"mathtt": @(kMTFontStyleTypewriter),
-                       @"texttt": @(kMTFontStyleTypewriter),
                        @"mathit": @(kMTFontStyleItalic),
-                       @"textit": @(kMTFontStyleItalic),
                        @"mit": @(kMTFontStyleItalic),
                        @"mathsf": @(kMTFontStyleSansSerif),
-                       @"textsf": @(kMTFontStyleSansSerif),
                        @"mathfrak": @(kMTFontStyleFraktur),
                        @"frak": @(kMTFontStyleFraktur),
                        @"mathbb": @(kMTFontStyleBlackboard),
                        @"mathbfit": @(kMTFontStyleBoldItalic),
                        @"bm": @(kMTFontStyleBoldItalic),
-                       @"text": @(kMTFontStyleRoman),
                    };
     }
     return fontStyles;

--- a/iosMath/lib/MTMathList.h
+++ b/iosMath/lib/MTMathList.h
@@ -61,10 +61,14 @@ typedef NS_ENUM(NSUInteger, MTMathAtomType)
     /// A generic over/under stack atom. Supports \overrightarrow, \overleftarrow,
     /// \overleftrightarrow, \underrightarrow, \underleftarrow, \underleftrightarrow,
     /// \overbrace, \underbrace. Future: \stackrel, \overset, \underset.
-    kMTMathAtomStack,
+    kMTMathAtomStack = 18,
+    /// A run of opaque (non-math) Unicode text — \text, \textrm, \textbf,
+    /// \textit, \textsf, \texttt. Captured raw at parse time; the body cannot
+    /// contain math.
+    kMTMathAtomText = 19,
 
     // Atoms after this point do not support subscripts or superscripts
-    
+
     /// A left atom - Left & Right in TeX. We don't need two since we track boundaries separately.
     kMTMathAtomBoundary = 101,
     
@@ -116,6 +120,28 @@ typedef NS_ENUM(NSUInteger, MTFontStyle)
     kMTFontStyleBlackboard,
     /// Bold italic
     kMTFontStyleBoldItalic,
+};
+
+/**
+ @typedef MTTextStyle
+ @brief The "text-mode" font style used by `\text`, `\textrm`, `\textbf`, …
+
+ Distinct from `MTFontStyle` because text-mode renders via system text
+ fonts (with CoreText traits), while `MTFontStyle` controls
+ Unicode-math-alphanumeric remapping for math-mode atoms.
+ */
+typedef NS_ENUM(NSUInteger, MTTextStyle)
+{
+    /// `\text`, `\textrm`
+    kMTTextStyleRoman = 0,
+    /// `\textbf`
+    kMTTextStyleBold,
+    /// `\textit`
+    kMTTextStyleItalic,
+    /// `\textsf`
+    kMTTextStyleSansSerif,
+    /// `\texttt`
+    kMTTextStyleTypewriter,
 };
 
 /** A `MTMathAtom` is the basic unit of a math list. Each atom represents a single character
@@ -459,6 +485,34 @@ typedef NS_ENUM(NSUInteger, MTMathStackConstructionKind) {
 /// The math class used for inter-element spacing after typesetting.
 /// Default: kMTMathAtomOrdinary.
 @property (nonatomic) MTMathAtomType displayClass;
+
+@end
+
+/**
+ An atom representing a run of plain Unicode text (text mode).
+ Created by `\text`, `\textrm`, `\textbf`, `\textit`, `\textsf`, `\texttt`.
+ The body is captured verbatim at parse time — math is not permitted inside.
+ */
+@interface MTTextAtom : MTMathAtom
+
+- (instancetype) init NS_UNAVAILABLE;
++ (instancetype) atomWithType:(MTMathAtomType) type
+                        value:(NSString*) value NS_UNAVAILABLE;
+
+/**
+ Designated initializer. `style` must be a valid `MTTextStyle` value;
+ out-of-range values trigger an assertion in debug builds.
+ */
+- (instancetype) initWithText:(NSString*) text
+                        style:(MTTextStyle) style NS_DESIGNATED_INITIALIZER;
+
+/// The raw Unicode text, with backslash escapes already processed at
+/// parse time. The string may contain characters outside the BMP
+/// (UTF-16 surrogate pairs).
+@property (nonatomic, copy) NSString* text;
+
+/// The text-mode style.
+@property (nonatomic) MTTextStyle textStyle;
 
 @end
 

--- a/iosMath/lib/MTMathList.h
+++ b/iosMath/lib/MTMathList.h
@@ -132,15 +132,15 @@ typedef NS_ENUM(NSUInteger, MTFontStyle)
  */
 typedef NS_ENUM(NSUInteger, MTTextStyle)
 {
-    /// `\text`, `\textrm`
+    /// Upright (roman) text style — the default for `\text` and `\textrm`.
     kMTTextStyleRoman = 0,
-    /// `\textbf`
+    /// Upright bold text style i.e. `\textbf`.
     kMTTextStyleBold,
-    /// `\textit`
+    /// Italic text style i.e. `\textit`.
     kMTTextStyleItalic,
-    /// `\textsf`
+    /// Sans-serif (upright) text style i.e. `\textsf`.
     kMTTextStyleSansSerif,
-    /// `\texttt`
+    /// Typewriter (monospace) text style i.e. `\texttt`.
     kMTTextStyleTypewriter,
 };
 
@@ -513,6 +513,14 @@ typedef NS_ENUM(NSUInteger, MTMathStackConstructionKind) {
 
 /// The text-mode style.
 @property (nonatomic) MTTextStyle textStyle;
+
+/**
+ The set of characters that are special inside a `\text*` body and must be
+ backslash-escaped on serialization (and consumed unescaped on parse).
+ Shared by the parser and the LaTeX writer so the two operations cannot
+ drift out of sync.
+ */
++ (NSCharacterSet *)latexEscapableCharacterSet;
 
 @end
 

--- a/iosMath/lib/MTMathList.m
+++ b/iosMath/lib/MTMathList.m
@@ -149,6 +149,10 @@ static NSString* fractionCommandForDelimiterPair(NSString* leftDelimiter, NSStri
         case kMTMathAtomStack:
             return [[MTMathStack alloc] init];
 
+        case kMTMathAtomText:
+            return [[MTTextAtom alloc] initWithText:value ?: @""
+                                             style:kMTTextStyleRoman];
+
         case kMTMathAtomSpace:
             return [[MTMathSpace alloc] initWithSpace:0];
         
@@ -1274,6 +1278,22 @@ static NSString* fractionCommandForDelimiterPair(NSString* leftDelimiter, NSStri
     @throw [NSException exceptionWithName:@"InvalidMethod"
                                    reason:@"[MTTextAtom initWithType:value:] cannot be called. Use [MTTextAtom initWithText:style:] instead."
                                  userInfo:nil];
+}
+
+- (void)setText:(NSString *)text
+{
+    NSParameterAssert(text);
+    NSString* copiedText = [text copy] ?: @"";
+    _text = copiedText;
+    [super setNucleus:copiedText];
+}
+
+- (void)setNucleus:(NSString *)nucleus
+{
+    NSParameterAssert(nucleus);
+    NSString* copiedNucleus = [nucleus copy] ?: @"";
+    [super setNucleus:copiedNucleus];
+    _text = copiedNucleus;
 }
 
 - (id)copyWithZone:(NSZone *)zone

--- a/iosMath/lib/MTMathList.m
+++ b/iosMath/lib/MTMathList.m
@@ -1296,29 +1296,28 @@ static NSString* fractionCommandForDelimiterPair(NSString* leftDelimiter, NSStri
     return fin;
 }
 
++ (NSCharacterSet *)latexEscapableCharacterSet
+{
+    static NSCharacterSet *set;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        set = [NSCharacterSet characterSetWithCharactersInString:@"\\{}_^%&#$"];
+    });
+    return set;
+}
+
 - (void)appendLaTeXToString:(NSMutableString *)str
 {
     NSString* command = [MTMathAtomFactory commandNameForTextStyle:self.textStyle];
     [str appendFormat:@"\\%@{", command];
 
-    // Escape only the eight characters that are special in TeX text-mode
-    // bodies. All other characters (including arbitrary Unicode) pass
-    // through verbatim.
+    NSCharacterSet* escapable = [MTTextAtom latexEscapableCharacterSet];
     for (NSUInteger i = 0; i < self.text.length; i++) {
         unichar c = [self.text characterAtIndex:i];
-        switch (c) {
-            case '\\': [str appendString:@"\\\\"]; break;
-            case '{':  [str appendString:@"\\{"];  break;
-            case '}':  [str appendString:@"\\}"];  break;
-            case '_':  [str appendString:@"\\_"];  break;
-            case '^':  [str appendString:@"\\^"];  break;
-            case '%':  [str appendString:@"\\%"];  break;
-            case '&':  [str appendString:@"\\&"];  break;
-            case '#':  [str appendString:@"\\#"];  break;
-            case '$':  [str appendString:@"\\$"];  break;
-            default:
-                [str appendFormat:@"%C", c];
-                break;
+        if ([escapable characterIsMember:c]) {
+            [str appendFormat:@"\\%C", c];
+        } else {
+            [str appendFormat:@"%C", c];
         }
     }
     [str appendString:@"}"];

--- a/iosMath/lib/MTMathList.m
+++ b/iosMath/lib/MTMathList.m
@@ -64,6 +64,8 @@ static NSString* typeToText(MTMathAtomType type) {
             return @"Accent";
         case kMTMathAtomStack:
             return @"Stack";
+        case kMTMathAtomText:
+            return @"Text";
         case kMTMathAtomBoundary:
             return @"Boundary";
         case kMTMathAtomSpace:
@@ -1240,6 +1242,86 @@ static NSString* fractionCommandForDelimiterPair(NSString* leftDelimiter, NSStri
         // Programmatically-built stack with non-canonical constructions — emit only the inner list.
         [str appendString:[MTMathListBuilder mathListToString:self.innerList]];
     }
+}
+
+@end
+
+#pragma mark - MTTextAtom
+
+@implementation MTTextAtom
+
+- (instancetype)initWithText:(NSString *)text style:(MTTextStyle)style
+{
+    NSParameterAssert(text);
+    NSParameterAssert(style <= kMTTextStyleTypewriter);
+    // The nucleus is set to the raw text so existing consumers reading
+    // nucleus (e.g. description, stringValue) work reasonably without
+    // changes. fontStyle is left at kMTFontStyleDefault so
+    // mathListToString: does not wrap the atom in a \mathrm{...} group.
+    self = [super initWithType:kMTMathAtomText value:text];
+    if (self) {
+        _text = [text copy];
+        _textStyle = style;
+    }
+    return self;
+}
+
+- (instancetype)initWithType:(MTMathAtomType)type value:(NSString *)value
+{
+    if (type == kMTMathAtomText) {
+        return [self initWithText:value ?: @"" style:kMTTextStyleRoman];
+    }
+    @throw [NSException exceptionWithName:@"InvalidMethod"
+                                   reason:@"[MTTextAtom initWithType:value:] cannot be called. Use [MTTextAtom initWithText:style:] instead."
+                                 userInfo:nil];
+}
+
+- (id)copyWithZone:(NSZone *)zone
+{
+    // [super copyWithZone:] uses [[[self class] alloc] initWithType:self.type value:self.nucleus]
+    // which dispatches to our overridden initWithType:value: (defaulting to Roman style),
+    // and copies fontStyle, indexRange, sub/superScript. We then restore the textStyle
+    // and ensure text is set from the source.
+    MTTextAtom* copy = [super copyWithZone:zone];
+    copy->_text = [self.text copyWithZone:zone];
+    copy->_textStyle = self.textStyle;
+    return copy;
+}
+
+- (instancetype)finalized
+{
+    MTTextAtom* fin = [super finalized];
+    fin->_text = [self.text copy];
+    fin->_textStyle = self.textStyle;
+    return fin;
+}
+
+- (void)appendLaTeXToString:(NSMutableString *)str
+{
+    NSString* command = [MTMathAtomFactory commandNameForTextStyle:self.textStyle];
+    [str appendFormat:@"\\%@{", command];
+
+    // Escape only the eight characters that are special in TeX text-mode
+    // bodies. All other characters (including arbitrary Unicode) pass
+    // through verbatim.
+    for (NSUInteger i = 0; i < self.text.length; i++) {
+        unichar c = [self.text characterAtIndex:i];
+        switch (c) {
+            case '\\': [str appendString:@"\\\\"]; break;
+            case '{':  [str appendString:@"\\{"];  break;
+            case '}':  [str appendString:@"\\}"];  break;
+            case '_':  [str appendString:@"\\_"];  break;
+            case '^':  [str appendString:@"\\^"];  break;
+            case '%':  [str appendString:@"\\%"];  break;
+            case '&':  [str appendString:@"\\&"];  break;
+            case '#':  [str appendString:@"\\#"];  break;
+            case '$':  [str appendString:@"\\$"];  break;
+            default:
+                [str appendFormat:@"%C", c];
+                break;
+        }
+    }
+    [str appendString:@"}"];
 }
 
 @end

--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -291,12 +291,12 @@ NSString *const MTParseError = @"ParseError";
 }
 
 // Reads the {...} body following a \text* command.  The body is captured
-// raw — every code point flows through unchanged except for the eight
-// LaTeX escapes \\, \{, \}, \_, \^, \%, \&, \#, \$ which unescape to their
-// literal character.  Balanced nested {...} groups are accepted as
-// TeX-style grouping (the braces are stripped, the inner content is
-// captured).  Any other backslash sequence is a parse error, as is `$`,
-// any unmatched brace, or a trailing backslash.
+// raw — every code point flows through unchanged except for the backslash
+// escapes accepted by `[MTTextAtom latexEscapableCharacterSet]`, which
+// unescape to their literal character.  Balanced nested {...} groups are
+// accepted as TeX-style grouping (the braces are stripped, the inner
+// content is captured).  Any other backslash sequence is a parse error,
+// as is `$`, any unmatched brace, or a trailing backslash.
 - (NSString*) readTextArgument
 {
     [self skipSpaces];
@@ -310,6 +310,7 @@ NSString *const MTParseError = @"ParseError";
         return nil;
     }
 
+    NSCharacterSet* escapable = [MTTextAtom latexEscapableCharacterSet];
     NSMutableString* body = [NSMutableString string];
     NSInteger depth = 0;
     while ([self hasCharacters]) {
@@ -321,17 +322,14 @@ NSString *const MTParseError = @"ParseError";
                 return nil;
             }
             unichar esc = [self getNextCharacter];
-            switch (esc) {
-                case '\\': case '{': case '}': case '_':
-                case '^':  case '%': case '&': case '#': case '$':
-                    [body appendFormat:@"%C", esc];
-                    break;
-                default:
-                    [self setError:MTParseErrorInvalidCommand
-                           message:[NSString stringWithFormat:
-                                    @"Unsupported escape \\%C in \\text* body",
-                                    esc]];
-                    return nil;
+            if ([escapable characterIsMember:esc]) {
+                [body appendFormat:@"%C", esc];
+            } else {
+                [self setError:MTParseErrorInvalidCommand
+                       message:[NSString stringWithFormat:
+                                @"Unsupported escape \\%C in \\text* body",
+                                esc]];
+                return nil;
             }
             continue;
         }

--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -322,7 +322,10 @@ NSString *const MTParseError = @"ParseError";
                 return nil;
             }
             unichar esc = [self getNextCharacter];
-            if ([escapable characterIsMember:esc]) {
+            if (esc == ' ') {
+                // \<space> is a forced literal space in LaTeX text mode.
+                [body appendString:@" "];
+            } else if ([escapable characterIsMember:esc]) {
                 [body appendFormat:@"%C", esc];
             } else {
                 [self setError:MTParseErrorInvalidCommand

--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -290,27 +290,102 @@ NSString *const MTParseError = @"ParseError";
     return mutable;
 }
 
-// Reads the {...} body following a \text* command.  The body is captured
-// raw — every code point flows through unchanged except for the backslash
-// escapes accepted by `[MTTextAtom latexEscapableCharacterSet]`, which
-// unescape to their literal character.  Balanced nested {...} groups are
-// accepted as TeX-style grouping (the braces are stripped, the inner
-// content is captured).  Any other backslash sequence is a parse error,
-// as is `$`, any unmatched brace, or a trailing backslash.
-- (NSString*) readTextArgument
+- (void) skipTextArgumentSpaces
 {
-    [self skipSpaces];
-    if (![self hasCharacters] || [self getNextCharacter] != '{') {
-        // Roll the position back so the error highlights the right spot.
-        if ([self hasCharacters] || _currentChar > 0) {
+    static NSCharacterSet* whitespace = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        whitespace = [NSCharacterSet whitespaceAndNewlineCharacterSet];
+    });
+
+    while ([self hasCharacters]) {
+        unichar ch = [self getNextCharacter];
+        if (![whitespace characterIsMember:ch]) {
             [self unlookCharacter];
+            return;
         }
-        [self setError:MTParseErrorCharacterNotFound
-               message:@"Missing { for \\text* argument"];
+    }
+}
+
+- (NSString*) readUnbracedTextTokenStartingWith:(unichar)c
+                                   escapableSet:(NSCharacterSet*)escapable
+{
+    if (c == '\\') {
+        if (![self hasCharacters]) {
+            [self setError:MTParseErrorMismatchBraces
+                   message:@"Trailing \\ after \\text*"];
+            return nil;
+        }
+
+        NSString* command = [self readCommand];
+        if (command.length == 1) {
+            unichar escaped = [command characterAtIndex:0];
+            if (escaped == ' ') {
+                return @" ";
+            }
+            if ([escapable characterIsMember:escaped]) {
+                return command;
+            }
+        }
+
+        MTMathAtom* atom = [MTMathAtomFactory atomForLatexSymbolName:command];
+        if (atom && atom.nucleus.length > 0) {
+            return atom.nucleus;
+        }
+
+        [self setError:MTParseErrorInvalidCommand
+               message:[NSString stringWithFormat:
+                        @"Unsupported command \\%@ as \\text* argument",
+                        command]];
         return nil;
     }
 
+    if (c == '$') {
+        [self setError:MTParseErrorInvalidCommand
+               message:@"$ is not allowed inside \\text*"];
+        return nil;
+    }
+    if (c == '^' || c == '_' || c == '}' || c == '&') {
+        [self unlookCharacter];
+        [self setError:MTParseErrorCharacterNotFound
+               message:@"Missing argument for \\text*"];
+        return nil;
+    }
+
+    NSMutableString* token = [NSMutableString stringWithCharacters:&c length:1];
+    if (c >= 0xD800 && c <= 0xDBFF && [self hasCharacters]) {
+        unichar low = [self getNextCharacter];
+        if (low >= 0xDC00 && low <= 0xDFFF) {
+            [token appendFormat:@"%C", low];
+        } else {
+            [self unlookCharacter];
+        }
+    }
+    return token;
+}
+
+// Reads the argument following a \text* command.  Braced bodies are
+// captured raw — every code point flows through unchanged except for the
+// backslash escapes accepted by `[MTTextAtom latexEscapableCharacterSet]`,
+// which unescape to their literal character.  Balanced nested {...}
+// groups are accepted as TeX-style grouping (the braces are stripped, the
+// inner content is captured).  Without braces, LaTeX compatibility is
+// preserved by consuming a single following text token.
+- (NSString*) readTextArgument
+{
+    [self skipTextArgumentSpaces];
     NSCharacterSet* escapable = [MTTextAtom latexEscapableCharacterSet];
+    if (![self hasCharacters]) {
+        [self setError:MTParseErrorCharacterNotFound
+               message:@"Missing argument for \\text*"];
+        return nil;
+    }
+
+    unichar first = [self getNextCharacter];
+    if (first != '{') {
+        return [self readUnbracedTextTokenStartingWith:first escapableSet:escapable];
+    }
+
     NSMutableString* body = [NSMutableString string];
     NSInteger depth = 0;
     while ([self hasCharacters]) {

--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -183,6 +183,25 @@ NSString *const MTParseError = @"ParseError";
             if ([self applyModifier:command atom:prevAtom]) {
                 continue;
             }
+            // Recognize \text* commands first — they consume their {…}
+            // body raw, so they must be handled before the legacy
+            // font-style dispatch (and before the six \text* keys are
+            // removed from MTMathAtomFactory.fontStyles).
+            MTTextStyle textStyle = [MTMathAtomFactory textStyleWithName:command];
+            if (textStyle != (MTTextStyle)NSNotFound) {
+                NSString* body = [self readTextArgument];
+                if (!body) {
+                    return nil; // error already set
+                }
+                MTTextAtom* textAtom = [[MTTextAtom alloc] initWithText:body
+                                                                  style:textStyle];
+                [list addAtom:textAtom];
+                prevAtom = textAtom;
+                if (oneCharOnly) {
+                    return list;
+                }
+                continue;
+            }
             MTFontStyle fontStyle = [MTMathAtomFactory fontStyleWithName:command];
             if (fontStyle != NSNotFound) {
                 BOOL oldSpacesAllowed = _spacesAllowed;
@@ -269,6 +288,76 @@ NSString *const MTParseError = @"ParseError";
         }
     }
     return mutable;
+}
+
+// Reads the {...} body following a \text* command.  The body is captured
+// raw — every code point flows through unchanged except for the eight
+// LaTeX escapes \\, \{, \}, \_, \^, \%, \&, \#, \$ which unescape to their
+// literal character.  Balanced nested {...} groups are accepted as
+// TeX-style grouping (the braces are stripped, the inner content is
+// captured).  Any other backslash sequence is a parse error, as is `$`,
+// any unmatched brace, or a trailing backslash.
+- (NSString*) readTextArgument
+{
+    [self skipSpaces];
+    if (![self hasCharacters] || [self getNextCharacter] != '{') {
+        // Roll the position back so the error highlights the right spot.
+        if ([self hasCharacters] || _currentChar > 0) {
+            [self unlookCharacter];
+        }
+        [self setError:MTParseErrorCharacterNotFound
+               message:@"Missing { for \\text* argument"];
+        return nil;
+    }
+
+    NSMutableString* body = [NSMutableString string];
+    NSInteger depth = 0;
+    while ([self hasCharacters]) {
+        unichar c = [self getNextCharacter];
+        if (c == '\\') {
+            if (![self hasCharacters]) {
+                [self setError:MTParseErrorMismatchBraces
+                       message:@"Trailing \\ inside \\text*"];
+                return nil;
+            }
+            unichar esc = [self getNextCharacter];
+            switch (esc) {
+                case '\\': case '{': case '}': case '_':
+                case '^':  case '%': case '&': case '#': case '$':
+                    [body appendFormat:@"%C", esc];
+                    break;
+                default:
+                    [self setError:MTParseErrorInvalidCommand
+                           message:[NSString stringWithFormat:
+                                    @"Unsupported escape \\%C in \\text* body",
+                                    esc]];
+                    return nil;
+            }
+            continue;
+        }
+        if (c == '{') {
+            // Balanced group — opening brace is grouping, not content.
+            depth += 1;
+            continue;
+        }
+        if (c == '}') {
+            if (depth == 0) {
+                return body; // matched the outer {
+            }
+            depth -= 1;
+            continue;
+        }
+        if (c == '$') {
+            // Math-in-text is out of scope.
+            [self setError:MTParseErrorInvalidCommand
+                   message:@"$ is not allowed inside \\text*"];
+            return nil;
+        }
+        [body appendFormat:@"%C", c];
+    }
+    [self setError:MTParseErrorMismatchBraces
+           message:@"Unmatched { in \\text* body"];
+    return nil;
 }
 
 - (NSString*) readColor

--- a/iosMath/render/MTFontManager.h
+++ b/iosMath/render/MTFontManager.h
@@ -10,8 +10,10 @@
 //  
 
 @import Foundation;
+@import CoreText;
 
 #import "MTFont.h"
+#import "MTMathList.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -42,6 +44,20 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Helper function to return the Latin Modern Math font. */
 - (MTFont *) latinModernFontWithSize:(CGFloat)size;
+
+/**
+ Returns a CoreText font suitable for `\text*` rendering. The caller owns
+ the returned reference (CF_RETAINED) and must `CFRelease` it.
+
+ - `kMTTextStyleRoman` and `kMTTextStyleSansSerif` → system text font.
+ - `kMTTextStyleBold` / `kMTTextStyleItalic` → system text font with
+   `kCTFontTraitBold` / `kCTFontTraitItalic` applied via
+   `CTFontCreateCopyWithSymbolicTraits`. If the trait is unsatisfiable the
+   plain system font is returned.
+ - `kMTTextStyleTypewriter` → system monospace font.
+ */
++ (CTFontRef) textCTFontForStyle:(MTTextStyle) style
+                            size:(CGFloat) size CF_RETURNS_RETAINED;
 
 @end
 

--- a/iosMath/render/MTFontManager.m
+++ b/iosMath/render/MTFontManager.m
@@ -74,4 +74,43 @@ const int kDefaultFontSize = 20;
     return [self latinModernFontWithSize:kDefaultFontSize];
 }
 
++ (CTFontRef) textCTFontForStyle:(MTTextStyle) style
+                            size:(CGFloat) size
+{
+    CTFontUIFontType base;
+    switch (style) {
+        case kMTTextStyleTypewriter:
+            base = kCTFontUIFontUserFixedPitch;
+            break;
+        case kMTTextStyleRoman:
+        case kMTTextStyleBold:
+        case kMTTextStyleItalic:
+        case kMTTextStyleSansSerif:
+        default:
+            base = kCTFontUIFontSystem;
+            break;
+    }
+
+    CTFontRef baseFont = CTFontCreateUIFontForLanguage(base, size, NULL);
+    if (baseFont == NULL) {
+        return CTFontCreateWithName(CFSTR("Helvetica"), size, NULL);
+    }
+
+    CTFontSymbolicTraits requested = 0;
+    if (style == kMTTextStyleBold)   requested |= kCTFontTraitBold;
+    if (style == kMTTextStyleItalic) requested |= kCTFontTraitItalic;
+
+    if (requested == 0) {
+        return baseFont;
+    }
+
+    CTFontRef styled = CTFontCreateCopyWithSymbolicTraits(
+        baseFont, size, NULL, requested, requested);
+    if (styled != NULL) {
+        CFRelease(baseFont);
+        return styled;
+    }
+    return baseFont;
+}
+
 @end

--- a/iosMath/render/MTFontManager.m
+++ b/iosMath/render/MTFontManager.m
@@ -92,9 +92,6 @@ const int kDefaultFontSize = 20;
     }
 
     CTFontRef baseFont = CTFontCreateUIFontForLanguage(base, size, NULL);
-    if (baseFont == NULL) {
-        return CTFontCreateWithName(CFSTR("Helvetica"), size, NULL);
-    }
 
     CTFontSymbolicTraits requested = 0;
     if (style == kMTTextStyleBold)   requested |= kCTFontTraitBold;

--- a/iosMath/render/MTMathListDisplay.h
+++ b/iosMath/render/MTMathListDisplay.h
@@ -72,6 +72,23 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+/**
+ A display rendering one run of plain text via CoreText, used by
+ `\text`, `\textrm`, `\textbf`, `\textit`, `\textsf`, `\texttt`. The
+ underlying font is a system text font (not an `MTFont`).
+ */
+@interface MTTextDisplay : MTDisplay
+
+- (instancetype) init NS_UNAVAILABLE;
+
+/// The raw Unicode text rendered by this display.
+@property (nonatomic, readonly, copy) NSString* text;
+
+/// The text-mode style this display was built with.
+@property (nonatomic, readonly) MTTextStyle textStyle;
+
+@end
+
 /// An MTLine is a rendered form of MTMathList in one line.
 /// It can render itself using the draw method.
 @interface MTMathListDisplay : MTDisplay

--- a/iosMath/render/MTMathListDisplay.m
+++ b/iosMath/render/MTMathListDisplay.m
@@ -178,20 +178,17 @@ static BOOL isIos6Supported(void) {
 @implementation MTTextDisplay {
     CTLineRef _line;
     NSAttributedString *_attributedString;
-    CGFloat _xHeightShift;
 }
 
 - (instancetype) initWithText:(NSString *) text
                     textStyle:(MTTextStyle) textStyle
                        ctFont:(CTFontRef) ctFont
-                 xHeightShift:(CGFloat) xHeightShift
                         range:(NSRange) range
 {
     self = [super init];
     if (self) {
         _text = [text copy];
         _textStyle = textStyle;
-        _xHeightShift = xHeightShift;
         self.range = range;
         self.position = CGPointZero;
 
@@ -236,9 +233,7 @@ static BOOL isIos6Supported(void) {
 {
     [super draw:context];
     CGContextSaveGState(context);
-    CGContextSetTextPosition(context,
-                             self.position.x,
-                             self.position.y - _xHeightShift);
+    CGContextSetTextPosition(context, self.position.x, self.position.y);
     CTLineDraw(_line, context);
     CGContextRestoreGState(context);
 }

--- a/iosMath/render/MTMathListDisplay.m
+++ b/iosMath/render/MTMathListDisplay.m
@@ -164,10 +164,82 @@ static BOOL isIos6Supported(void) {
 {
     [super draw:context];
     CGContextSaveGState(context);
-    
+
     CGContextSetTextPosition(context, self.position.x, self.position.y);
     CTLineDraw(_line, context);
-    
+
+    CGContextRestoreGState(context);
+}
+
+@end
+
+#pragma mark - MTTextDisplay
+
+@implementation MTTextDisplay {
+    CTLineRef _line;
+    NSAttributedString *_attributedString;
+    CGFloat _xHeightShift;
+}
+
+- (instancetype) initWithText:(NSString *) text
+                    textStyle:(MTTextStyle) textStyle
+                       ctFont:(CTFontRef) ctFont
+                 xHeightShift:(CGFloat) xHeightShift
+                        range:(NSRange) range
+{
+    self = [super init];
+    if (self) {
+        _text = [text copy];
+        _textStyle = textStyle;
+        _xHeightShift = xHeightShift;
+        self.range = range;
+        self.position = CGPointZero;
+
+        NSDictionary *attrs = @{ (NSString *)kCTFontAttributeName: (__bridge id)ctFont };
+        _attributedString = [[NSAttributedString alloc]
+                              initWithString:text ?: @""
+                                  attributes:attrs];
+        _line = CTLineCreateWithAttributedString(
+                    (__bridge CFAttributedStringRef)_attributedString);
+
+        self.width = (CGFloat)CTLineGetTypographicBounds(_line, NULL, NULL, NULL);
+        CGRect bounds = CTLineGetBoundsWithOptions(_line, kCTLineBoundsUseGlyphPathBounds);
+        self.ascent  = MAX(0, CGRectGetMaxY(bounds));
+        self.descent = MAX(0, -CGRectGetMinY(bounds));
+    }
+    return self;
+}
+
+- (void) dealloc
+{
+    if (_line) {
+        CFRelease(_line);
+        _line = NULL;
+    }
+}
+
+- (void) setTextColor:(MTColor *) textColor
+{
+    [super setTextColor:textColor];
+
+    NSMutableAttributedString *m = [_attributedString mutableCopy];
+    [m addAttribute:(NSString *)kCTForegroundColorAttributeName
+              value:(id)textColor.CGColor
+              range:NSMakeRange(0, m.length)];
+    _attributedString = [m copy];
+    if (_line) CFRelease(_line);
+    _line = CTLineCreateWithAttributedString(
+                (__bridge CFAttributedStringRef)_attributedString);
+}
+
+- (void) draw:(CGContextRef) context
+{
+    [super draw:context];
+    CGContextSaveGState(context);
+    CGContextSetTextPosition(context,
+                             self.position.x,
+                             self.position.y - _xHeightShift);
+    CTLineDraw(_line, context);
     CGContextRestoreGState(context);
 }
 

--- a/iosMath/render/internal/MTMathListDisplayInternal.h
+++ b/iosMath/render/internal/MTMathListDisplayInternal.h
@@ -57,14 +57,11 @@ NS_ASSUME_NONNULL_BEGIN
    `ctFont` already encodes traits.
  - `ctFont`: a CT font owned by the caller; this initializer takes its
    own retain so the caller may release.
- - `xHeightShift`: amount (in points) to shift the baseline at draw
-   time, so the text x-height aligns with the math x-height.
  - `range`: the source-code character range driving this display.
  */
 - (instancetype) initWithText:(NSString*) text
                     textStyle:(MTTextStyle) textStyle
                        ctFont:(CTFontRef) ctFont
-                 xHeightShift:(CGFloat) xHeightShift
                         range:(NSRange) range NS_DESIGNATED_INITIALIZER;
 
 - (instancetype) init NS_UNAVAILABLE;

--- a/iosMath/render/internal/MTMathListDisplayInternal.h
+++ b/iosMath/render/internal/MTMathListDisplayInternal.h
@@ -48,6 +48,29 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@interface MTTextDisplay ()
+
+/**
+ Designated initializer.
+ - `text`: raw body (already escape-processed).
+ - `textStyle`: the requested style — used for introspection only;
+   `ctFont` already encodes traits.
+ - `ctFont`: a CT font owned by the caller; this initializer takes its
+   own retain so the caller may release.
+ - `xHeightShift`: amount (in points) to shift the baseline at draw
+   time, so the text x-height aligns with the math x-height.
+ - `range`: the source-code character range driving this display.
+ */
+- (instancetype) initWithText:(NSString*) text
+                    textStyle:(MTTextStyle) textStyle
+                       ctFont:(CTFontRef) ctFont
+                 xHeightShift:(CGFloat) xHeightShift
+                        range:(NSRange) range NS_DESIGNATED_INITIALIZER;
+
+- (instancetype) init NS_UNAVAILABLE;
+
+@end
+
 @interface MTFractionDisplay ()
 
 - (instancetype)initWithNumerator:(MTMathListDisplay*) numerator denominator:(MTMathListDisplay*) denominator position:(CGPoint) position range:(NSRange) range NS_DESIGNATED_INITIALIZER;

--- a/iosMath/render/internal/MTTypesetter.m
+++ b/iosMath/render/internal/MTTypesetter.m
@@ -10,6 +10,7 @@
 
 #import "MTTypesetter.h"
 #import "MTFont+Internal.h"
+#import "MTFontManager.h"
 #import "MTMathListDisplayInternal.h"
 #import "../../lib/MTUnicode.h"
 
@@ -51,6 +52,7 @@ NSUInteger getInterElementSpaceArrayIndexForType(MTMathAtomType type, BOOL row) 
         case kMTMathAtomColorbox:
         case kMTMathAtomOrdinary:
         case kMTMathAtomPlaceholder:   // A placeholder is treated as ordinary
+        case kMTMathAtomText:          // Text blocks are spaced as Ord
             return 0;
         case kMTMathAtomLargeOperator:
             return 1;
@@ -573,6 +575,19 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
     _currentPosition.x += interElementSpace;
 }
 
+// Returns the y-shift needed so a text-font baseline lines up with the
+// math-font's x-height. Positive ⇒ the text run should be drawn lower than
+// the math baseline so that the lower-case x-heights of the two fonts meet.
+// (LLD §3.3 / §5.1)
+- (CGFloat) xHeightShiftForTextFont:(CTFontRef) textFont
+{
+    // The math-table x-height is exposed as `accentBaseHeight`
+    // (\fontdimen5 in TeX, see MTFontMathTable.h:136).
+    CGFloat mathX = _styleFont.mathTable.accentBaseHeight;
+    CGFloat textX = (CGFloat) CTFontGetXHeight(textFont);
+    return mathX - textX;
+}
+
 - (void) createDisplayAtoms:(NSArray*) preprocessed
 {
     // items should contain all the nodes that need to be layed out.
@@ -639,14 +654,56 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
                 }
                 MTMathColorbox* colorboxAtom = (MTMathColorbox*) atom;
                 MTDisplay* display = [MTTypesetter createLineForMathList:colorboxAtom.innerList font:_font style:_style];
-                
+
                 display.localBackgroundColor = [MTColor colorFromHexString:colorboxAtom.colorString];
                 display.position = _currentPosition;
                 _currentPosition.x += display.width;
                 [_displayAtoms addObject:display];
                 break;
             }
-                
+
+            case kMTMathAtomText: {
+                // Flush any pending math run so the text block stands alone.
+                if (_currentLine.length > 0) {
+                    [self addDisplayLine];
+                }
+                // Inter-element spacing: kMTMathAtomText maps to the
+                // Ordinary row/column in getInterElementSpaceArrayIndexForType,
+                // so addInterElementSpace works unchanged.
+                [self addInterElementSpace:prevNode currentType:atom.type];
+
+                MTTextAtom* textAtom = (MTTextAtom*) atom;
+                CTFontRef textFont = [MTFontManager textCTFontForStyle:textAtom.textStyle
+                                                                  size:_styleFont.fontSize];
+                CGFloat shift = [self xHeightShiftForTextFont:textFont];
+
+                MTTextDisplay* display = [[MTTextDisplay alloc]
+                                          initWithText:textAtom.text
+                                             textStyle:textAtom.textStyle
+                                                ctFont:textFont
+                                          xHeightShift:shift
+                                                 range:textAtom.indexRange];
+                // MTTextDisplay's initializer takes its own retain on the
+                // CTFont via the attributed-string attribute dictionary.
+                CFRelease(textFont);
+
+                display.position = _currentPosition;
+                _currentPosition.x += display.width;
+                [_displayAtoms addObject:display];
+
+                // Sub/superscripts attach via the existing makeScripts: path
+                // with delta=0 (no math italic correction for text blocks).
+                if (atom.subScript || atom.superScript) {
+                    [self makeScripts:atom display:display
+                                index:atom.indexRange.location delta:0];
+                }
+                // No mutation of atom.type. prevNode bookkeeping at the
+                // bottom of the loop assigns prevNode = atom; on the next
+                // iteration the spacing-index lookup for kMTMathAtomText
+                // resolves to the same index as Ord.
+                break;
+            }
+
             case kMTMathAtomRadical: {
                 // stash the existing layout
                 if (_currentLine.length > 0) {

--- a/iosMath/render/internal/MTTypesetter.m
+++ b/iosMath/render/internal/MTTypesetter.m
@@ -575,19 +575,6 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
     _currentPosition.x += interElementSpace;
 }
 
-// Returns the y-shift needed so a text-font baseline lines up with the
-// math-font's x-height. Positive ⇒ the text run should be drawn lower than
-// the math baseline so that the lower-case x-heights of the two fonts meet.
-// (LLD §3.3 / §5.1)
-- (CGFloat) xHeightShiftForTextFont:(CTFontRef) textFont
-{
-    // The math-table x-height is exposed as `accentBaseHeight`
-    // (\fontdimen5 in TeX, see MTFontMathTable.h:136).
-    CGFloat mathX = _styleFont.mathTable.accentBaseHeight;
-    CGFloat textX = (CGFloat) CTFontGetXHeight(textFont);
-    return mathX - textX;
-}
-
 - (void) createDisplayAtoms:(NSArray*) preprocessed
 {
     // items should contain all the nodes that need to be layed out.
@@ -675,13 +662,11 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
                 MTTextAtom* textAtom = (MTTextAtom*) atom;
                 CTFontRef textFont = [MTFontManager textCTFontForStyle:textAtom.textStyle
                                                                   size:_styleFont.fontSize];
-                CGFloat shift = [self xHeightShiftForTextFont:textFont];
 
                 MTTextDisplay* display = [[MTTextDisplay alloc]
                                           initWithText:textAtom.text
                                              textStyle:textAtom.textStyle
                                                 ctFont:textFont
-                                          xHeightShift:shift
                                                  range:textAtom.indexRange];
                 // MTTextDisplay's initializer takes its own retain on the
                 // CTFont via the attributed-string attribute dictionary.

--- a/iosMathExample/example/ViewController.m
+++ b/iosMathExample/example/ViewController.m
@@ -91,7 +91,7 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
     // Demo formulae — LaTeX strings from MathExamples.h
     static const CGFloat demoHeights[] = {
         60, 40, 40, 80, 60, 40, 40, 40, 40, 60, 40, 40, 60, 60, 60, 70, 70, 140, 60, 90, 60, 60, 70,
-        60, 60, 60, 70, 60, 60, 60, 60
+        70, 60, 60, 70, 60, 60, 60, 60
     };
     NSArray<NSString*>* demoFormulas = MathDemoFormulas();
     for (NSUInteger i = 0; i < demoFormulas.count; i++) {

--- a/iosMathExample/example/ViewController.m
+++ b/iosMathExample/example/ViewController.m
@@ -90,7 +90,8 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
     [self setEqualWidths:contentView andView:self.scrollView];
     // Demo formulae — LaTeX strings from MathExamples.h
     static const CGFloat demoHeights[] = {
-        60, 40, 40, 80, 60, 40, 40, 40, 40, 60, 40, 40, 60, 60, 60, 70, 70, 140, 60, 90, 60, 60, 70
+        60, 40, 40, 80, 60, 40, 40, 40, 40, 60, 40, 40, 60, 60, 60, 70, 70, 140, 60, 90, 60, 60, 70,
+        60, 60, 60, 70, 60, 60, 60, 60
     };
     NSArray<NSString*>* demoFormulas = MathDemoFormulas();
     for (NSUInteger i = 0; i < demoFormulas.count; i++) {

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -1673,6 +1673,40 @@ static NSArray* getTestDataLargeDelimiters() {
     }
 }
 
+- (void) testTextSingleCharacterArgument {
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\textbf abc"];
+    XCTAssertEqual(list.atoms.count, (NSUInteger)3);
+
+    MTTextAtom *atom = (MTTextAtom *)list.atoms[0];
+    XCTAssertTrue([atom isKindOfClass:[MTTextAtom class]]);
+    XCTAssertEqualObjects(atom.text, @"a");
+    XCTAssertEqual(atom.textStyle, kMTTextStyleBold);
+    XCTAssertEqualObjects(list.atoms[1].nucleus, @"b");
+    XCTAssertEqualObjects(list.atoms[2].nucleus, @"c");
+    XCTAssertEqualObjects([MTMathListBuilder mathListToString:list], @"\\textbf{a}bc");
+}
+
+- (void) testTextSingleEscapedArgument {
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\textit\\%"];
+    XCTAssertEqual(list.atoms.count, (NSUInteger)1);
+
+    MTTextAtom *atom = (MTTextAtom *)list.atoms[0];
+    XCTAssertTrue([atom isKindOfClass:[MTTextAtom class]]);
+    XCTAssertEqualObjects(atom.text, @"%");
+    XCTAssertEqual(atom.textStyle, kMTTextStyleItalic);
+    XCTAssertEqualObjects([MTMathListBuilder mathListToString:list], @"\\textit{\\%}");
+}
+
+- (void) testTextSingleNonLatinArgument {
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\text 你"];
+    XCTAssertEqual(list.atoms.count, (NSUInteger)1);
+
+    MTTextAtom *atom = (MTTextAtom *)list.atoms[0];
+    XCTAssertTrue([atom isKindOfClass:[MTTextAtom class]]);
+    XCTAssertEqualObjects(atom.text, @"你");
+    XCTAssertEqual(atom.textStyle, kMTTextStyleRoman);
+}
+
 - (void) testTextChinese {
     MTMathList *list = [MTMathListBuilder buildFromString:@"\\text{你好}"];
     MTTextAtom *atom = (MTTextAtom *)list.atoms[0];
@@ -1837,9 +1871,9 @@ static NSArray* getTestDataLargeDelimiters() {
 
 #pragma mark - MTTextAtom parsing — error cases
 
-- (void) testTextMissingOpenBrace {
+- (void) testTextMissingArgument {
     NSError *error = nil;
-    MTMathList *list = [MTMathListBuilder buildFromString:@"\\textbf abc"
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\textbf"
                                                      error:&error];
     XCTAssertNil(list);
     XCTAssertNotNil(error);

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -1744,6 +1744,23 @@ static NSArray* getTestDataLargeDelimiters() {
     XCTAssertEqualObjects(atom.text, @"50% $5 {x} \\");
 }
 
+- (void) testTextBackslashSpace {
+    // \<space> is the canonical LaTeX forced space in text mode. The legacy
+    // parser accepted it via the single-char command table, so existing
+    // inputs like \text{hello\ world} and \textbf{hello\ world} must keep
+    // working under the new \text* path.
+    MTMathList *plain = [MTMathListBuilder buildFromString:@"\\text{hello\\ world}"];
+    MTTextAtom *plainAtom = (MTTextAtom *)plain.atoms[0];
+    XCTAssertTrue([plainAtom isKindOfClass:[MTTextAtom class]]);
+    XCTAssertEqualObjects(plainAtom.text, @"hello world");
+
+    MTMathList *bold = [MTMathListBuilder buildFromString:@"\\textbf{hello\\ world}"];
+    MTTextAtom *boldAtom = (MTTextAtom *)bold.atoms[0];
+    XCTAssertTrue([boldAtom isKindOfClass:[MTTextAtom class]]);
+    XCTAssertEqualObjects(boldAtom.text, @"hello world");
+    XCTAssertEqual(boldAtom.textStyle, kMTTextStyleBold);
+}
+
 - (void) testTextUnicodeWhitespace {
     // U+00A0 NBSP must pass through unchanged.
     NSString *src = [NSString stringWithFormat:@"\\text{a%Cb}", (unichar)0x00A0];

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -1777,6 +1777,27 @@ static NSArray* getTestDataLargeDelimiters() {
     XCTAssertEqualObjects(atom.superScript.atoms[0].nucleus, @"2");
 }
 
+- (void) testTextSubAndSuperscript {
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\textbf{abc}_i^{n+1}"];
+    XCTAssertEqual(list.atoms.count, (NSUInteger)1);
+    MTTextAtom *atom = (MTTextAtom *)list.atoms[0];
+    XCTAssertTrue([atom isKindOfClass:[MTTextAtom class]]);
+    XCTAssertEqualObjects(atom.text, @"abc");
+
+    XCTAssertNotNil(atom.subScript);
+    XCTAssertEqual(atom.subScript.atoms.count, (NSUInteger)1);
+    XCTAssertEqualObjects(atom.subScript.atoms[0].nucleus, @"i");
+
+    XCTAssertNotNil(atom.superScript);
+    XCTAssertEqual(atom.superScript.atoms.count, (NSUInteger)3);
+    XCTAssertEqualObjects(atom.superScript.atoms[0].nucleus, @"n");
+    XCTAssertEqualObjects(atom.superScript.atoms[1].nucleus, @"+");
+    XCTAssertEqualObjects(atom.superScript.atoms[2].nucleus, @"1");
+
+    XCTAssertEqualObjects([MTMathListBuilder mathListToString:list],
+                          @"\\textbf{abc}^{n+1}_{i}");
+}
+
 #pragma mark - MTTextAtom parsing — round-trip
 
 - (void) testTextRoundTripChineseBold {

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -1318,25 +1318,18 @@ static NSArray* getTestDataParseErrors() {
     NSString* desc = [NSString stringWithFormat:@"Error for string:%@", str];
 
     XCTAssertNotNil(list, @"%@", desc);
-    XCTAssertEqualObjects(@(list.atoms.count), @3, @"%@", desc);
+    XCTAssertEqualObjects(@(list.atoms.count), @1, @"%@", desc);
+
     MTMathAtom* atom = list.atoms[0];
-    XCTAssertEqual(atom.type, kMTMathAtomVariable, @"%@", desc);
-    XCTAssertEqualObjects(atom.nucleus, @"x", @"%@", desc);
-    XCTAssertEqual(atom.fontStyle, kMTFontStyleRoman);
-
-    atom = list.atoms[1];
-    XCTAssertEqual(atom.type, kMTMathAtomOrdinary, @"%@", desc);
-    XCTAssertEqualObjects(atom.nucleus, @" ", @"%@", desc);
-
-    atom = list.atoms[2];
-    XCTAssertEqual(atom.type, kMTMathAtomVariable, @"%@", desc);
-    XCTAssertEqualObjects(atom.nucleus, @"y", @"%@", desc);
-    XCTAssertEqual(atom.fontStyle, kMTFontStyleRoman);
-
+    XCTAssertEqual(atom.type, kMTMathAtomText, @"%@", desc);
+    XCTAssertTrue([atom isKindOfClass:[MTTextAtom class]], @"%@", desc);
+    XCTAssertEqualObjects(((MTTextAtom *)atom).text, @"x y", @"%@", desc);
+    XCTAssertEqual(((MTTextAtom *)atom).textStyle, kMTTextStyleRoman, @"%@", desc);
+    XCTAssertEqual(atom.fontStyle, kMTFontStyleDefault, @"%@", desc);
 
     // convert it back to latex
     NSString* latex = [MTMathListBuilder mathListToString:list];
-    XCTAssertEqualObjects(latex, @"\\mathrm{x\\  y}", @"%@", desc);
+    XCTAssertEqualObjects(latex, @"\\text{x y}", @"%@", desc);
 }
 
 - (void) testLimits
@@ -1638,6 +1631,222 @@ static NSArray* getTestDataLargeDelimiters() {
     XCTAssertEqualObjects([MTMathAtomFactory commandNameForTextStyle:kMTTextStyleItalic],     @"textit");
     XCTAssertEqualObjects([MTMathAtomFactory commandNameForTextStyle:kMTTextStyleSansSerif],  @"textsf");
     XCTAssertEqualObjects([MTMathAtomFactory commandNameForTextStyle:kMTTextStyleTypewriter], @"texttt");
+}
+
+#pragma mark - MTTextAtom parsing — body capture
+
+- (void) testTextEmpty {
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\text{}"];
+    XCTAssertEqual(list.atoms.count, (NSUInteger)1);
+    MTTextAtom *atom = (MTTextAtom *)list.atoms[0];
+    XCTAssertTrue([atom isKindOfClass:[MTTextAtom class]]);
+    XCTAssertEqualObjects(atom.text, @"");
+    XCTAssertEqual(atom.textStyle, kMTTextStyleRoman);
+}
+
+- (void) testTextAscii {
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\text{abc}"];
+    XCTAssertEqual(list.atoms.count, (NSUInteger)1);
+    MTTextAtom *atom = (MTTextAtom *)list.atoms[0];
+    XCTAssertEqualObjects(atom.text, @"abc");
+    XCTAssertEqual(atom.textStyle, kMTTextStyleRoman);
+}
+
+- (void) testTextStyles {
+    NSDictionary *cases = @{
+        @"\\textrm{x}":  @(kMTTextStyleRoman),
+        @"\\text{x}":    @(kMTTextStyleRoman),
+        @"\\textbf{x}":  @(kMTTextStyleBold),
+        @"\\textit{x}":  @(kMTTextStyleItalic),
+        @"\\textsf{x}":  @(kMTTextStyleSansSerif),
+        @"\\texttt{x}":  @(kMTTextStyleTypewriter),
+    };
+    for (NSString *src in cases) {
+        MTMathList *list = [MTMathListBuilder buildFromString:src];
+        XCTAssertEqual(list.atoms.count, (NSUInteger)1, @"%@", src);
+        MTTextAtom *atom = (MTTextAtom *)list.atoms[0];
+        XCTAssertTrue([atom isKindOfClass:[MTTextAtom class]], @"%@", src);
+        XCTAssertEqualObjects(atom.text, @"x", @"%@", src);
+        XCTAssertEqual(atom.textStyle,
+                       (MTTextStyle)[cases[src] unsignedIntegerValue],
+                       @"%@", src);
+    }
+}
+
+- (void) testTextChinese {
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\text{你好}"];
+    MTTextAtom *atom = (MTTextAtom *)list.atoms[0];
+    XCTAssertEqualObjects(atom.text, @"你好");
+}
+
+- (void) testTextCyrillicRoman {
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\text{Привет}"];
+    MTTextAtom *atom = (MTTextAtom *)list.atoms[0];
+    XCTAssertEqualObjects(atom.text, @"Привет");
+    XCTAssertEqual(atom.textStyle, kMTTextStyleRoman);
+}
+
+- (void) testTextCyrillicBold {
+    // Today \textbf{Привет} drops the body characters because Cyrillic
+    // outside U+0411–U+044E is filtered and bold-font-trait styling is
+    // unavailable. New path captures the body raw.
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\textbf{Привет}"];
+    MTTextAtom *atom = (MTTextAtom *)list.atoms[0];
+    XCTAssertEqualObjects(atom.text, @"Привет");
+    XCTAssertEqual(atom.textStyle, kMTTextStyleBold);
+}
+
+- (void) testTextCyrillicItalic {
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\textit{Привет}"];
+    MTTextAtom *atom = (MTTextAtom *)list.atoms[0];
+    XCTAssertEqualObjects(atom.text, @"Привет");
+    XCTAssertEqual(atom.textStyle, kMTTextStyleItalic);
+}
+
+- (void) testTextDevanagari {
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\text{नमस्ते}"];
+    MTTextAtom *atom = (MTTextAtom *)list.atoms[0];
+    XCTAssertEqualObjects(atom.text, @"नमस्ते");
+}
+
+- (void) testTextHebrew {
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\text{שלום}"];
+    MTTextAtom *atom = (MTTextAtom *)list.atoms[0];
+    XCTAssertEqualObjects(atom.text, @"שלום");
+}
+
+- (void) testTextArabic {
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\text{مرحبا}"];
+    MTTextAtom *atom = (MTTextAtom *)list.atoms[0];
+    XCTAssertEqualObjects(atom.text, @"مرحبا");
+}
+
+- (void) testTextMixedScripts {
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\text{Hello 你好 שלום}"];
+    XCTAssertEqual(list.atoms.count, (NSUInteger)1);
+    MTTextAtom *atom = (MTTextAtom *)list.atoms[0];
+    XCTAssertEqualObjects(atom.text, @"Hello 你好 שלום");
+}
+
+- (void) testTextWithSpaces {
+    // \textbf{a b} previously dropped the space silently because
+    // _spacesAllowed was set only for \text. Raw capture keeps it.
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\textbf{a b}"];
+    MTTextAtom *atom = (MTTextAtom *)list.atoms[0];
+    XCTAssertEqualObjects(atom.text, @"a b");
+    XCTAssertEqual(atom.textStyle, kMTTextStyleBold);
+}
+
+- (void) testTextEscapes {
+    NSString *src = @"\\text{50\\% \\$5 \\{x\\} \\\\}";
+    MTMathList *list = [MTMathListBuilder buildFromString:src];
+    MTTextAtom *atom = (MTTextAtom *)list.atoms[0];
+    XCTAssertEqualObjects(atom.text, @"50% $5 {x} \\");
+}
+
+- (void) testTextUnicodeWhitespace {
+    // U+00A0 NBSP must pass through unchanged.
+    NSString *src = [NSString stringWithFormat:@"\\text{a%Cb}", (unichar)0x00A0];
+    MTMathList *list = [MTMathListBuilder buildFromString:src];
+    MTTextAtom *atom = (MTTextAtom *)list.atoms[0];
+    NSString *expected = [NSString stringWithFormat:@"a%Cb", (unichar)0x00A0];
+    XCTAssertEqualObjects(atom.text, expected);
+}
+
+- (void) testTextNestedBraceGrouping {
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\text{a {b} c}"];
+    MTTextAtom *atom = (MTTextAtom *)list.atoms[0];
+    XCTAssertEqualObjects(atom.text, @"a b c");
+}
+
+- (void) testTextDeeplyNestedGrouping {
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\text{{{x}}}"];
+    MTTextAtom *atom = (MTTextAtom *)list.atoms[0];
+    XCTAssertEqualObjects(atom.text, @"x");
+}
+
+#pragma mark - MTTextAtom parsing — scripts
+
+- (void) testTextSuperscript {
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\textbf{abc}^2"];
+    XCTAssertEqual(list.atoms.count, (NSUInteger)1);
+    MTTextAtom *atom = (MTTextAtom *)list.atoms[0];
+    XCTAssertTrue([atom isKindOfClass:[MTTextAtom class]]);
+    XCTAssertNotNil(atom.superScript);
+    XCTAssertEqual(atom.superScript.atoms.count, (NSUInteger)1);
+    XCTAssertEqualObjects(atom.superScript.atoms[0].nucleus, @"2");
+}
+
+#pragma mark - MTTextAtom parsing — round-trip
+
+- (void) testTextRoundTripChineseBold {
+    NSString *src = @"\\textbf{你好}";
+    MTMathList *list = [MTMathListBuilder buildFromString:src];
+    XCTAssertEqualObjects([MTMathListBuilder mathListToString:list], src);
+}
+
+- (void) testTextRoundTripWithScript {
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\textbf{你好}^{2}"];
+    XCTAssertEqualObjects([MTMathListBuilder mathListToString:list],
+                          @"\\textbf{你好}^{2}");
+}
+
+- (void) testTextRoundTripEscapes {
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\text{50\\% \\$5}"];
+    XCTAssertEqualObjects([MTMathListBuilder mathListToString:list],
+                          @"\\text{50\\% \\$5}");
+}
+
+#pragma mark - MTTextAtom parsing — error cases
+
+- (void) testTextMissingOpenBrace {
+    NSError *error = nil;
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\textbf abc"
+                                                     error:&error];
+    XCTAssertNil(list);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, MTParseErrorCharacterNotFound);
+}
+
+- (void) testTextMissingCloseBrace {
+    NSError *error = nil;
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\text{abc"
+                                                     error:&error];
+    XCTAssertNil(list);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, MTParseErrorMismatchBraces);
+}
+
+- (void) testTextUnbalancedNestedBrace {
+    NSError *error = nil;
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\text{a{b}"
+                                                     error:&error];
+    XCTAssertNil(list);
+    XCTAssertEqual(error.code, MTParseErrorMismatchBraces);
+}
+
+- (void) testTextNestedTextRejected {
+    NSError *error = nil;
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\textbf{\\textit{x}}"
+                                                     error:&error];
+    XCTAssertNil(list);
+    XCTAssertEqual(error.code, MTParseErrorInvalidCommand);
+}
+
+- (void) testTextDollarRejected {
+    NSError *error = nil;
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\text{$x$}"
+                                                     error:&error];
+    XCTAssertNil(list);
+    XCTAssertNotNil(error);
+}
+
+- (void) testTextUnknownEscapeRejected {
+    NSError *error = nil;
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\text{a\\foo b}"
+                                                     error:&error];
+    XCTAssertNil(list);
+    XCTAssertEqual(error.code, MTParseErrorInvalidCommand);
 }
 
 @end

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -1849,4 +1849,19 @@ static NSArray* getTestDataLargeDelimiters() {
     XCTAssertEqual(error.code, MTParseErrorInvalidCommand);
 }
 
+- (void) testRawCyrillicDropped {
+    // Post-removal: raw Cyrillic outside \text* drops to nothing.
+    // Pre-removal: U+0411–U+044E silently became Variable atoms.
+    MTMathList *list = [MTMathListBuilder buildFromString:@"Привет"];
+    XCTAssertEqual(list.atoms.count, (NSUInteger)0);
+}
+
+- (void) testRawCyrillicInTextStillWorks {
+    // Sanity: the only supported path is \text* — already covered
+    // elsewhere, repeated here for symmetry against the regression.
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\text{Привет}"];
+    XCTAssertEqual(list.atoms.count, (NSUInteger)1);
+    XCTAssertEqualObjects(((MTTextAtom *)list.atoms[0]).text, @"Привет");
+}
+
 @end

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -1612,4 +1612,32 @@ static NSArray* getTestDataLargeDelimiters() {
     XCTAssertEqualObjects(latex, @"x");
 }
 
+#pragma mark - MTTextStyle factory APIs
+
+- (void) testTextStyleWithNameKnown
+{
+    XCTAssertEqual([MTMathAtomFactory textStyleWithName:@"text"],   kMTTextStyleRoman);
+    XCTAssertEqual([MTMathAtomFactory textStyleWithName:@"textrm"], kMTTextStyleRoman);
+    XCTAssertEqual([MTMathAtomFactory textStyleWithName:@"textbf"], kMTTextStyleBold);
+    XCTAssertEqual([MTMathAtomFactory textStyleWithName:@"textit"], kMTTextStyleItalic);
+    XCTAssertEqual([MTMathAtomFactory textStyleWithName:@"textsf"], kMTTextStyleSansSerif);
+    XCTAssertEqual([MTMathAtomFactory textStyleWithName:@"texttt"], kMTTextStyleTypewriter);
+}
+
+- (void) testTextStyleWithNameUnknown
+{
+    XCTAssertEqual([MTMathAtomFactory textStyleWithName:@"mathbf"], (MTTextStyle)NSNotFound);
+    XCTAssertEqual([MTMathAtomFactory textStyleWithName:@"foobar"], (MTTextStyle)NSNotFound);
+    XCTAssertEqual([MTMathAtomFactory textStyleWithName:@""],       (MTTextStyle)NSNotFound);
+}
+
+- (void) testCommandNameForTextStyle
+{
+    XCTAssertEqualObjects([MTMathAtomFactory commandNameForTextStyle:kMTTextStyleRoman],      @"text");
+    XCTAssertEqualObjects([MTMathAtomFactory commandNameForTextStyle:kMTTextStyleBold],       @"textbf");
+    XCTAssertEqualObjects([MTMathAtomFactory commandNameForTextStyle:kMTTextStyleItalic],     @"textit");
+    XCTAssertEqualObjects([MTMathAtomFactory commandNameForTextStyle:kMTTextStyleSansSerif],  @"textsf");
+    XCTAssertEqualObjects([MTMathAtomFactory commandNameForTextStyle:kMTTextStyleTypewriter], @"texttt");
+}
+
 @end

--- a/iosMathTests/MTMathListTest.m
+++ b/iosMathTests/MTMathListTest.m
@@ -699,6 +699,31 @@ _XCTPrimitiveAssertNotEqual(test, expression1, @#expression1, expression2, @#exp
     XCTAssertTrue([atom isKindOfClass:[MTTextAtom class]]);
 }
 
+- (void) testTextAtomFactoryCreatesTextAtom
+{
+    MTMathAtom *atom = [MTMathAtom atomWithType:kMTMathAtomText value:@"abc"];
+    XCTAssertTrue([atom isKindOfClass:[MTTextAtom class]]);
+    XCTAssertEqual(atom.type, kMTMathAtomText);
+    XCTAssertEqualObjects(atom.nucleus, @"abc");
+    XCTAssertEqualObjects(((MTTextAtom *)atom).text, @"abc");
+    XCTAssertEqual(((MTTextAtom *)atom).textStyle, kMTTextStyleRoman);
+}
+
+- (void) testTextAtomTextAndNucleusStayInSync
+{
+    MTTextAtom *atom = [[MTTextAtom alloc] initWithText:@"abc" style:kMTTextStyleRoman];
+    atom.text = @"def";
+    XCTAssertEqualObjects(atom.nucleus, @"def");
+    XCTAssertEqualObjects(atom.stringValue, @"def");
+
+    atom.nucleus = @"ghi";
+    XCTAssertEqualObjects(atom.text, @"ghi");
+
+    NSMutableString *out = [NSMutableString string];
+    [atom appendLaTeXToString:out];
+    XCTAssertEqualObjects(out, @"\\text{ghi}");
+}
+
 - (void) testTextAtomScriptsAllowed
 {
     MTTextAtom *atom = [[MTTextAtom alloc] initWithText:@"x" style:kMTTextStyleBold];

--- a/iosMathTests/MTMathListTest.m
+++ b/iosMathTests/MTMathListTest.m
@@ -688,4 +688,109 @@ _XCTPrimitiveAssertNotEqual(test, expression1, @#expression1, expression2, @#exp
     [MTMathListTest checkListCopy:copy.cells[0][2] original:list2 forTest:self];
 }
 
+#pragma mark - MTTextAtom
+
+- (void) testTextAtomTypeIsText
+{
+    MTTextAtom *atom = [[MTTextAtom alloc] initWithText:@"abc" style:kMTTextStyleRoman];
+    XCTAssertEqual(atom.type, kMTMathAtomText);
+    XCTAssertEqualObjects(atom.text, @"abc");
+    XCTAssertEqual(atom.textStyle, kMTTextStyleRoman);
+    XCTAssertTrue([atom isKindOfClass:[MTTextAtom class]]);
+}
+
+- (void) testTextAtomScriptsAllowed
+{
+    MTTextAtom *atom = [[MTTextAtom alloc] initWithText:@"x" style:kMTTextStyleBold];
+    XCTAssertTrue(atom.scriptsAllowed);
+}
+
+- (void) testTextAtomFontStyleDefault
+{
+    // MTTextAtom must keep fontStyle = Default so the round-trip serializer
+    // does not wrap it in a \mathrm{...} group; the atom's own
+    // appendLaTeXToString: writes the \textbf{...} envelope.
+    MTTextAtom *atom = [[MTTextAtom alloc] initWithText:@"x" style:kMTTextStyleBold];
+    XCTAssertEqual(atom.fontStyle, kMTFontStyleDefault);
+}
+
+- (void) testTextAtomCopy
+{
+    MTTextAtom *atom = [[MTTextAtom alloc] initWithText:@"你好" style:kMTTextStyleItalic];
+    MTMathList *sup = [[MTMathList alloc] init];
+    [sup addAtom:[MTMathAtomFactory atomForCharacter:'2']];
+    atom.superScript = sup;
+    // indexRange is read-only in the public header; set via KVC for this test.
+    [atom setValue:[NSValue valueWithRange:NSMakeRange(3, 7)] forKey:@"indexRange"];
+
+    MTTextAtom *copy = [atom copy];
+    XCTAssertTrue([copy isKindOfClass:[MTTextAtom class]]);
+    XCTAssertEqualObjects(copy.text, @"你好");
+    XCTAssertEqual(copy.textStyle, kMTTextStyleItalic);
+    XCTAssertNotNil(copy.superScript);
+    XCTAssertNotEqual(copy.superScript, sup); // deep copy
+    XCTAssertEqual(copy.indexRange.location, (NSUInteger)3);
+    XCTAssertEqual(copy.indexRange.length,   (NSUInteger)7);
+}
+
+- (void) testTextAtomFinalize
+{
+    MTTextAtom *atom = [[MTTextAtom alloc] initWithText:@"x" style:kMTTextStyleRoman];
+    MTMathList *sup = [[MTMathList alloc] init];
+    [sup addAtom:[MTMathAtomFactory atomForCharacter:'2']];
+    atom.superScript = sup;
+
+    MTTextAtom *fin = (MTTextAtom *)[atom finalized];
+    XCTAssertTrue([fin isKindOfClass:[MTTextAtom class]]);
+    XCTAssertEqualObjects(fin.text, @"x");
+    XCTAssertNotNil(fin.superScript);
+}
+
+- (void) testTextAtomRoundTripPlain
+{
+    MTTextAtom *atom = [[MTTextAtom alloc] initWithText:@"abc" style:kMTTextStyleRoman];
+    NSMutableString *out = [NSMutableString string];
+    [atom appendLaTeXToString:out];
+    XCTAssertEqualObjects(out, @"\\text{abc}");
+}
+
+- (void) testTextAtomRoundTripBold
+{
+    MTTextAtom *atom = [[MTTextAtom alloc] initWithText:@"你好" style:kMTTextStyleBold];
+    NSMutableString *out = [NSMutableString string];
+    [atom appendLaTeXToString:out];
+    XCTAssertEqualObjects(out, @"\\textbf{你好}");
+}
+
+- (void) testTextAtomRoundTripEscapes
+{
+    // Body contains characters that must be escaped on round-trip:
+    // backslash, braces, _, ^, %, &, #, $.
+    MTTextAtom *atom = [[MTTextAtom alloc]
+                         initWithText:@"50% $5 {x} \\ a_b^c &d #e"
+                                style:kMTTextStyleRoman];
+    NSMutableString *out = [NSMutableString string];
+    [atom appendLaTeXToString:out];
+    XCTAssertEqualObjects(out, @"\\text{50\\% \\$5 \\{x\\} \\\\ a\\_b\\^c \\&d \\#e}");
+}
+
+- (void) testTextAtomAllStylesRoundTrip
+{
+    NSDictionary *cases = @{
+        @(kMTTextStyleRoman):      @"\\text{x}",
+        @(kMTTextStyleBold):       @"\\textbf{x}",
+        @(kMTTextStyleItalic):     @"\\textit{x}",
+        @(kMTTextStyleSansSerif):  @"\\textsf{x}",
+        @(kMTTextStyleTypewriter): @"\\texttt{x}",
+    };
+    for (NSNumber *key in cases) {
+        MTTextAtom *atom = [[MTTextAtom alloc]
+                             initWithText:@"x"
+                                    style:(MTTextStyle)key.unsignedIntegerValue];
+        NSMutableString *out = [NSMutableString string];
+        [atom appendLaTeXToString:out];
+        XCTAssertEqualObjects(out, cases[key], @"style %@", key);
+    }
+}
+
 @end

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -7,6 +7,7 @@
 //
 
 #import <XCTest/XCTest.h>
+#import <CoreText/CoreText.h>
 
 #import "MTTypesetter.h"
 #import "MTFont+Internal.h"
@@ -1906,5 +1907,52 @@
     XCTAssertGreaterThanOrEqual(arrowStack.over.width + 0.01, arrowStack.base.width);
 }
 
+#pragma mark - MTFontManager +textCTFontForStyle:size:
+
+- (void) testTextCTFontRomanReturnsFont {
+    CTFontRef font = [MTFontManager textCTFontForStyle:kMTTextStyleRoman size:20];
+    XCTAssertTrue(font != NULL);
+    CTFontSymbolicTraits traits = CTFontGetSymbolicTraits(font);
+    XCTAssertFalse((traits & kCTFontTraitBold)   != 0);
+    XCTAssertFalse((traits & kCTFontTraitItalic) != 0);
+    if (font) CFRelease(font);
+}
+
+- (void) testTextCTFontBoldHasBoldTrait {
+    CTFontRef font = [MTFontManager textCTFontForStyle:kMTTextStyleBold size:20];
+    XCTAssertTrue(font != NULL);
+    XCTAssertTrue((CTFontGetSymbolicTraits(font) & kCTFontTraitBold) != 0);
+    if (font) CFRelease(font);
+}
+
+- (void) testTextCTFontItalicHasItalicTrait {
+    CTFontRef font = [MTFontManager textCTFontForStyle:kMTTextStyleItalic size:20];
+    XCTAssertTrue(font != NULL);
+    XCTAssertTrue((CTFontGetSymbolicTraits(font) & kCTFontTraitItalic) != 0);
+    if (font) CFRelease(font);
+}
+
+- (void) testTextCTFontTypewriterIsMonospace {
+    CTFontRef font = [MTFontManager textCTFontForStyle:kMTTextStyleTypewriter size:20];
+    XCTAssertTrue(font != NULL);
+    XCTAssertTrue((CTFontGetSymbolicTraits(font) & kCTFontTraitMonoSpace) != 0);
+    if (font) CFRelease(font);
+}
+
+- (void) testTextCTFontSansFallback {
+    CTFontRef font = [MTFontManager textCTFontForStyle:kMTTextStyleSansSerif size:20];
+    XCTAssertTrue(font != NULL);
+    CTFontSymbolicTraits traits = CTFontGetSymbolicTraits(font);
+    XCTAssertFalse((traits & kCTFontTraitBold)   != 0);
+    XCTAssertFalse((traits & kCTFontTraitItalic) != 0);
+    if (font) CFRelease(font);
+}
+
+- (void) testTextCTFontSizeMatches {
+    CGFloat target = 17.5;
+    CTFontRef font = [MTFontManager textCTFontForStyle:kMTTextStyleRoman size:target];
+    XCTAssertEqualWithAccuracy(CTFontGetSize(font), target, 0.001);
+    if (font) CFRelease(font);
+}
 
 @end

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -1962,7 +1962,6 @@
     MTTextDisplay *d = [[MTTextDisplay alloc] initWithText:@"abc"
                                                  textStyle:kMTTextStyleRoman
                                                     ctFont:font
-                                              xHeightShift:0
                                                      range:NSMakeRange(0, 3)];
     XCTAssertNotNil(d);
     XCTAssertEqualObjects(d.text, @"abc");
@@ -1978,7 +1977,6 @@
     MTTextDisplay *d = [[MTTextDisplay alloc] initWithText:@""
                                                  textStyle:kMTTextStyleRoman
                                                     ctFont:font
-                                              xHeightShift:0
                                                      range:NSMakeRange(0, 0)];
     XCTAssertNotNil(d);
     XCTAssertLessThan(d.width, 0.5);
@@ -1990,7 +1988,6 @@
     MTTextDisplay *d = [[MTTextDisplay alloc] initWithText:@"你好"
                                                  textStyle:kMTTextStyleRoman
                                                     ctFont:font
-                                              xHeightShift:0
                                                      range:NSMakeRange(0, 2)];
     XCTAssertNotNil(d);
     XCTAssertGreaterThan(d.width, 0);
@@ -2002,7 +1999,6 @@
     MTTextDisplay *d = [[MTTextDisplay alloc] initWithText:@"abc"
                                                  textStyle:kMTTextStyleBold
                                                     ctFont:font
-                                              xHeightShift:0
                                                      range:NSMakeRange(0, 3)];
     CGColorSpaceRef cs = CGColorSpaceCreateDeviceRGB();
     CGContextRef ctx = CGBitmapContextCreate(NULL, 100, 50, 8, 0, cs,
@@ -2189,12 +2185,21 @@
         createLineForMathList:list font:font style:kMTLineStyleDisplay];
     BOOL hasMath = NO;
     BOOL hasText = NO;
+    MTCTLineDisplay *math = nil;
+    MTTextDisplay *text = nil;
     for (MTDisplay *d in display.subDisplays) {
-        if ([d isKindOfClass:[MTCTLineDisplay class]]) hasMath = YES;
-        if ([d isKindOfClass:[MTTextDisplay class]])   hasText = YES;
+        if ([d isKindOfClass:[MTCTLineDisplay class]]) {
+            hasMath = YES;
+            if (!math) math = (MTCTLineDisplay *)d;
+        }
+        if ([d isKindOfClass:[MTTextDisplay class]]) {
+            hasText = YES;
+            if (!text) text = (MTTextDisplay *)d;
+        }
     }
     XCTAssertTrue(hasMath);
     XCTAssertTrue(hasText);
+    XCTAssertEqualWithAccuracy(text.position.y, math.position.y, 0.001);
 }
 
 @end

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -2127,4 +2127,74 @@
     XCTAssertTrue(hasScript);
 }
 
+#pragma mark - End-to-end \text* rendering (Phase 5)
+
+- (void) testTextDisplayChineseFromString {
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\text{你好}"];
+    MTFont *font = [MTFontManager fontManager].defaultFont;
+    MTMathListDisplay *display = [MTTypesetter
+        createLineForMathList:list font:font style:kMTLineStyleDisplay];
+    XCTAssertEqual(display.subDisplays.count, (NSUInteger)1);
+    MTTextDisplay *text = (MTTextDisplay *)display.subDisplays.firstObject;
+    XCTAssertGreaterThan(text.width, 0);
+    [self assertCTLineHasNoNotdef:text];
+}
+
+- (void) testTextDisplayCyrillicBoldFromString {
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\textbf{Привет}"];
+    MTFont *font = [MTFontManager fontManager].defaultFont;
+    MTMathListDisplay *display = [MTTypesetter
+        createLineForMathList:list font:font style:kMTLineStyleDisplay];
+    MTTextDisplay *text = (MTTextDisplay *)display.subDisplays.firstObject;
+    XCTAssertEqual(text.textStyle, kMTTextStyleBold);
+    XCTAssertGreaterThan(text.width, 0);
+    [self assertCTLineHasNoNotdef:text];
+}
+
+- (void) testTextDisplayDevanagariFromString {
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\text{नमस्ते}"];
+    MTFont *font = [MTFontManager fontManager].defaultFont;
+    MTMathListDisplay *display = [MTTypesetter
+        createLineForMathList:list font:font style:kMTLineStyleDisplay];
+    MTTextDisplay *text = (MTTextDisplay *)display.subDisplays.firstObject;
+    XCTAssertGreaterThan(text.width, 0);
+    [self assertCTLineHasNoNotdef:text];
+}
+
+- (void) testTextDisplayHebrewFromString {
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\text{שלום}"];
+    MTFont *font = [MTFontManager fontManager].defaultFont;
+    MTMathListDisplay *display = [MTTypesetter
+        createLineForMathList:list font:font style:kMTLineStyleDisplay];
+    MTTextDisplay *text = (MTTextDisplay *)display.subDisplays.firstObject;
+    XCTAssertGreaterThan(text.width, 0);
+    [self assertCTLineHasNoNotdef:text];
+}
+
+- (void) testTextDisplayArabicFromString {
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\text{مرحبا}"];
+    MTFont *font = [MTFontManager fontManager].defaultFont;
+    MTMathListDisplay *display = [MTTypesetter
+        createLineForMathList:list font:font style:kMTLineStyleDisplay];
+    MTTextDisplay *text = (MTTextDisplay *)display.subDisplays.firstObject;
+    XCTAssertGreaterThan(text.width, 0);
+    // Per LLD §1 we don't assert RTL ordering — just that all glyphs resolved.
+    [self assertCTLineHasNoNotdef:text];
+}
+
+- (void) testTextInMixedLine {
+    MTMathList *list = [MTMathListBuilder buildFromString:@"x + \\text{ok}"];
+    MTFont *font = [MTFontManager fontManager].defaultFont;
+    MTMathListDisplay *display = [MTTypesetter
+        createLineForMathList:list font:font style:kMTLineStyleDisplay];
+    BOOL hasMath = NO;
+    BOOL hasText = NO;
+    for (MTDisplay *d in display.subDisplays) {
+        if ([d isKindOfClass:[MTCTLineDisplay class]]) hasMath = YES;
+        if ([d isKindOfClass:[MTTextDisplay class]])   hasText = YES;
+    }
+    XCTAssertTrue(hasMath);
+    XCTAssertTrue(hasText);
+}
+
 @end

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -1955,4 +1955,62 @@
     if (font) CFRelease(font);
 }
 
+#pragma mark - MTTextDisplay construction
+
+- (void) testTextDisplayConstructionLatin {
+    CTFontRef font = [MTFontManager textCTFontForStyle:kMTTextStyleRoman size:20];
+    MTTextDisplay *d = [[MTTextDisplay alloc] initWithText:@"abc"
+                                                 textStyle:kMTTextStyleRoman
+                                                    ctFont:font
+                                              xHeightShift:0
+                                                     range:NSMakeRange(0, 3)];
+    XCTAssertNotNil(d);
+    XCTAssertEqualObjects(d.text, @"abc");
+    XCTAssertEqual(d.textStyle, kMTTextStyleRoman);
+    XCTAssertGreaterThan(d.width, 0);
+    XCTAssertEqual(d.range.location, (NSUInteger)0);
+    XCTAssertEqual(d.range.length,   (NSUInteger)3);
+    if (font) CFRelease(font);
+}
+
+- (void) testTextDisplayConstructionEmpty {
+    CTFontRef font = [MTFontManager textCTFontForStyle:kMTTextStyleRoman size:20];
+    MTTextDisplay *d = [[MTTextDisplay alloc] initWithText:@""
+                                                 textStyle:kMTTextStyleRoman
+                                                    ctFont:font
+                                              xHeightShift:0
+                                                     range:NSMakeRange(0, 0)];
+    XCTAssertNotNil(d);
+    XCTAssertLessThan(d.width, 0.5);
+    if (font) CFRelease(font);
+}
+
+- (void) testTextDisplayConstructionChinese {
+    CTFontRef font = [MTFontManager textCTFontForStyle:kMTTextStyleRoman size:20];
+    MTTextDisplay *d = [[MTTextDisplay alloc] initWithText:@"你好"
+                                                 textStyle:kMTTextStyleRoman
+                                                    ctFont:font
+                                              xHeightShift:0
+                                                     range:NSMakeRange(0, 2)];
+    XCTAssertNotNil(d);
+    XCTAssertGreaterThan(d.width, 0);
+    if (font) CFRelease(font);
+}
+
+- (void) testTextDisplayDrawDoesNotCrash {
+    CTFontRef font = [MTFontManager textCTFontForStyle:kMTTextStyleBold size:20];
+    MTTextDisplay *d = [[MTTextDisplay alloc] initWithText:@"abc"
+                                                 textStyle:kMTTextStyleBold
+                                                    ctFont:font
+                                              xHeightShift:0
+                                                     range:NSMakeRange(0, 3)];
+    CGColorSpaceRef cs = CGColorSpaceCreateDeviceRGB();
+    CGContextRef ctx = CGBitmapContextCreate(NULL, 100, 50, 8, 0, cs,
+                                             kCGImageAlphaPremultipliedLast);
+    XCTAssertNoThrow([d draw:ctx]);
+    CGContextRelease(ctx);
+    CGColorSpaceRelease(cs);
+    if (font) CFRelease(font);
+}
+
 @end

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -2013,4 +2013,118 @@
     if (font) CFRelease(font);
 }
 
+#pragma mark - Phase 4: Typesetter handles MTTextAtom
+
+- (MTMathList *) listWithTextAtom:(MTTextAtom *)atom {
+    MTMathList *list = [[MTMathList alloc] init];
+    [list addAtom:atom];
+    return list;
+}
+
+// Helper: walk every glyph run in the CTLine and assert no glyph index 0
+// (`.notdef` in TrueType/OpenType). Re-create the line from the public
+// MTTextDisplay properties since the line itself is private.
+- (void) assertCTLineHasNoNotdef:(MTTextDisplay *)display {
+    CTFontRef font = [MTFontManager textCTFontForStyle:display.textStyle size:20];
+    NSAttributedString *as = [[NSAttributedString alloc]
+                               initWithString:display.text
+                                   attributes:@{(NSString *)kCTFontAttributeName: (__bridge id)font}];
+    CTLineRef line = CTLineCreateWithAttributedString(
+                        (__bridge CFAttributedStringRef)as);
+    CFArrayRef runs = CTLineGetGlyphRuns(line);
+    for (CFIndex i = 0; i < CFArrayGetCount(runs); i++) {
+        CTRunRef run = CFArrayGetValueAtIndex(runs, i);
+        CFIndex count = CTRunGetGlyphCount(run);
+        CGGlyph glyphs[count];
+        CTRunGetGlyphs(run, CFRangeMake(0, count), glyphs);
+        for (CFIndex j = 0; j < count; j++) {
+            XCTAssertNotEqual(glyphs[j], 0,
+                              @"`.notdef` for char index %ld in '%@'",
+                              (long)j, display.text);
+        }
+    }
+    CFRelease(line);
+    CFRelease(font);
+}
+
+- (void) testTypesetterTextDisplayPresent {
+    MTTextAtom *atom = [[MTTextAtom alloc] initWithText:@"abc"
+                                                  style:kMTTextStyleBold];
+    MTFont *font = [MTFontManager fontManager].defaultFont;
+    MTMathListDisplay *display = [MTTypesetter
+        createLineForMathList:[self listWithTextAtom:atom]
+                         font:font
+                        style:kMTLineStyleDisplay];
+    XCTAssertNotNil(display);
+    XCTAssertEqual(display.subDisplays.count, (NSUInteger)1);
+    XCTAssertTrue([display.subDisplays.firstObject
+                    isKindOfClass:[MTTextDisplay class]]);
+    XCTAssertGreaterThan(display.subDisplays.firstObject.width, 0);
+}
+
+- (void) testTypesetterTextDisplayEmpty {
+    MTTextAtom *atom = [[MTTextAtom alloc] initWithText:@""
+                                                  style:kMTTextStyleRoman];
+    MTFont *font = [MTFontManager fontManager].defaultFont;
+    XCTAssertNoThrow(([MTTypesetter
+        createLineForMathList:[self listWithTextAtom:atom]
+                         font:font
+                        style:kMTLineStyleDisplay]));
+}
+
+- (void) testTypesetterTextDisplayChinese {
+    MTTextAtom *atom = [[MTTextAtom alloc] initWithText:@"你好"
+                                                  style:kMTTextStyleRoman];
+    MTFont *font = [MTFontManager fontManager].defaultFont;
+    MTMathListDisplay *display = [MTTypesetter
+        createLineForMathList:[self listWithTextAtom:atom]
+                         font:font
+                        style:kMTLineStyleDisplay];
+    MTTextDisplay *text = (MTTextDisplay *)display.subDisplays.firstObject;
+    XCTAssertGreaterThan(text.width, 0);
+    XCTAssertEqualObjects(text.text, @"你好");
+    [self assertCTLineHasNoNotdef:text];
+}
+
+- (void) testTypesetterTextNotFusedAcrossAtoms {
+    // Two adjacent text atoms must remain separate displays — Rule 14
+    // would fuse Ord+Ord, and this test pins down that distinct enum
+    // prevents fusion.
+    MTTextAtom *a = [[MTTextAtom alloc] initWithText:@"a" style:kMTTextStyleRoman];
+    MTTextAtom *b = [[MTTextAtom alloc] initWithText:@"b" style:kMTTextStyleBold];
+    MTMathList *list = [[MTMathList alloc] init];
+    [list addAtom:a];
+    [list addAtom:b];
+    MTFont *font = [MTFontManager fontManager].defaultFont;
+    MTMathListDisplay *display = [MTTypesetter
+        createLineForMathList:list font:font style:kMTLineStyleDisplay];
+    XCTAssertEqual(display.subDisplays.count, (NSUInteger)2);
+    XCTAssertTrue([display.subDisplays[0] isKindOfClass:[MTTextDisplay class]]);
+    XCTAssertTrue([display.subDisplays[1] isKindOfClass:[MTTextDisplay class]]);
+}
+
+- (void) testTypesetterTextWithSuperscript {
+    MTTextAtom *t = [[MTTextAtom alloc] initWithText:@"abc" style:kMTTextStyleBold];
+    MTMathList *sup = [[MTMathList alloc] init];
+    [sup addAtom:[MTMathAtomFactory atomForCharacter:'2']];
+    t.superScript = sup;
+
+    MTFont *font = [MTFontManager fontManager].defaultFont;
+    MTMathListDisplay *display = [MTTypesetter
+        createLineForMathList:[self listWithTextAtom:t]
+                         font:font
+                        style:kMTLineStyleDisplay];
+
+    BOOL hasText   = NO;
+    BOOL hasScript = NO;
+    for (MTDisplay *d in display.subDisplays) {
+        if ([d isKindOfClass:[MTTextDisplay class]]) hasText = YES;
+        // Scripts emerge as MTMathListDisplay sub-displays (per existing
+        // makeScripts: convention).
+        if ([d isKindOfClass:[MTMathListDisplay class]]) hasScript = YES;
+    }
+    XCTAssertTrue(hasText);
+    XCTAssertTrue(hasScript);
+}
+
 @end


### PR DESCRIPTION
## Summary

Adds first-class non-Latin text support to iosMath via a new `MTTextAtom` (Approach E from the LLD): `\text`, `\textrm`, `\textbf`, `\textit`, `\textsf`, `\texttt` now capture their bodies as raw `NSString` and render through CoreText's system-font cascade. This unlocks CJK, Cyrillic, Devanagari, Hebrew, Arabic, etc. inside math layouts without relying on the math font's BMP coverage. The implementation also retires the legacy Cyrillic-as-Variable carve-out, since `\text` now handles arbitrary scripts uniformly.

- New atom type `kMTMathAtomText` (= 19) with `MTTextStyle` enum (Roman/Bold/Italic/SansSerif/Typewriter), distinct from Ordinary so Rule 14 fusion is avoided.
- New `MTTextDisplay` opaque sub-display embedded into the parent math line, x-height-aligned via the math font's `\fontdimen5`.
- New `MTFontManager +textCTFontForStyle:size:` returning a `CTFontRef` with system font + symbolic traits.
- Parser switch: the six `\text*` commands route to `MTTextAtom`; raw-body capture supports balanced braces and the standard 8 LaTeX escapes (`\\`, `\{`, `\}`, `\_`, `\^`, `\%`, `\&`, `\#`, `\$`).
- 34 new tests; full suite 217 → 219 (the +2 are item 6's regression coverage for the dropped carve-out).

## Plan & LLD

- Plan: [\`docs/plans/2026-05-10-non-latin-text-atom.md\`](docs/plans/2026-05-10-non-latin-text-atom.md)
- LLD: [\`docs/lld/2026-05-10-non-latin-text-atom.md\`](docs/lld/2026-05-10-non-latin-text-atom.md)

(These live under untracked \`docs/\` per the orchestrator setup; they're not in the diff but are the design reference for review.)

## Commits

- [item 1] feat: add MTTextAtom and MTTextStyle data model (\`010565a\`)
- [item 2] feat: MTFontManager +textCTFontForStyle:size: (\`abd89fe\`)
- [item 3] feat: MTTextDisplay for CoreText system-font runs (\`9ceb5b4\`)
- [item 4] feat: typesetter renders MTTextAtom as MTTextDisplay (\`436f286\`)
- [item 5] feat: parser routes \\text* to MTTextAtom (\`01e071b\`)
- [item 6] refactor: drop Cyrillic carve-out in atomForCharacter: (\`d32b192\`)
- [item 7] docs(examples): add mixed text + math demonstrators (\`23382fc\`)

Each commit's tests pass independently (verified per-commit with \`swift test\`).

## Test plan

- [x] \`swift test\` — 219/219 pass at HEAD and at every intermediate commit
- [ ] Run iOS sample app (\`iosMathExample\`) on simulator and visually confirm entries 23–30 (Cyrillic, CJK, Devanagari, Hebrew, Arabic, mixed-style, scripts-on-text)
- [ ] Run macOS sample app (\`MacOSMathExample\`) and confirm the same
- [ ] Run \`SwiftMathExample\` (SwiftUI) and confirm the three new \`NamedFormula\` entries render
- [ ] Spot-check that pre-existing math layouts (fractions, radicals, integrals) are byte-identical — \`MTTextAtom\` is opaque to the parent line so layout for non-text math should be unchanged
- [ ] One known follow-up: \`Example/iosMathExample/example/ViewController.m\` and \`MacOSMathExample/AppDelegate.m\` carry hard-coded \`demoHeights[]\` arrays that stop at index 22; new entries 23–30 fall through to the 60pt default. If any clip in practice, extend the arrays.