### PR TITLE
Fraction typesetter — style override, cfrac struts, thinspace, numerator alignment

### DIFF
--- a/iosMath/lib/MTMathList.h
+++ b/iosMath/lib/MTMathList.h
@@ -331,6 +331,39 @@ typedef NS_ENUM(NSUInteger, MTDelimiterSize) {
     kMTDelimiterSize4 = 4,
 };
 
+/**
+ @typedef MTFractionStyle
+ @brief Explicit math style for a fraction (the AMSMath \genfrac style digit).
+
+ - kMTFractionStyleAuto: Honor the surrounding style via TeX Rule 15a
+   (one step smaller for operands; same style as parent for the bar/metrics).
+   This is the default and corresponds to plain \frac/\binom/\atop/\over.
+ - kMTFractionStyleDisplay: Force display style for this fraction
+   (\dfrac, \dbinom, \cfrac).
+ - kMTFractionStyleText: Force text style (\tfrac, \tbinom).
+ - kMTFractionStyleScript / kMTFractionStyleScriptScript: Reserved for
+   future \genfrac support. Not produced by any command in this LLD's
+   scope, but valid values for forward use.
+ */
+typedef NS_ENUM(NSUInteger, MTFractionStyle) {
+    kMTFractionStyleAuto = 0,
+    kMTFractionStyleDisplay,
+    kMTFractionStyleText,
+    kMTFractionStyleScript,
+    kMTFractionStyleScriptScript,
+};
+
+/**
+ @typedef MTFractionAlignment
+ @brief Horizontal alignment of the numerator within the fraction column.
+ Only \cfrac[l]/[c]/[r] sets a non-center value.
+ */
+typedef NS_ENUM(NSUInteger, MTFractionAlignment) {
+    kMTFractionAlignmentCenter = 0,
+    kMTFractionAlignmentLeft,
+    kMTFractionAlignmentRight,
+};
+
 /** A `MTMathAtom` representing an explicit fixed-size delimiter.
 
  Produced by the parser from the `\big`/`\Big`/`\bigg`/`\Bigg` family (plus

--- a/iosMath/lib/MTMathList.h
+++ b/iosMath/lib/MTMathList.h
@@ -270,11 +270,19 @@ typedef NS_ENUM(NSUInteger, MTFractionAlignment) {
 /** True for \cfrac. The typesetter uses this flag to apply AMSMath's
  strut equivalents to both operand displays and to wrap the rendered
  fraction with surrounding 3mu thin space. Does not affect the style
- decision, which is encoded in styleOverride. */
+ decision, which is encoded in styleOverride.
+
+ Not persisted by appendLaTeXToString:/+[MTMathListBuilder mathListToString:]:
+ \cfrac serializes as \frac{\displaystyle{...}}{\displaystyle{...}}, so a
+ latex -> MTMathList -> latex round trip drops this flag. */
 @property (nonatomic) BOOL isContinuedFraction;
 
 /** Numerator alignment within max(numWidth, denWidth). Default
- kMTFractionAlignmentCenter. Only \cfrac[l]/[r] sets a non-default value. */
+ kMTFractionAlignmentCenter. Only \cfrac[l]/[r] sets a non-default value.
+
+ Not persisted by appendLaTeXToString:/+[MTMathListBuilder mathListToString:]:
+ the [l]/[r] optional argument is not emitted, so a round trip drops this
+ alignment. */
 @property (nonatomic) MTFractionAlignment numeratorAlignment;
 
 @end

--- a/iosMath/lib/MTMathList.h
+++ b/iosMath/lib/MTMathList.h
@@ -205,6 +205,39 @@ typedef NS_ENUM(NSUInteger, MTTextStyle)
 
 @end
 
+/**
+ @typedef MTFractionStyle
+ @brief Explicit math style for a fraction (the AMSMath \genfrac style digit).
+
+ - kMTFractionStyleAuto: Honor the surrounding style via TeX Rule 15a
+   (one step smaller for operands; same style as parent for the bar/metrics).
+   This is the default and corresponds to plain \frac/\binom/\atop/\over.
+ - kMTFractionStyleDisplay: Force display style for this fraction
+   (\dfrac, \dbinom, \cfrac).
+ - kMTFractionStyleText: Force text style (\tfrac, \tbinom).
+ - kMTFractionStyleScript / kMTFractionStyleScriptScript: Reserved for
+   future \genfrac support. Not produced by any command in this LLD's
+   scope, but valid values for forward use.
+ */
+typedef NS_ENUM(NSUInteger, MTFractionStyle) {
+    kMTFractionStyleAuto = 0,
+    kMTFractionStyleDisplay,
+    kMTFractionStyleText,
+    kMTFractionStyleScript,
+    kMTFractionStyleScriptScript,
+};
+
+/**
+ @typedef MTFractionAlignment
+ @brief Horizontal alignment of the numerator within the fraction column.
+ Only \cfrac[l]/[c]/[r] sets a non-center value.
+ */
+typedef NS_ENUM(NSUInteger, MTFractionAlignment) {
+    kMTFractionAlignmentCenter = 0,
+    kMTFractionAlignmentLeft,
+    kMTFractionAlignmentRight,
+};
+
 /** An atom of type fraction. This atom has a numerator and denominator. */
 @interface MTFraction : MTMathAtom
 
@@ -227,6 +260,22 @@ typedef NS_ENUM(NSUInteger, MTTextStyle)
 @property (nonatomic, nullable) NSString* leftDelimiter;
 /** An optional delimiter for a fraction on the right. */
 @property (nonatomic, nullable) NSString* rightDelimiter;
+
+/** Optional explicit style override for this fraction. Default
+ kMTFractionStyleAuto means: honor the surrounding style via TeX Rule 15a.
+ \dfrac and \dbinom set this to kMTFractionStyleDisplay; \tfrac and \tbinom
+ set this to kMTFractionStyleText; \cfrac sets this to kMTFractionStyleDisplay. */
+@property (nonatomic) MTFractionStyle styleOverride;
+
+/** True for \cfrac. The typesetter uses this flag to apply AMSMath's
+ strut equivalents to both operand displays and to wrap the rendered
+ fraction with surrounding 3mu thin space. Does not affect the style
+ decision, which is encoded in styleOverride. */
+@property (nonatomic) BOOL isContinuedFraction;
+
+/** Numerator alignment within max(numWidth, denWidth). Default
+ kMTFractionAlignmentCenter. Only \cfrac[l]/[r] sets a non-default value. */
+@property (nonatomic) MTFractionAlignment numeratorAlignment;
 
 @end
 
