### PR TITLE
Fix crash on lone \sqrt at end of input (#188)

### DIFF
--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -746,21 +746,18 @@ NSString *const MTParseError = @"ParseError";
     } else if ([command isEqualToString:@"sqrt"]) {
         // A sqrt command with one argument
         MTRadical* rad = [MTRadical new];
+        // Guard against a lone "\sqrt" at the end of input: only read a
+        // character if one is available.
         if ([self hasCharacters]) {
             unichar ch = [self getNextCharacter];
             if (ch == '[') {
                 // special handling for sqrt[degree]{radicand}
                 rad.degree = [self buildInternal:false stopChar:']'];
-                rad.radicand = [self buildInternal:true];
             } else {
                 [self unlookCharacter];
-                rad.radicand = [self buildInternal:true];
             }
-        } else {
-            // No argument follows (e.g. a lone "\sqrt" at the end of input).
-            // Build an empty radicand rather than reading past the end.
-            rad.radicand = [self buildInternal:true];
         }
+        rad.radicand = [self buildInternal:true];
         return rad;
     } else if ([command isEqualToString:@"left"]) {
         // Save the current inner while a new one gets built.

--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -746,13 +746,19 @@ NSString *const MTParseError = @"ParseError";
     } else if ([command isEqualToString:@"sqrt"]) {
         // A sqrt command with one argument
         MTRadical* rad = [MTRadical new];
-        unichar ch = [self getNextCharacter];
-        if (ch == '[') {
-            // special handling for sqrt[degree]{radicand}
-            rad.degree = [self buildInternal:false stopChar:']'];
-            rad.radicand = [self buildInternal:true];
+        if ([self hasCharacters]) {
+            unichar ch = [self getNextCharacter];
+            if (ch == '[') {
+                // special handling for sqrt[degree]{radicand}
+                rad.degree = [self buildInternal:false stopChar:']'];
+                rad.radicand = [self buildInternal:true];
+            } else {
+                [self unlookCharacter];
+                rad.radicand = [self buildInternal:true];
+            }
         } else {
-            [self unlookCharacter];
+            // No argument follows (e.g. a lone "\sqrt" at the end of input).
+            // Build an empty radicand rather than reading past the end.
             rad.radicand = [self buildInternal:true];
         }
         return rad;

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -403,6 +403,30 @@ static NSArray* getTestDataSuperSubScript() {
     XCTAssertEqualObjects(latex, @"\\sqrt{}", @"%@", desc);
 }
 
+- (void) testSqrtInGroup
+{
+    // A \sqrt with no argument inside a group exercises a different path
+    // (empty radicand via the oneCharOnly stop-char guard) than the
+    // end-of-input case, and must also not crash.
+    NSString *str = @"{\\sqrt}";
+    MTMathList* list = [MTMathListBuilder buildFromString:str];
+    NSString* desc = [NSString stringWithFormat:@"Error for string:%@", str];
+
+    XCTAssertNotNil(list, @"%@", desc);
+    XCTAssertEqualObjects(@(list.atoms.count), @1, @"%@", desc);
+    MTRadical* rad = list.atoms[0];
+    XCTAssertEqual(rad.type, kMTMathAtomRadical, @"%@", desc);
+
+    MTMathList *subList = rad.radicand;
+    XCTAssertNotNil(subList, @"%@", desc);
+    XCTAssertEqualObjects(@(subList.atoms.count), @0, @"%@", desc);
+    XCTAssertNil(rad.degree, @"%@", desc);
+
+    // convert it back to latex
+    NSString* latex = [MTMathListBuilder mathListToString:list];
+    XCTAssertEqualObjects(latex, @"\\sqrt{}", @"%@", desc);
+}
+
 - (void) testSqrtInSqrt
 {
     NSString *str = @"\\sqrt\\sqrt2";

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -378,6 +378,31 @@ static NSArray* getTestDataSuperSubScript() {
     XCTAssertEqualObjects(latex, @"\\sqrt{2}", @"%@", desc);
 }
 
+- (void) testSqrtAtEnd
+{
+    // A lone \sqrt with no argument at the end of the input must not crash
+    // (it previously asserted in getNextCharacter). It should parse as a
+    // radical with an empty radicand, matching \sqrt{}.
+    NSString *str = @"\\sqrt";
+    MTMathList* list = [MTMathListBuilder buildFromString:str];
+    NSString* desc = [NSString stringWithFormat:@"Error for string:%@", str];
+
+    XCTAssertNotNil(list, @"%@", desc);
+    XCTAssertEqualObjects(@(list.atoms.count), @1, @"%@", desc);
+    MTRadical* rad = list.atoms[0];
+    XCTAssertEqual(rad.type, kMTMathAtomRadical, @"%@", desc);
+    XCTAssertEqualObjects(rad.nucleus, @"", @"%@", desc);
+
+    MTMathList *subList = rad.radicand;
+    XCTAssertNotNil(subList, @"%@", desc);
+    XCTAssertEqualObjects(@(subList.atoms.count), @0, @"%@", desc);
+    XCTAssertNil(rad.degree, @"%@", desc);
+
+    // convert it back to latex
+    NSString* latex = [MTMathListBuilder mathListToString:list];
+    XCTAssertEqualObjects(latex, @"\\sqrt{}", @"%@", desc);
+}
+
 - (void) testSqrtInSqrt
 {
     NSString *str = @"\\sqrt\\sqrt2";


### PR DESCRIPTION
## Summary
Fixes #188. A lone `\sqrt` at the end of the input crashed the parser with an `NSInternalInconsistencyException`.

The `sqrt` branch in `MTMathListBuilder` called `getNextCharacter` unconditionally to peek for an optional `[degree]` argument. When `\sqrt` was the last token, that call tripped the `NSAssert([self hasCharacters])` in `getNextCharacter` and crashed.

## Fix
Guard the lookahead with `[self hasCharacters]`. When no argument follows, build an empty radicand — the same result `\sqrt{}` already produces. This matches the fix proposed by the issue author.

## Testing
- Added `testSqrtAtEnd`: asserts `\sqrt` parses to a radical with an empty radicand and round-trips to `\sqrt{}`. Confirmed it crashed before the fix and passes after.
- Full suite green: 264 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)