@@ -329,39 +378,6 @@ typedef NS_ENUM(NSUInteger, MTDelimiterSize) {
     kMTDelimiterSize3 = 3,
     /// `\Bigg`, `\Biggl`, `\Biggr`, `\Biggm`
     kMTDelimiterSize4 = 4,
-};
-
-/**
- @typedef MTFractionStyle
- @brief Explicit math style for a fraction (the AMSMath \genfrac style digit).
-
- - kMTFractionStyleAuto: Honor the surrounding style via TeX Rule 15a
-   (one step smaller for operands; same style as parent for the bar/metrics).
-   This is the default and corresponds to plain \frac/\binom/\atop/\over.
- - kMTFractionStyleDisplay: Force display style for this fraction
-   (\dfrac, \dbinom, \cfrac).
- - kMTFractionStyleText: Force text style (\tfrac, \tbinom).
- - kMTFractionStyleScript / kMTFractionStyleScriptScript: Reserved for
-   future \genfrac support. Not produced by any command in this LLD's
-   scope, but valid values for forward use.
- */
-typedef NS_ENUM(NSUInteger, MTFractionStyle) {
-    kMTFractionStyleAuto = 0,
-    kMTFractionStyleDisplay,
-    kMTFractionStyleText,
-    kMTFractionStyleScript,
-    kMTFractionStyleScriptScript,
-};
-
-/**
- @typedef MTFractionAlignment
- @brief Horizontal alignment of the numerator within the fraction column.
- Only \cfrac[l]/[c]/[r] sets a non-center value.
- */
-typedef NS_ENUM(NSUInteger, MTFractionAlignment) {
-    kMTFractionAlignmentCenter = 0,
-    kMTFractionAlignmentLeft,
-    kMTFractionAlignmentRight,
 };
 
 /** A `MTMathAtom` representing an explicit fixed-size delimiter.

--- a/iosMath/lib/MTMathList.m
+++ b/iosMath/lib/MTMathList.m
@@ -381,12 +381,31 @@ static NSString* fractionCommandForDelimiterPair(NSString* leftDelimiter, NSStri
 
 - (void)appendLaTeXToString:(NSMutableString *)str
 {
+    NSString* numLatex = [MTMathListBuilder mathListToString:self.numerator];
+    NSString* denLatex = [MTMathListBuilder mathListToString:self.denominator];
+    NSString* (^wrap)(NSString*) = ^NSString*(NSString* inner) {
+        switch (self.styleOverride) {
+            case kMTFractionStyleDisplay:
+                return [NSString stringWithFormat:@"\\displaystyle{%@}", inner];
+            case kMTFractionStyleText:
+                return [NSString stringWithFormat:@"\\textstyle{%@}", inner];
+            case kMTFractionStyleScript:
+                return [NSString stringWithFormat:@"\\scriptstyle{%@}", inner];
+            case kMTFractionStyleScriptScript:
+                return [NSString stringWithFormat:@"\\scriptscriptstyle{%@}", inner];
+            case kMTFractionStyleAuto:
+            default:
+                return inner;
+        }
+    };
+    NSString* numWrapped = wrap(numLatex);
+    NSString* denWrapped = wrap(denLatex);
     if (self.hasRule) {
-        [str appendFormat:@"\\frac{%@}{%@}", [MTMathListBuilder mathListToString:self.numerator], [MTMathListBuilder mathListToString:self.denominator]];
+        [str appendFormat:@"\\frac{%@}{%@}", numWrapped, denWrapped];
         return;
     }
     NSString* command = fractionCommandForDelimiterPair(self.leftDelimiter, self.rightDelimiter);
-    [str appendFormat:@"{%@ \\%@ %@}", [MTMathListBuilder mathListToString:self.numerator], command, [MTMathListBuilder mathListToString:self.denominator]];
+    [str appendFormat:@"{%@ \\%@ %@}", numWrapped, command, denWrapped];
 }
 
 @end

--- a/iosMath/lib/MTMathList.m
+++ b/iosMath/lib/MTMathList.m
@@ -365,6 +365,9 @@ static NSString* fractionCommandForDelimiterPair(NSString* leftDelimiter, NSStri
     frac->_hasRule = self.hasRule;
     frac.leftDelimiter = [self.leftDelimiter copyWithZone:zone];
     frac.rightDelimiter = [self.rightDelimiter copyWithZone:zone];
+    frac.styleOverride = self.styleOverride;
+    frac.isContinuedFraction = self.isContinuedFraction;
+    frac.numeratorAlignment = self.numeratorAlignment;
     return frac;
 }
 

--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -959,6 +959,39 @@ NSString *const MTParseError = @"ParseError";
     return largeDelimiterCommands;
 }
 
++ (NSDictionary<NSString*, NSDictionary*>*) fractionMacroCommands
+{
+    static NSDictionary<NSString*, NSDictionary*>* fractionMacroCommands = nil;
+    static dispatch_once_t fractionOnceToken;
+    dispatch_once(&fractionOnceToken, ^{
+        fractionMacroCommands = @{
+            @"frac"   : @{ @"hasRule": @YES,
+                           @"style":   @(kMTFractionStyleAuto) },
+            @"binom"  : @{ @"hasRule":    @NO,
+                           @"leftDelim":  @"(",
+                           @"rightDelim": @")",
+                           @"style":      @(kMTFractionStyleAuto) },
+            @"dfrac"  : @{ @"hasRule": @YES,
+                           @"style":   @(kMTFractionStyleDisplay) },
+            @"tfrac"  : @{ @"hasRule": @YES,
+                           @"style":   @(kMTFractionStyleText) },
+            @"dbinom" : @{ @"hasRule":    @NO,
+                           @"leftDelim":  @"(",
+                           @"rightDelim": @")",
+                           @"style":      @(kMTFractionStyleDisplay) },
+            @"tbinom" : @{ @"hasRule":    @NO,
+                           @"leftDelim":  @"(",
+                           @"rightDelim": @")",
+                           @"style":      @(kMTFractionStyleText) },
+            @"cfrac"  : @{ @"hasRule":      @YES,
+                           @"style":       @(kMTFractionStyleDisplay),
+                           @"continued":   @YES,
+                           @"acceptsAlign":@YES },
+        };
+    });
+    return fractionMacroCommands;
+}
+
 + (NSDictionary*) styleToCommands
 {
     static NSDictionary* styleToCommands = nil;

--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -707,25 +707,42 @@ NSString *const MTParseError = @"ParseError";
                                                         mathClass:mathClass
                                                              size:size];
     }
+    NSDictionary<NSString*, NSDictionary*>* fracTable = [MTMathListBuilder fractionMacroCommands];
+    NSDictionary* fracSpec = fracTable[command];
+    if (fracSpec) {
+        BOOL hasRule = [fracSpec[@"hasRule"] boolValue];
+        MTFractionStyle style = (MTFractionStyle)[fracSpec[@"style"] unsignedIntegerValue];
+        MTFraction* frac = hasRule ? [MTFraction new] : [[MTFraction alloc] initWithRule:NO];
+        frac.styleOverride = style;
+        if ([fracSpec[@"acceptsAlign"] boolValue]) {
+            MTFractionAlignment alignment = kMTFractionAlignmentCenter;
+            if ([self readOptionalAlignment:&alignment]) {
+                if (_error) {
+                    return nil;
+                }
+                frac.numeratorAlignment = alignment;
+            }
+        }
+        if ([fracSpec[@"continued"] boolValue]) {
+            frac.isContinuedFraction = YES;
+        }
+        frac.numerator = [self buildInternal:true];
+        frac.denominator = [self buildInternal:true];
+        NSString* leftDelim = fracSpec[@"leftDelim"];
+        NSString* rightDelim = fracSpec[@"rightDelim"];
+        if (leftDelim) {
+            frac.leftDelimiter = leftDelim;
+        }
+        if (rightDelim) {
+            frac.rightDelimiter = rightDelim;
+        }
+        return frac;
+    }
     MTAccent* accent = [MTMathAtomFactory accentWithName:command];
     if (accent) {
         // The command is an accent
         accent.innerList = [self buildInternal:true];
         return accent;
-    } else if ([command isEqualToString:@"frac"]) {
-        // A fraction command has 2 arguments
-        MTFraction* frac = [MTFraction new];
-        frac.numerator = [self buildInternal:true];
-        frac.denominator = [self buildInternal:true];
-        return frac;
-    } else if ([command isEqualToString:@"binom"]) {
-        // A binom command has 2 arguments
-        MTFraction* frac = [[MTFraction alloc] initWithRule:NO];
-        frac.numerator = [self buildInternal:true];
-        frac.denominator = [self buildInternal:true];
-        frac.leftDelimiter = @"(";
-        frac.rightDelimiter = @")";
-        return frac;
     } else if ([command isEqualToString:@"sqrt"]) {
         // A sqrt command with one argument
         MTRadical* rad = [MTRadical new];

--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -84,6 +84,60 @@ NSString *const MTParseError = @"ParseError";
     _currentChar--;
 }
 
+// Reads an optional [l|c|r] argument for \cfrac. If the next character is '[',
+// consumes one letter (l|c|r), then ']', writes the corresponding
+// MTFractionAlignment to *outAlignment, returns YES. If the bracket body is
+// anything else, calls -setError: and still returns YES (consumption happened);
+// the caller should bail on _error. If the next character is not '[', restores
+// the position and returns NO.
+- (BOOL) readOptionalAlignment:(MTFractionAlignment*)outAlignment
+{
+    if (![self hasCharacters]) {
+        return NO;
+    }
+    unichar ch = [self getNextCharacter];
+    if (ch != '[') {
+        [self unlookCharacter];
+        return NO;
+    }
+    // Read one alignment letter
+    if (![self hasCharacters]) {
+        [self setError:MTParseErrorInvalidCommand
+               message:@"Unterminated optional alignment for \\cfrac"];
+        return YES;
+    }
+    unichar letter = [self getNextCharacter];
+    MTFractionAlignment alignment;
+    switch (letter) {
+        case 'l': alignment = kMTFractionAlignmentLeft;   break;
+        case 'c': alignment = kMTFractionAlignmentCenter; break;
+        case 'r': alignment = kMTFractionAlignmentRight;  break;
+        default: {
+            NSString* errorMessage = [NSString stringWithFormat:
+                @"Invalid alignment for \\cfrac: '%C' (expected l, c, or r)", letter];
+            [self setError:MTParseErrorInvalidCommand message:errorMessage];
+            return YES;
+        }
+    }
+    // Require closing ']'
+    if (![self hasCharacters]) {
+        [self setError:MTParseErrorInvalidCommand
+               message:@"Unterminated optional alignment for \\cfrac"];
+        return YES;
+    }
+    unichar close = [self getNextCharacter];
+    if (close != ']') {
+        NSString* errorMessage = [NSString stringWithFormat:
+            @"Expected ']' to close \\cfrac alignment, got '%C'", close];
+        [self setError:MTParseErrorInvalidCommand message:errorMessage];
+        return YES;
+    }
+    if (outAlignment) {
+        *outAlignment = alignment;
+    }
+    return YES;
+}
+
 - (MTMathList *)build
 {
     MTMathList* list = [self buildInternal:false];

--- a/iosMath/render/MTMathListDisplay.m
+++ b/iosMath/render/MTMathListDisplay.m
@@ -382,7 +382,22 @@ static BOOL isIos6Supported(void) {
 
 - (void) updateNumeratorPosition
 {
-    _numerator.position = CGPointMake(self.position.x + (self.width - _numerator.width)/2, self.position.y + self.numeratorUp);
+    CGFloat maxWidth = self.width;
+    CGFloat numWidth = _numerator.width;
+    CGFloat offset;
+    switch (self.numeratorAlignment) {
+        case kMTFractionAlignmentLeft:
+            offset = 0;
+            break;
+        case kMTFractionAlignmentRight:
+            offset = maxWidth - numWidth;
+            break;
+        case kMTFractionAlignmentCenter:
+        default:
+            offset = (maxWidth - numWidth) / 2;
+            break;
+    }
+    _numerator.position = CGPointMake(self.position.x + offset, self.position.y + self.numeratorUp);
 }
 
 - (void) setPosition:(CGPoint)position

--- a/iosMath/render/internal/MTMathListDisplayInternal.h
+++ b/iosMath/render/internal/MTMathListDisplayInternal.h
@@ -78,6 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) CGFloat denominatorDown;
 @property (nonatomic) CGFloat linePosition;
 @property (nonatomic) CGFloat lineThickness;
+@property (nonatomic) MTFractionAlignment numeratorAlignment;
 
 @end
 

--- a/iosMath/render/internal/MTTypesetter.m
+++ b/iosMath/render/internal/MTTypesetter.m
@@ -1216,6 +1216,20 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
                            withHeight:[self targetHeightForLargeDelimiterSize:atom.delimiterSize]];
 }
 
+// Maps an MTFractionStyle to the corresponding MTLineStyle. For
+// kMTFractionStyleAuto, returns the current _style ivar (no override).
+- (MTLineStyle) lineStyleForFractionStyle:(MTFractionStyle) fs
+{
+    switch (fs) {
+        case kMTFractionStyleDisplay:       return kMTLineStyleDisplay;
+        case kMTFractionStyleText:          return kMTLineStyleText;
+        case kMTFractionStyleScript:        return kMTLineStyleScript;
+        case kMTFractionStyleScriptScript:  return kMTLineStyleScriptScript;
+        case kMTFractionStyleAuto:
+        default:                            return _style;
+    }
+}
+
 - (MTLineStyle) fractionStyle
 {
     if (_style == kMTLineStyleScriptScript) {

--- a/iosMath/render/internal/MTTypesetter.m
+++ b/iosMath/render/internal/MTTypesetter.m
@@ -1244,17 +1244,27 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
     BOOL didOverrideStyle = NO;
     if (frac.styleOverride != kMTFractionStyleAuto) {
         MTLineStyle overrideStyle = [self lineStyleForFractionStyle:frac.styleOverride];
+        // Only mutate _style (and _styleFont) when the override actually differs.
+        // When they're equal the frame metrics are already correct, so neither
+        // the -setStyle: nor the matching restore at the end of this method is
+        // needed.
         if (overrideStyle != _style) {
             [self setStyle:overrideStyle];
             didOverrideStyle = YES;
         }
     }
 
-    MTLineStyle fractionStyle = self.fractionStyle;
+    // AMSMath \cfrac: numerator and denominator are always typeset in display
+    // style (not one step down like \frac), and the denominator is not cramped.
+    MTLineStyle fractionStyle = frac.isContinuedFraction ? kMTLineStyleDisplay : self.fractionStyle;
     MTMathListDisplay* numeratorDisplay = [MTTypesetter createLineForMathList:frac.numerator font:_font style:fractionStyle cramped:false];
-    MTMathListDisplay* denominatorDisplay = [MTTypesetter createLineForMathList:frac.denominator font:_font style:fractionStyle cramped:true];
+    MTMathListDisplay* denominatorDisplay = [MTTypesetter createLineForMathList:frac.denominator font:_font style:fractionStyle cramped:!frac.isContinuedFraction];
 
     if (frac.isContinuedFraction) {
+        // Apply cfrac strut floors to the operand boxes *before* numeratorShiftUp
+        // and denominatorShiftDown are computed. AMSMath's strut is a floor on
+        // the operand box, not on the shift, so the bar-clearance logic below
+        // must see the inflated extents.
         CGFloat strutHeight = 0.85 * _styleFont.fontSize;
         CGFloat strutDepth  = 0.35 * _styleFont.fontSize;
         if (numeratorDisplay.ascent   < strutHeight) numeratorDisplay.ascent   = strutHeight;
@@ -1320,10 +1330,12 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
 
     if (frac.isContinuedFraction) {
         CGFloat thinspace = 3.0 * _styleFont.mathTable.muUnit;
-        // Position the inner display offset by thinspace within the wrapper.
-        result.position = CGPointMake(thinspace, 0);
+        // Construct the wrapper first (so recomputeDimensions inside
+        // initWithDisplays runs on a natural {0,0}-positioned child), then set
+        // the child's offset and explicitly override all wrapper metrics.
         MTMathListDisplay* wrapped = [[MTMathListDisplay alloc] initWithDisplays:@[result]
                                                                            range:frac.indexRange];
+        result.position = CGPointMake(thinspace, 0);
         wrapped.position = _currentPosition;
         wrapped.ascent  = result.ascent;
         wrapped.descent = result.descent;

--- a/iosMath/render/internal/MTTypesetter.m
+++ b/iosMath/render/internal/MTTypesetter.m
@@ -1254,6 +1254,15 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
     MTMathListDisplay* numeratorDisplay = [MTTypesetter createLineForMathList:frac.numerator font:_font style:fractionStyle cramped:false];
     MTMathListDisplay* denominatorDisplay = [MTTypesetter createLineForMathList:frac.denominator font:_font style:fractionStyle cramped:true];
 
+    if (frac.isContinuedFraction) {
+        CGFloat strutHeight = 0.85 * _styleFont.fontSize;
+        CGFloat strutDepth  = 0.35 * _styleFont.fontSize;
+        if (numeratorDisplay.ascent   < strutHeight) numeratorDisplay.ascent   = strutHeight;
+        if (numeratorDisplay.descent  < strutDepth)  numeratorDisplay.descent  = strutDepth;
+        if (denominatorDisplay.ascent  < strutHeight) denominatorDisplay.ascent  = strutHeight;
+        if (denominatorDisplay.descent < strutDepth)  denominatorDisplay.descent = strutDepth;
+    }
+
     // determine the location of the numerator
     CGFloat numeratorShiftUp = [self numeratorShiftUp:frac.hasRule];
     CGFloat denominatorShiftDown = [self denominatorShiftDown:frac.hasRule];

--- a/iosMath/render/internal/MTTypesetter.m
+++ b/iosMath/render/internal/MTTypesetter.m
@@ -1318,6 +1318,19 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
         result = [self addDelimitersToFractionDisplay:display forFraction:frac];
     }
 
+    if (frac.isContinuedFraction) {
+        CGFloat thinspace = 3.0 * _styleFont.mathTable.muUnit;
+        // Position the inner display offset by thinspace within the wrapper.
+        result.position = CGPointMake(thinspace, 0);
+        MTMathListDisplay* wrapped = [[MTMathListDisplay alloc] initWithDisplays:@[result]
+                                                                           range:frac.indexRange];
+        wrapped.position = _currentPosition;
+        wrapped.ascent  = result.ascent;
+        wrapped.descent = result.descent;
+        wrapped.width   = result.width + 2.0 * thinspace;
+        result = wrapped;
+    }
+
     if (didOverrideStyle) {
         [self setStyle:savedStyle];
     }

--- a/iosMath/render/internal/MTTypesetter.m
+++ b/iosMath/render/internal/MTTypesetter.m
@@ -1240,17 +1240,26 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
 
 - (MTDisplay*) makeFraction:(MTFraction*) frac
 {
-    // lay out the parts of the fraction
+    MTLineStyle savedStyle = _style;
+    BOOL didOverrideStyle = NO;
+    if (frac.styleOverride != kMTFractionStyleAuto) {
+        MTLineStyle overrideStyle = [self lineStyleForFractionStyle:frac.styleOverride];
+        if (overrideStyle != _style) {
+            [self setStyle:overrideStyle];
+            didOverrideStyle = YES;
+        }
+    }
+
     MTLineStyle fractionStyle = self.fractionStyle;
     MTMathListDisplay* numeratorDisplay = [MTTypesetter createLineForMathList:frac.numerator font:_font style:fractionStyle cramped:false];
     MTMathListDisplay* denominatorDisplay = [MTTypesetter createLineForMathList:frac.denominator font:_font style:fractionStyle cramped:true];
-    
+
     // determine the location of the numerator
     CGFloat numeratorShiftUp = [self numeratorShiftUp:frac.hasRule];
     CGFloat denominatorShiftDown = [self denominatorShiftDown:frac.hasRule];
     CGFloat barLocation = _styleFont.mathTable.axisHeight;
     CGFloat barThickness = (frac.hasRule) ? _styleFont.mathTable.fractionRuleThickness : 0;
-    
+
     if (frac.hasRule) {
         // This is the difference between the lowest edge of the numerator and the top edge of the fraction bar
         CGFloat distanceFromNumeratorToBar = (numeratorShiftUp - numeratorDisplay.descent) - (barLocation + barThickness/2);
@@ -1261,7 +1270,7 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
             // at least minNumeratorGap.
             numeratorShiftUp += (minNumeratorGap - distanceFromNumeratorToBar);
         }
-        
+
         // Do the same for the denominator
         // This is the difference between the top edge of the denominator and the bottom edge of the fraction bar
         CGFloat distanceFromDenominatorToBar = (barLocation - barThickness/2) - (denominatorDisplay.ascent - denominatorShiftDown);
@@ -1282,19 +1291,28 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
             denominatorShiftDown += (minGap - clearance)/2;
         }
     }
-    
+
     MTFractionDisplay *display = [[MTFractionDisplay alloc] initWithNumerator:numeratorDisplay denominator:denominatorDisplay
                                                                      position:_currentPosition range:frac.indexRange];
-    
+    // Set numeratorAlignment BEFORE numeratorUp so the first -updateNumeratorPosition
+    // call (triggered by setNumeratorUp:) sees the correct alignment.
+    display.numeratorAlignment = frac.numeratorAlignment;
     display.numeratorUp = numeratorShiftUp;
     display.denominatorDown = denominatorShiftDown;
     display.lineThickness = barThickness;
     display.linePosition = barLocation;
+
+    MTDisplay* result;
     if (!frac.leftDelimiter && !frac.rightDelimiter) {
-        return display;
+        result = display;
     } else {
-        return [self addDelimitersToFractionDisplay:display forFraction:frac];
+        result = [self addDelimitersToFractionDisplay:display forFraction:frac];
     }
+
+    if (didOverrideStyle) {
+        [self setStyle:savedStyle];
+    }
+    return result;
 }
 
 - (MTDisplay*) addDelimitersToFractionDisplay:(MTFractionDisplay*)display forFraction:(MTFraction*) frac

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -274,7 +274,7 @@ static NSArray* getTestDataSuperSubScript() {
     NSString *str = @"\\frac1c";
     MTMathList* list = [MTMathListBuilder buildFromString:str];
     NSString* desc = [NSString stringWithFormat:@"Error for string:%@", str];
-    
+
     XCTAssertNotNil(list, @"%@", desc);
     XCTAssertEqualObjects(@(list.atoms.count), @1, @"%@", desc);
     MTFraction* frac = list.atoms[0];
@@ -283,7 +283,10 @@ static NSArray* getTestDataSuperSubScript() {
     XCTAssertTrue(frac.hasRule);
     XCTAssertNil(frac.rightDelimiter);
     XCTAssertNil(frac.leftDelimiter);
-    
+    XCTAssertEqual(frac.styleOverride, kMTFractionStyleAuto);
+    XCTAssertFalse(frac.isContinuedFraction);
+    XCTAssertEqual(frac.numeratorAlignment, kMTFractionAlignmentCenter);
+
     MTMathList *subList = frac.numerator;
     XCTAssertNotNil(subList, @"%@", desc);
     XCTAssertEqualObjects(@(subList.atoms.count), @1, @"%@", desc);
@@ -756,7 +759,7 @@ static NSArray* getTestDataLeftRight() {
     NSString *str = @"\\binom{n}{k}";
     MTMathList* list = [MTMathListBuilder buildFromString:str];
     NSString* desc = [NSString stringWithFormat:@"Error for string:%@", str];
-    
+
     XCTAssertNotNil(list, @"%@", desc);
     XCTAssertEqualObjects(@(list.atoms.count), @1, @"%@", desc);
     MTFraction* frac = list.atoms[0];
@@ -765,7 +768,10 @@ static NSArray* getTestDataLeftRight() {
     XCTAssertFalse(frac.hasRule);
     XCTAssertEqualObjects(frac.rightDelimiter, @")");
     XCTAssertEqualObjects(frac.leftDelimiter, @"(");
-    
+    XCTAssertEqual(frac.styleOverride, kMTFractionStyleAuto);
+    XCTAssertFalse(frac.isContinuedFraction);
+    XCTAssertEqual(frac.numeratorAlignment, kMTFractionAlignmentCenter);
+
     MTMathList *subList = frac.numerator;
     XCTAssertNotNil(subList, @"%@", desc);
     XCTAssertEqualObjects(@(subList.atoms.count), @1, @"%@", desc);

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -940,6 +940,25 @@ static NSArray* getTestDataLeftRight() {
     XCTAssertEqual(error.code, MTParseErrorInvalidCommand);
 }
 
+- (void) testDfracInDfrac
+{
+    NSString *str = @"\\dfrac{1}{x+\\dfrac{1}{y}}";
+    MTMathList* list = [MTMathListBuilder buildFromString:str];
+    MTFraction* outer = list.atoms[0];
+    XCTAssertEqual(outer.styleOverride, kMTFractionStyleDisplay);
+    // Denominator: x + (inner dfrac)
+    // Find the inner fraction inside the denominator
+    MTFraction* inner = nil;
+    for (MTMathAtom* atom in outer.denominator.atoms) {
+        if (atom.type == kMTMathAtomFraction) {
+            inner = (MTFraction*)atom;
+            break;
+        }
+    }
+    XCTAssertNotNil(inner);
+    XCTAssertEqual(inner.styleOverride, kMTFractionStyleDisplay);
+}
+
 - (void) testOverLine
 {
     NSString *str = @"\\overline 2";

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -846,7 +846,10 @@ static NSArray* getTestDataLeftRight() {
     XCTAssertEqualObjects(((MTMathAtom*)frac.numerator.atoms[0]).nucleus, @"1");
     XCTAssertEqualObjects(@(frac.denominator.atoms.count), @1);
     XCTAssertEqualObjects(((MTMathAtom*)frac.denominator.atoms[0]).nucleus, @"c");
-    // Round-trip via the new \displaystyle wrapping
+    // Round-trip wraps each operand in \displaystyle rather than emitting
+    // \dfrac directly. Re-parsing produces MTMathStyle(Display) atoms inside
+    // each operand sub-list and styleOverride = kMTFractionStyleAuto on the
+    // fraction itself (partial-fidelity trade-off per LLD 3.3.5 / 5.1).
     NSString* latex = [MTMathListBuilder mathListToString:list];
     XCTAssertEqualObjects(latex, @"\\frac{\\displaystyle{1}}{\\displaystyle{c}}");
 }
@@ -855,6 +858,7 @@ static NSArray* getTestDataLeftRight() {
 {
     NSString *str = @"\\tfrac1c";
     MTMathList* list = [MTMathListBuilder buildFromString:str];
+    XCTAssertNotNil(list);
     MTFraction* frac = list.atoms[0];
     XCTAssertTrue(frac.hasRule);
     XCTAssertEqual(frac.styleOverride, kMTFractionStyleText);
@@ -867,6 +871,7 @@ static NSArray* getTestDataLeftRight() {
 {
     NSString *str = @"\\dbinom{n}{k}";
     MTMathList* list = [MTMathListBuilder buildFromString:str];
+    XCTAssertNotNil(list);
     MTFraction* frac = list.atoms[0];
     XCTAssertFalse(frac.hasRule);
     XCTAssertEqualObjects(frac.leftDelimiter, @"(");
@@ -880,6 +885,7 @@ static NSArray* getTestDataLeftRight() {
 {
     NSString *str = @"\\tbinom{n}{k}";
     MTMathList* list = [MTMathListBuilder buildFromString:str];
+    XCTAssertNotNil(list);
     MTFraction* frac = list.atoms[0];
     XCTAssertFalse(frac.hasRule);
     XCTAssertEqualObjects(frac.leftDelimiter, @"(");
@@ -912,6 +918,12 @@ static NSArray* getTestDataLeftRight() {
     MTFraction* frac = list.atoms[0];
     XCTAssertEqual(frac.numeratorAlignment, kMTFractionAlignmentLeft);
     XCTAssertTrue(frac.isContinuedFraction);
+    // Round-trip drops the [l] alignment (and the \cfrac flag); the output
+    // is indistinguishable from \cfrac{a}{b}. Asserting it here pins the
+    // lossy contract so a future serializer change can't silently emit
+    // alignment data in a form the parser can't read back.
+    NSString* latex = [MTMathListBuilder mathListToString:list];
+    XCTAssertEqualObjects(latex, @"\\frac{\\displaystyle{a}}{\\displaystyle{b}}");
 }
 
 - (void) testCfracRightAlign
@@ -920,6 +932,9 @@ static NSArray* getTestDataLeftRight() {
     MTMathList* list = [MTMathListBuilder buildFromString:str];
     MTFraction* frac = list.atoms[0];
     XCTAssertEqual(frac.numeratorAlignment, kMTFractionAlignmentRight);
+    // Round-trip drops the [r] alignment; same lossy contract as [l].
+    NSString* latex = [MTMathListBuilder mathListToString:list];
+    XCTAssertEqualObjects(latex, @"\\frac{\\displaystyle{a}}{\\displaystyle{b}}");
 }
 
 - (void) testCfracCenterAlignExplicit

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -792,6 +792,41 @@ static NSArray* getTestDataLeftRight() {
     XCTAssertEqualObjects(latex, @"{n \\choose k}", @"%@", desc);
 }
 
+- (void) testFractionAppendLaTexWithStyleOverride
+{
+    // Build an MTFraction directly, set styleOverride, then serialize.
+    // (Parser support for \dfrac etc. arrives in item 7.)
+    MTFraction* dfrac = [MTFraction new];
+    dfrac.numerator = [MTMathListBuilder buildFromString:@"a"];
+    dfrac.denominator = [MTMathListBuilder buildFromString:@"b"];
+    dfrac.styleOverride = kMTFractionStyleDisplay;
+    MTMathList* dlist = [MTMathList new];
+    [dlist addAtom:dfrac];
+    NSString* dlatex = [MTMathListBuilder mathListToString:dlist];
+    XCTAssertEqualObjects(dlatex, @"\\frac{\\displaystyle{a}}{\\displaystyle{b}}");
+
+    MTFraction* tfrac = [MTFraction new];
+    tfrac.numerator = [MTMathListBuilder buildFromString:@"a"];
+    tfrac.denominator = [MTMathListBuilder buildFromString:@"b"];
+    tfrac.styleOverride = kMTFractionStyleText;
+    MTMathList* tlist = [MTMathList new];
+    [tlist addAtom:tfrac];
+    NSString* tlatex = [MTMathListBuilder mathListToString:tlist];
+    XCTAssertEqualObjects(tlatex, @"\\frac{\\textstyle{a}}{\\textstyle{b}}");
+
+    // \dbinom-shaped (hasRule = NO, ( ) delimiters, Display override)
+    MTFraction* dbinom = [[MTFraction alloc] initWithRule:NO];
+    dbinom.numerator = [MTMathListBuilder buildFromString:@"n"];
+    dbinom.denominator = [MTMathListBuilder buildFromString:@"k"];
+    dbinom.leftDelimiter = @"(";
+    dbinom.rightDelimiter = @")";
+    dbinom.styleOverride = kMTFractionStyleDisplay;
+    MTMathList* dblist = [MTMathList new];
+    [dblist addAtom:dbinom];
+    NSString* dblatex = [MTMathListBuilder mathListToString:dblist];
+    XCTAssertEqualObjects(dblatex, @"{\\displaystyle{n} \\choose \\displaystyle{k}}");
+}
+
 - (void) testOverLine
 {
     NSString *str = @"\\overline 2";

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -827,6 +827,68 @@ static NSArray* getTestDataLeftRight() {
     XCTAssertEqualObjects(dblatex, @"{\\displaystyle{n} \\choose \\displaystyle{k}}");
 }
 
+- (void) testDfrac
+{
+    NSString *str = @"\\dfrac1c";
+    MTMathList* list = [MTMathListBuilder buildFromString:str];
+    XCTAssertNotNil(list);
+    XCTAssertEqualObjects(@(list.atoms.count), @1);
+    MTFraction* frac = list.atoms[0];
+    XCTAssertEqual(frac.type, kMTMathAtomFraction);
+    XCTAssertTrue(frac.hasRule);
+    XCTAssertEqual(frac.styleOverride, kMTFractionStyleDisplay);
+    XCTAssertFalse(frac.isContinuedFraction);
+    XCTAssertEqual(frac.numeratorAlignment, kMTFractionAlignmentCenter);
+    XCTAssertNil(frac.leftDelimiter);
+    XCTAssertNil(frac.rightDelimiter);
+    // numerator = "1", denominator = "c"
+    XCTAssertEqualObjects(@(frac.numerator.atoms.count), @1);
+    XCTAssertEqualObjects(((MTMathAtom*)frac.numerator.atoms[0]).nucleus, @"1");
+    XCTAssertEqualObjects(@(frac.denominator.atoms.count), @1);
+    XCTAssertEqualObjects(((MTMathAtom*)frac.denominator.atoms[0]).nucleus, @"c");
+    // Round-trip via the new \displaystyle wrapping
+    NSString* latex = [MTMathListBuilder mathListToString:list];
+    XCTAssertEqualObjects(latex, @"\\frac{\\displaystyle{1}}{\\displaystyle{c}}");
+}
+
+- (void) testTfrac
+{
+    NSString *str = @"\\tfrac1c";
+    MTMathList* list = [MTMathListBuilder buildFromString:str];
+    MTFraction* frac = list.atoms[0];
+    XCTAssertTrue(frac.hasRule);
+    XCTAssertEqual(frac.styleOverride, kMTFractionStyleText);
+    XCTAssertFalse(frac.isContinuedFraction);
+    NSString* latex = [MTMathListBuilder mathListToString:list];
+    XCTAssertEqualObjects(latex, @"\\frac{\\textstyle{1}}{\\textstyle{c}}");
+}
+
+- (void) testDbinom
+{
+    NSString *str = @"\\dbinom{n}{k}";
+    MTMathList* list = [MTMathListBuilder buildFromString:str];
+    MTFraction* frac = list.atoms[0];
+    XCTAssertFalse(frac.hasRule);
+    XCTAssertEqualObjects(frac.leftDelimiter, @"(");
+    XCTAssertEqualObjects(frac.rightDelimiter, @")");
+    XCTAssertEqual(frac.styleOverride, kMTFractionStyleDisplay);
+    NSString* latex = [MTMathListBuilder mathListToString:list];
+    XCTAssertEqualObjects(latex, @"{\\displaystyle{n} \\choose \\displaystyle{k}}");
+}
+
+- (void) testTbinom
+{
+    NSString *str = @"\\tbinom{n}{k}";
+    MTMathList* list = [MTMathListBuilder buildFromString:str];
+    MTFraction* frac = list.atoms[0];
+    XCTAssertFalse(frac.hasRule);
+    XCTAssertEqualObjects(frac.leftDelimiter, @"(");
+    XCTAssertEqualObjects(frac.rightDelimiter, @")");
+    XCTAssertEqual(frac.styleOverride, kMTFractionStyleText);
+    NSString* latex = [MTMathListBuilder mathListToString:list];
+    XCTAssertEqualObjects(latex, @"{\\textstyle{n} \\choose \\textstyle{k}}");
+}
+
 - (void) testOverLine
 {
     NSString *str = @"\\overline 2";

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -889,6 +889,57 @@ static NSArray* getTestDataLeftRight() {
     XCTAssertEqualObjects(latex, @"{\\textstyle{n} \\choose \\textstyle{k}}");
 }
 
+- (void) testCfrac
+{
+    NSString *str = @"\\cfrac{a}{b}";
+    MTMathList* list = [MTMathListBuilder buildFromString:str];
+    XCTAssertNotNil(list);
+    MTFraction* frac = list.atoms[0];
+    XCTAssertTrue(frac.hasRule);
+    XCTAssertEqual(frac.styleOverride, kMTFractionStyleDisplay);
+    XCTAssertTrue(frac.isContinuedFraction);
+    XCTAssertEqual(frac.numeratorAlignment, kMTFractionAlignmentCenter);
+    // Round-trip is lossy: the cfrac flag and alignment are not emitted.
+    NSString* latex = [MTMathListBuilder mathListToString:list];
+    XCTAssertEqualObjects(latex, @"\\frac{\\displaystyle{a}}{\\displaystyle{b}}");
+}
+
+- (void) testCfracLeftAlign
+{
+    NSString *str = @"\\cfrac[l]{a}{b}";
+    MTMathList* list = [MTMathListBuilder buildFromString:str];
+    XCTAssertNotNil(list);
+    MTFraction* frac = list.atoms[0];
+    XCTAssertEqual(frac.numeratorAlignment, kMTFractionAlignmentLeft);
+    XCTAssertTrue(frac.isContinuedFraction);
+}
+
+- (void) testCfracRightAlign
+{
+    NSString *str = @"\\cfrac[r]{a}{b}";
+    MTMathList* list = [MTMathListBuilder buildFromString:str];
+    MTFraction* frac = list.atoms[0];
+    XCTAssertEqual(frac.numeratorAlignment, kMTFractionAlignmentRight);
+}
+
+- (void) testCfracCenterAlignExplicit
+{
+    NSString *str = @"\\cfrac[c]{a}{b}";
+    MTMathList* list = [MTMathListBuilder buildFromString:str];
+    MTFraction* frac = list.atoms[0];
+    XCTAssertEqual(frac.numeratorAlignment, kMTFractionAlignmentCenter);
+}
+
+- (void) testCfracInvalidAlign
+{
+    NSString *str = @"\\cfrac[zzz]{a}{b}";
+    NSError* error = nil;
+    MTMathList* list = [MTMathListBuilder buildFromString:str error:&error];
+    XCTAssertNil(list);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, MTParseErrorInvalidCommand);
+}
+
 - (void) testOverLine
 {
     NSString *str = @"\\overline 2";

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -613,9 +613,9 @@
     MTFractionDisplay* inner = (MTFractionDisplay*)wrapList.subDisplays[0];
     XCTAssertTrue([inner isKindOfClass:[MTFractionDisplay class]]);
 
-    // Get the muUnit for the *display* style (cfrac forces Display).
-    MTFont* styleFont = [font copyFontWithSize:font.fontSize];
-    CGFloat thinspace = 3.0 * styleFont.mathTable.muUnit;
+    // muUnit is taken from the font; kMTLineStyleDisplay uses font.fontSize
+    // unchanged, so no per-style copy is needed here.
+    CGFloat thinspace = 3.0 * font.mathTable.muUnit;
     XCTAssertEqualWithAccuracy(wrapList.width, inner.width + 2.0 * thinspace, 0.001);
     XCTAssertEqualWithAccuracy(inner.position.x - wrapList.position.x, thinspace, 0.001);
 

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -598,6 +598,33 @@
     XCTAssertLessThan(plainFrac.numerator.descent, 0.35 * fontSize);
 }
 
+- (void) testCfracThinspaceWrap
+{
+    MTFont* font = [[MTFontManager fontManager] defaultFont];
+    MTMathList* cfracList = [MTMathListBuilder buildFromString:@"\\cfrac{a}{b}"];
+    MTMathListDisplay* cfracTop = [MTTypesetter createLineForMathList:cfracList font:font style:kMTLineStyleText];
+    // Top sub-display for \cfrac should be an MTMathListDisplay wrapper (not the
+    // MTFractionDisplay directly), containing one MTFractionDisplay child.
+    XCTAssertEqual(cfracTop.subDisplays.count, (NSUInteger)1);
+    MTDisplay* wrap = cfracTop.subDisplays[0];
+    XCTAssertTrue([wrap isKindOfClass:[MTMathListDisplay class]]);
+    MTMathListDisplay* wrapList = (MTMathListDisplay*)wrap;
+    XCTAssertEqual(wrapList.subDisplays.count, (NSUInteger)1);
+    MTFractionDisplay* inner = (MTFractionDisplay*)wrapList.subDisplays[0];
+    XCTAssertTrue([inner isKindOfClass:[MTFractionDisplay class]]);
+
+    // Get the muUnit for the *display* style (cfrac forces Display).
+    MTFont* styleFont = [font copyFontWithSize:font.fontSize];
+    CGFloat thinspace = 3.0 * styleFont.mathTable.muUnit;
+    XCTAssertEqualWithAccuracy(wrapList.width, inner.width + 2.0 * thinspace, 0.001);
+    XCTAssertEqualWithAccuracy(inner.position.x - wrapList.position.x, thinspace, 0.001);
+
+    // By contrast, \frac produces an MTFractionDisplay directly (no wrap).
+    MTMathList* fracList = [MTMathListBuilder buildFromString:@"\\frac{a}{b}"];
+    MTMathListDisplay* fracTop = [MTTypesetter createLineForMathList:fracList font:font style:kMTLineStyleText];
+    XCTAssertTrue([fracTop.subDisplays[0] isKindOfClass:[MTFractionDisplay class]]);
+}
+
 - (void)testAtop {
     MTMathList* mathList = [[MTMathList alloc] init];
     MTFraction* frac = [[MTFraction alloc] initWithRule:NO];

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -542,6 +542,24 @@
     XCTAssertEqualWithAccuracy(display.width, 10, 0.01);
 }
 
+- (void) testDfracInlineStylePicksDisplayMetrics
+{
+    // Reference: \frac at display style
+    MTMathList* refList = [MTMathListBuilder buildFromString:@"\\frac{1}{2}"];
+    MTMathListDisplay* refDisplay = [MTTypesetter createLineForMathList:refList font:self.font style:kMTLineStyleDisplay];
+    MTFractionDisplay* refFrac = (MTFractionDisplay*)refDisplay.subDisplays[0];
+
+    // Under test: \dfrac at text style — should match the \frac-at-display metrics
+    MTMathList* testList = [MTMathListBuilder buildFromString:@"\\dfrac{1}{2}"];
+    MTMathListDisplay* testDisplay = [MTTypesetter createLineForMathList:testList font:self.font style:kMTLineStyleText];
+    MTFractionDisplay* testFrac = (MTFractionDisplay*)testDisplay.subDisplays[0];
+
+    XCTAssertEqualWithAccuracy(testFrac.numeratorUp,     refFrac.numeratorUp,     0.001);
+    XCTAssertEqualWithAccuracy(testFrac.denominatorDown, refFrac.denominatorDown, 0.001);
+    XCTAssertEqualWithAccuracy(testFrac.linePosition,    refFrac.linePosition,    0.001);
+    XCTAssertEqualWithAccuracy(testFrac.lineThickness,   refFrac.lineThickness,   0.001);
+}
+
 - (void)testAtop {
     MTMathList* mathList = [[MTMathList alloc] init];
     MTFraction* frac = [[MTFraction alloc] initWithRule:NO];

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -560,6 +560,44 @@
     XCTAssertEqualWithAccuracy(testFrac.lineThickness,   refFrac.lineThickness,   0.001);
 }
 
+- (void) testCfracStrutAppliedToOperands
+{
+    MTFont* font = [[MTFontManager fontManager] defaultFont];
+    MTMathList* cfracList = [MTMathListBuilder buildFromString:@"\\cfrac{a}{b}"];
+    MTMathListDisplay* cfracDisplay = [MTTypesetter createLineForMathList:cfracList font:font style:kMTLineStyleText];
+    // After item 14 the top-level may be wrapped in MTMathListDisplay (3mu wrap),
+    // so first locate the MTFractionDisplay.
+    MTFractionDisplay* cfrac = nil;
+    for (MTDisplay* d in cfracDisplay.subDisplays) {
+        if ([d isKindOfClass:[MTFractionDisplay class]]) {
+            cfrac = (MTFractionDisplay*)d;
+            break;
+        }
+        if ([d isKindOfClass:[MTMathListDisplay class]]) {
+            for (MTDisplay* dd in ((MTMathListDisplay*)d).subDisplays) {
+                if ([dd isKindOfClass:[MTFractionDisplay class]]) {
+                    cfrac = (MTFractionDisplay*)dd;
+                    break;
+                }
+            }
+        }
+        if (cfrac) break;
+    }
+    XCTAssertNotNil(cfrac);
+    CGFloat fontSize = font.fontSize;
+    XCTAssertGreaterThanOrEqual(cfrac.numerator.ascent,   0.85 * fontSize - 0.001);
+    XCTAssertGreaterThanOrEqual(cfrac.numerator.descent,  0.35 * fontSize - 0.001);
+    XCTAssertGreaterThanOrEqual(cfrac.denominator.ascent,  0.85 * fontSize - 0.001);
+    XCTAssertGreaterThanOrEqual(cfrac.denominator.descent, 0.35 * fontSize - 0.001);
+
+    // Confirm plain \frac does NOT have the strut floor applied.
+    MTMathList* fracList = [MTMathListBuilder buildFromString:@"\\frac{a}{b}"];
+    MTMathListDisplay* fracTopDisplay = [MTTypesetter createLineForMathList:fracList font:font style:kMTLineStyleText];
+    MTFractionDisplay* plainFrac = (MTFractionDisplay*)fracTopDisplay.subDisplays[0];
+    // Lower-case 'a' descent in math fonts is typically far below 0.35em — so the natural descent is strictly less than the strut floor.
+    XCTAssertLessThan(plainFrac.numerator.descent, 0.35 * fontSize);
+}
+
 - (void)testAtop {
     MTMathList* mathList = [[MTMathList alloc] init];
     MTFraction* frac = [[MTFraction alloc] initWithRule:NO];

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -625,6 +625,35 @@
     XCTAssertTrue([fracTop.subDisplays[0] isKindOfClass:[MTFractionDisplay class]]);
 }
 
+- (void) testCfracLeftAlignmentNumeratorOffset
+{
+    MTFont* font = [[MTFontManager fontManager] defaultFont];
+    // Make the denominator clearly wider than the numerator.
+    MTMathList* leftList = [MTMathListBuilder buildFromString:@"\\cfrac[l]{a}{b+c+d+e}"];
+    MTMathListDisplay* leftTop = [MTTypesetter createLineForMathList:leftList font:font style:kMTLineStyleDisplay];
+    MTMathListDisplay* leftWrap = (MTMathListDisplay*)leftTop.subDisplays[0];
+    MTFractionDisplay* leftFrac = (MTFractionDisplay*)leftWrap.subDisplays[0];
+    // Left-aligned: numerator's x position relative to the fraction position is 0
+    // (within float tolerance).
+    XCTAssertEqualWithAccuracy(leftFrac.numerator.position.x - leftFrac.position.x, 0.0, 0.001);
+
+    // Right-aligned: numerator is at (width - numWidth)
+    MTMathList* rightList = [MTMathListBuilder buildFromString:@"\\cfrac[r]{a}{b+c+d+e}"];
+    MTMathListDisplay* rightTop = [MTTypesetter createLineForMathList:rightList font:font style:kMTLineStyleDisplay];
+    MTMathListDisplay* rightWrap = (MTMathListDisplay*)rightTop.subDisplays[0];
+    MTFractionDisplay* rightFrac = (MTFractionDisplay*)rightWrap.subDisplays[0];
+    CGFloat expectedRightOffset = rightFrac.width - rightFrac.numerator.width;
+    XCTAssertEqualWithAccuracy(rightFrac.numerator.position.x - rightFrac.position.x, expectedRightOffset, 0.001);
+
+    // Center (default) reference
+    MTMathList* centerList = [MTMathListBuilder buildFromString:@"\\cfrac{a}{b+c+d+e}"];
+    MTMathListDisplay* centerTop = [MTTypesetter createLineForMathList:centerList font:font style:kMTLineStyleDisplay];
+    MTMathListDisplay* centerWrap = (MTMathListDisplay*)centerTop.subDisplays[0];
+    MTFractionDisplay* centerFrac = (MTFractionDisplay*)centerWrap.subDisplays[0];
+    CGFloat expectedCenterOffset = (centerFrac.width - centerFrac.numerator.width) / 2;
+    XCTAssertEqualWithAccuracy(centerFrac.numerator.position.x - centerFrac.position.x, expectedCenterOffset, 0.001);
+}
+
 - (void)testAtop {
     MTMathList* mathList = [[MTMathList alloc] init];
     MTFraction* frac = [[MTFraction alloc] initWithRule:NO];


### PR DESCRIPTION
## Summary

Wires the `styleOverride`, `isContinuedFraction`, and `numeratorAlignment` fields (added in PR 1) into the typesetter. This is PR 2 of 4 in the AMSMath fractions + multi-integral stack.

**Plan:** `docs/plans/2026-05-25-amsmath-fractions-and-multi-integrals.md`
**LLD:** `docs/lld/2026-05-25-amsmath-fractions-and-multi-integrals.md`

## Goal

Render `\dfrac`/`\tfrac`/`\dbinom`/`\tbinom` at their forced styles; render `\cfrac` with AMSMath strut equivalents (0.85em/0.35em) and 3mu thinspace padding; honor `\cfrac[l|c|r]` numerator alignment. Existing `\frac` / `\binom` rendering remains pixel-identical.

## Commits

- `[item 10]` Add `-lineStyleForFractionStyle:` helper to MTTypesetter
- `[item 11]` Add `numeratorAlignment` to MTFractionDisplay positioning
- `[item 12]` Honor `MTFraction.styleOverride` and `numeratorAlignment` in typesetter
- `[item 13]` Apply `\cfrac` strut floors (0.85em / 0.35em) to operand displays
- `[item 14]` Wrap `\cfrac` with 3mu thinspace padding via MTMathListDisplay
- `[item 15]` Typesetter test for `\cfrac[l]/[r]` numerator alignment

## Stack

- PR 1 (base): https://github.com/kostub/iosMath/pull/202 — Fraction data model + parser

## Test plan

- [ ] 217 tests pass (verified by item 15 full-suite run)
- [ ] `testDfracInlineStylePicksDisplayMetrics` — `\dfrac` in text mode produces display-style bar/gap metrics
- [ ] `testCfracStrutAppliedToOperands` — cfrac operand ascent/descent floored at 0.85em/0.35em; plain frac is not
- [ ] `testCfracThinspaceWrap` — cfrac top display is MTMathListDisplay wrapper with width = inner + 2×thinspace
- [ ] `testCfracLeftAlignmentNumeratorOffset` — `\cfrac[l]`/`\cfrac[r]`/`\cfrac` numerator x-offsets correct
- [ ] All existing typesetter tests pass (67 tests before new additions)