### PR TITLE
Example apps — expose all 8 fonts + font-size slider

### DIFF
--- a/MacOSMathExample/AppDelegate.m
+++ b/MacOSMathExample/AppDelegate.m
@@ -11,6 +11,7 @@
 
 #import "AppDelegate.h"
 #import "MTMathUILabel.h"
+#import "MTFontManager.h"
 #import "../MathExamples.h"
 
 // Flipped NSView so Auto Layout stacks subviews top-to-bottom.
@@ -33,6 +34,18 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
     return (index < count) ? heights[index] : fallback;
 }
 
+static NSString *const kMacFontNames[] = {
+    @"Latin Modern Math", @"TeX Gyre Termes", @"XITS Math",
+    @"New Computer Modern", @"TeX Gyre Pagella", @"STIX Two",
+    @"Fira Math", @"Noto Sans Math",
+};
+static NSString *const kMacFontKeys[] = {
+    @"latinmodern-math", @"texgyretermes-math", @"xits-math",
+    @"newcm-math", @"texgyrepagella-math", @"stixtwo-math",
+    @"firamath", @"notosansmath",
+};
+static const NSUInteger kMacFontCount = 8;
+
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification
 {
     self.demoLabels = [[NSMutableArray alloc] init];
@@ -40,8 +53,37 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
 
     NSView* mainView = self.window.contentView;
 
-    // Scroll view fills the window.
-    NSScrollView* scrollView = [[NSScrollView alloc] initWithFrame:mainView.bounds];
+    // Header strip: font popup + size slider, pinned to the top of mainView.
+    CGFloat headerHeight = 36;
+    NSRect headerFrame = NSMakeRect(0, mainView.bounds.size.height - headerHeight,
+                                   mainView.bounds.size.width, headerHeight);
+    NSView* headerView = [[NSView alloc] initWithFrame:headerFrame];
+    headerView.autoresizingMask = NSViewWidthSizable | NSViewMinYMargin;
+
+    NSPopUpButton* fontPopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(8, 4, 220, 28) pullsDown:NO];
+    for (NSUInteger i = 0; i < kMacFontCount; i++) {
+        [fontPopup addItemWithTitle:kMacFontNames[i]];
+    }
+    [fontPopup setTarget:self];
+    [fontPopup setAction:@selector(changeFont:)];
+    fontPopup.autoresizingMask = NSViewMaxXMargin;
+    [headerView addSubview:fontPopup];
+
+    NSSlider* sizeSlider = [[NSSlider alloc] initWithFrame:NSMakeRect(236, 8, 200, 20)];
+    sizeSlider.minValue = 10;
+    sizeSlider.maxValue = 40;
+    sizeSlider.doubleValue = 15;
+    sizeSlider.target = self;
+    sizeSlider.action = @selector(changeSize:);
+    sizeSlider.autoresizingMask = NSViewWidthSizable;
+    [headerView addSubview:sizeSlider];
+
+    [mainView addSubview:headerView];
+
+    // Scroll view fills the window below the header.
+    NSRect scrollFrame = NSMakeRect(0, 0, mainView.bounds.size.width,
+                                    mainView.bounds.size.height - headerHeight);
+    NSScrollView* scrollView = [[NSScrollView alloc] initWithFrame:scrollFrame];
     scrollView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
     scrollView.hasVerticalScroller = YES;
     scrollView.hasHorizontalScroller = NO;
@@ -123,9 +165,7 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
     self.labels[6].contentInsets = NSEdgeInsetsMake(0, 20, 0, 0);
     self.labels[7].backgroundColor = highlight;
     self.labels[7].labelMode = kMTMathUILabelModeText;
-    self.labels[8].fontSize = 30;
     self.labels[8].textAlignment = kMTTextAlignmentCenter;
-    self.labels[9].fontSize = 10;
     self.labels[9].textAlignment = kMTTextAlignmentCenter;
     self.labels[17].labelMode = kMTMathUILabelModeText;
     self.labels[18].labelMode = kMTMathUILabelModeText;
@@ -141,6 +181,28 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
 
 - (void)applicationWillTerminate:(NSNotification *)aNotification
 {
+}
+
+#pragma mark - Font and size actions
+
+- (void)changeFont:(NSPopUpButton *)sender
+{
+    NSInteger i = sender.indexOfSelectedItem;
+    if (i < 0 || (NSUInteger)i >= kMacFontCount) return;
+    NSString* key = kMacFontKeys[i];
+    for (MTMathUILabel* label in self.demoLabels) {
+        label.font = [[MTFontManager fontManager] fontWithName:key size:label.font.fontSize];
+    }
+    for (MTMathUILabel* label in self.labels) {
+        label.font = [[MTFontManager fontManager] fontWithName:key size:label.font.fontSize];
+    }
+}
+
+- (void)changeSize:(NSSlider *)sender
+{
+    CGFloat size = (CGFloat)sender.doubleValue;
+    for (MTMathUILabel* label in self.demoLabels) { label.fontSize = size; }
+    for (MTMathUILabel* label in self.labels)     { label.fontSize = size; }
 }
 
 #pragma mark - Label creation helpers

--- a/MacOSMathExample/AppDelegate.m
+++ b/MacOSMathExample/AppDelegate.m
@@ -25,6 +25,14 @@
 @property (weak) IBOutlet NSWindow *window;
 @property (nonatomic, strong) NSMutableArray<MTMathUILabel*>* demoLabels;
 @property (nonatomic, strong) NSMutableArray<MTMathUILabel*>* labels;
+// Height constraints + their startup constants, so the size slider can rescale
+// each label (and the document view) instead of clipping at larger font sizes.
+// Demo labels render at fontSize 15; test labels at the default 20.
+@property (nonatomic, strong) NSMutableArray<NSLayoutConstraint*>* demoHeightConstraints;
+@property (nonatomic, strong) NSMutableArray<NSLayoutConstraint*>* testHeightConstraints;
+@property (nonatomic, strong) NSMutableArray<NSNumber*>* demoBaseHeights;
+@property (nonatomic, strong) NSMutableArray<NSNumber*>* testBaseHeights;
+@property (nonatomic, weak) NSView* documentContentView;
 @end
 
 @implementation AppDelegate
@@ -50,6 +58,10 @@ static const NSUInteger kMacFontCount = 8;
 {
     self.demoLabels = [[NSMutableArray alloc] init];
     self.labels = [[NSMutableArray alloc] init];
+    self.demoHeightConstraints = [[NSMutableArray alloc] init];
+    self.testHeightConstraints = [[NSMutableArray alloc] init];
+    self.demoBaseHeights = [[NSMutableArray alloc] init];
+    self.testBaseHeights = [[NSMutableArray alloc] init];
 
     NSView* mainView = self.window.contentView;
 
@@ -97,6 +109,7 @@ static const NSUInteger kMacFontCount = 8;
     contentView.autoresizingMask = NSViewWidthSizable;
     contentView.backgroundColor = NSColor.whiteColor;
     scrollView.documentView = contentView;
+    self.documentContentView = contentView;
 
     // --- Demo formulae — LaTeX strings from MathExamples.h ---
     static const CGFloat demoHeights[] = {
@@ -105,9 +118,12 @@ static const NSUInteger kMacFontCount = 8;
     NSArray<NSString*>* demoFormulas = MathDemoFormulas();
     for (NSUInteger i = 0; i < demoFormulas.count; i++) {
         CGFloat height = HeightAtIndex(demoHeights, sizeof(demoHeights)/sizeof(CGFloat), i, 60);
-        MTMathUILabel* label = [self createMathLabel:demoFormulas[i] withHeight:height];
+        MTMathUILabel* label = [[MTMathUILabel alloc] init];
+        label.latex = demoFormulas[i];
         label.fontSize = 15;
         [self.demoLabels addObject:label];
+        [self.demoHeightConstraints addObject:[self setHeight:height forView:label]];
+        [self.demoBaseHeights addObject:@(height)];
     }
 
     [self addLabelAsSubview:self.demoLabels[0] to:contentView];
@@ -137,7 +153,11 @@ static const NSUInteger kMacFontCount = 8;
     NSArray<NSString*>* testFormulas = MathTestFormulas();
     for (NSUInteger i = 0; i < testFormulas.count; i++) {
         CGFloat height = HeightAtIndex(testHeights, sizeof(testHeights)/sizeof(CGFloat), i, 40);
-        [self.labels addObject:[self createMathLabel:testFormulas[i] withHeight:height]];
+        MTMathUILabel* label = [[MTMathUILabel alloc] init];
+        label.latex = testFormulas[i];
+        [self.labels addObject:label];
+        [self.testHeightConstraints addObject:[self setHeight:height forView:label]];
+        [self.testBaseHeights addObject:@(height)];
     }
 
     CGFloat documentHeight = 10;
@@ -201,19 +221,29 @@ static const NSUInteger kMacFontCount = 8;
 - (void)changeSize:(NSSlider *)sender
 {
     CGFloat size = (CGFloat)sender.doubleValue;
-    for (MTMathUILabel* label in self.demoLabels) { label.fontSize = size; }
-    for (MTMathUILabel* label in self.labels)     { label.fontSize = size; }
+    // Scale each label's height from its startup baseline (demo 15, test 20) and
+    // grow the document view to match so formulas aren't clipped at larger sizes.
+    CGFloat documentHeight = 10; // top inset
+    for (NSUInteger i = 0; i < self.demoLabels.count; i++) {
+        self.demoLabels[i].fontSize = size;
+        CGFloat h = self.demoBaseHeights[i].doubleValue * (size / 15.0);
+        self.demoHeightConstraints[i].constant = h;
+        documentHeight += h + 10;
+    }
+    documentHeight += 30; // gap between sections
+    for (NSUInteger i = 0; i < self.labels.count; i++) {
+        self.labels[i].fontSize = size;
+        CGFloat h = self.testBaseHeights[i].doubleValue * (size / 20.0);
+        self.testHeightConstraints[i].constant = h;
+        documentHeight += h + 10;
+    }
+    NSView* contentView = self.documentContentView;
+    NSRect frame = contentView.frame;
+    frame.size.height = documentHeight;
+    contentView.frame = frame;
 }
 
 #pragma mark - Label creation helpers
-
-- (MTMathUILabel*)createMathLabel:(NSString*)latex withHeight:(CGFloat)height
-{
-    MTMathUILabel* label = [[MTMathUILabel alloc] init];
-    [self setHeight:height forView:label];
-    label.latex = latex;
-    return label;
-}
 
 - (void)addLabelWithIndex:(NSUInteger)idx inArray:(NSArray<MTMathUILabel*>*)array toView:(NSView*)contentView
 {
@@ -234,15 +264,17 @@ static const NSUInteger kMacFontCount = 8;
                                              options:0 metrics:nil views:views]];
 }
 
-- (void)setHeight:(CGFloat)height forView:(NSView*)view
+- (NSLayoutConstraint*)setHeight:(CGFloat)height forView:(NSView*)view
 {
     view.translatesAutoresizingMaskIntoConstraints = NO;
-    [NSLayoutConstraint constraintWithItem:view
+    NSLayoutConstraint* constraint = [NSLayoutConstraint constraintWithItem:view
                                  attribute:NSLayoutAttributeHeight
                                  relatedBy:NSLayoutRelationEqual
                                     toItem:nil
                                  attribute:NSLayoutAttributeNotAnAttribute
-                                multiplier:1 constant:height].active = YES;
+                                multiplier:1 constant:height];
+    constraint.active = YES;
+    return constraint;
 }
 
 - (void)setVerticalGap:(CGFloat)gap between:(NSView*)view1 and:(NSView*)view2

--- a/MacOSMathExample/AppDelegate.m
+++ b/MacOSMathExample/AppDelegate.m
@@ -47,11 +47,6 @@ static NSString *const kMacFontNames[] = {
     @"New Computer Modern", @"TeX Gyre Pagella", @"STIX Two",
     @"Fira Math", @"Noto Sans Math",
 };
-static NSString *const kMacFontKeys[] = {
-    @"latinmodern-math", @"texgyretermes-math", @"xits-math",
-    @"newcm-math", @"texgyrepagella-math", @"stixtwo-math",
-    @"firamath", @"notosansmath",
-};
 static const NSUInteger kMacFontCount = 8;
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification
@@ -209,6 +204,14 @@ static const NSUInteger kMacFontCount = 8;
 {
     NSInteger i = sender.indexOfSelectedItem;
     if (i < 0 || (NSUInteger)i >= kMacFontCount) return;
+    // Local (non-static) array: the public MTFontName* constants are runtime
+    // `extern NSString *const` values, not compile-time constants, so they can't
+    // initialize a file-scope static array.
+    NSString *const kMacFontKeys[] = {
+        MTFontNameLatinModern, MTFontNameTermes, MTFontNameXITS,
+        MTFontNameNewComputerModern, MTFontNamePagella, MTFontNameSTIXTwo,
+        MTFontNameFiraMath, MTFontNameNotoSansMath,
+    };
     NSString* key = kMacFontKeys[i];
     for (MTMathUILabel* label in self.demoLabels) {
         label.font = [[MTFontManager fontManager] fontWithName:key size:label.font.fontSize];

--- a/MacOSMathExample/Base.lproj/MainMenu.xib
+++ b/MacOSMathExample/Base.lproj/MainMenu.xib
@@ -15,8 +15,6 @@
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customObject id="Voe-Tx-rLC" customClass="AppDelegate">
             <connections>
-                <outlet property="inputTextField" destination="3eF-aq-wq7" id="ZaO-Km-dmc"/>
-                <outlet property="screen" destination="JGc-8F-Tcp" id="k46-7h-xbX"/>
                 <outlet property="window" destination="QvC-M9-y7g" id="gIp-Ho-8D9"/>
             </connections>
         </customObject>
@@ -690,29 +688,6 @@
             <view key="contentView" wantsLayer="YES" id="EiT-Mj-1SZ">
                 <rect key="frame" x="0.0" y="0.0" width="480" height="360"/>
                 <autoresizingMask key="autoresizingMask"/>
-                <subviews>
-                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rQu-NO-fcw">
-                        <rect key="frame" x="200" y="13" width="81" height="32"/>
-                        <buttonCell key="cell" type="push" title="Update!" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="q3o-Jo-ri0">
-                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                            <font key="font" metaFont="system"/>
-                        </buttonCell>
-                        <connections>
-                            <action selector="clickUpdateButton:" target="Voe-Tx-rLC" id="pNr-c5-o7t"/>
-                        </connections>
-                    </button>
-                    <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3eF-aq-wq7">
-                        <rect key="frame" x="20" y="49" width="440" height="22"/>
-                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Enter LaTeX here..." drawsBackground="YES" id="w3t-RT-Vy0">
-                            <font key="font" metaFont="system"/>
-                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                        </textFieldCell>
-                    </textField>
-                    <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JGc-8F-Tcp" customClass="MTMathUILabel">
-                        <rect key="frame" x="20" y="79" width="440" height="261"/>
-                    </customView>
-                </subviews>
             </view>
         </window>
     </objects>

--- a/SwiftMathExample/ContentView.swift
+++ b/SwiftMathExample/ContentView.swift
@@ -32,14 +32,16 @@ struct ContentView: View {
     /// Selected math font, shared across all tabs — switching it in the
     /// Playground re-renders the Examples and Gallery too, mirroring the ObjC example.
     @State private var font: MathFont = .latinModern
+    /// Global font size, shared across all tabs (range 10–40, default 15).
+    @State private var fontSize: CGFloat = 15
 
     var body: some View {
         TabView {
-            ExamplesTab(font: font)
+            ExamplesTab(font: font, fontSize: fontSize)
                 .tabItem { Label("Examples", systemImage: "function") }
-            PlaygroundTab(font: $font)
+            PlaygroundTab(font: $font, fontSize: $fontSize)
                 .tabItem { Label("Playground", systemImage: "pencil.and.scribble") }
-            GalleryTab(font: font)
+            GalleryTab(font: font, fontSize: fontSize)
                 .tabItem { Label("Gallery", systemImage: "square.grid.2x2") }
         }
     }
@@ -100,13 +102,14 @@ private let namedExamples: [NamedFormula] = {
 /// Curated, named examples — suitable as a quick-start reference.
 private struct ExamplesTab: View {
     let font: MathFont
+    let fontSize: CGFloat
 
     var body: some View {
         NavigationView {
             ScrollView {
                 VStack(alignment: .leading, spacing: 20) {
                     ForEach(namedExamples.indices, id: \.self) { i in
-                        ExampleCard(formula: namedExamples[i], font: font)
+                        ExampleCard(formula: namedExamples[i], font: font, fontSize: fontSize)
                     }
                 }
                 .padding()
@@ -125,6 +128,7 @@ private struct ExamplesTab: View {
 private struct ExampleCard: View {
     let formula: NamedFormula
     let font: MathFont
+    let fontSize: CGFloat
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -135,8 +139,8 @@ private struct ExampleCard: View {
             // Rogers–Ramanujan fraction in Latin Modern) scrolls within its card
             // instead of stretching the whole column and clipping every card's left edge.
             ScrollView(.horizontal, showsIndicators: false) {
-                MathLabel(latex: formula.latex, fontSize: formula.fontSize, mode: formula.mode,
-                          font: font.font(size: formula.fontSize))
+                MathLabel(latex: formula.latex, fontSize: fontSize, mode: formula.mode,
+                          font: font.font(size: fontSize))
                     .frame(height: formula.height)
             }
         }
@@ -153,9 +157,8 @@ private struct ExampleCard: View {
 /// live. Mirrors the LaTeX text field and font switcher in the ObjC iosMathExample.
 private struct PlaygroundTab: View {
     @Binding var font: MathFont
+    @Binding var fontSize: CGFloat
     @State private var latex = #"x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}"#
-
-    private let fontSize: CGFloat = 24
 
     var body: some View {
         NavigationView {
@@ -176,13 +179,17 @@ private struct PlaygroundTab: View {
                 .clipShape(RoundedRectangle(cornerRadius: 10))
                 .shadow(color: .black.opacity(0.06), radius: 4, x: 0, y: 2)
 
-                // Font switcher.
-                Picker("Font", selection: $font) {
-                    ForEach(MathFont.allCases) { font in
-                        Text(font.rawValue).tag(font)
+                // Font switcher + size slider.
+                HStack {
+                    Picker("Font", selection: $font) {
+                        ForEach(MathFont.allCases) { font in
+                            Text(font.rawValue).tag(font)
+                        }
                     }
+                    .pickerStyle(.menu)
+                    Slider(value: $fontSize, in: 10...40)
+                        .frame(maxWidth: 160)
                 }
-                .pickerStyle(.segmented)
 
                 // LaTeX editor.
                 Text("LaTeX")
@@ -220,6 +227,7 @@ private struct PlaygroundTab: View {
 /// Full typesetter test suite. Curated real-math formulae live in the Examples tab.
 private struct GalleryTab: View {
     let font: MathFont
+    let fontSize: CGFloat
 
     private static let testHeights: [CGFloat] = [
         40, 40, 40, 40, 40, 60, 60, 60, 90, 30, 40, 90, 40, 60, 60, 60,
@@ -240,13 +248,13 @@ private struct GalleryTab: View {
                     ForEach(testFormulas.indices, id: \.self) { i in
                         MathLabel(
                             latex: testFormulas[i],
-                            fontSize: testFontSize(at: i),
+                            fontSize: fontSize,
                             mode: testMode(at: i),
                             alignment: testAlignment(at: i),
                             highlighted: [0, 1, 3, 6, 7].contains(i),
                             leftInset: i == 6 ? 20 : 0,
                             rightInset: i == 3 ? 20 : 0,
-                            font: font.font(size: testFontSize(at: i))
+                            font: font.font(size: fontSize)
                         )
                         .frame(height: testHeight(at: i))
                         .padding(.horizontal, 10)
@@ -263,14 +271,6 @@ private struct GalleryTab: View {
         #if os(iOS)
         .navigationViewStyle(.stack)
         #endif
-    }
-
-    private func testFontSize(at i: Int) -> CGFloat {
-        switch i {
-        case 8: return 30
-        case 9: return 10
-        default: return 15
-        }
     }
 
     private func testHeight(at i: Int) -> CGFloat {

--- a/SwiftMathExample/ContentView.swift
+++ b/SwiftMathExample/ContentView.swift
@@ -141,7 +141,8 @@ private struct ExampleCard: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 MathLabel(latex: formula.latex, fontSize: fontSize, mode: formula.mode,
                           font: font.font(size: fontSize))
-                    .frame(height: formula.height)
+                    // Scale the card height with the font so larger sizes aren't clipped.
+                    .frame(height: formula.height * (fontSize / formula.fontSize))
             }
         }
         .padding()
@@ -256,7 +257,9 @@ private struct GalleryTab: View {
                             rightInset: i == 3 ? 20 : 0,
                             font: font.font(size: fontSize)
                         )
-                        .frame(height: testHeight(at: i))
+                        // Scale the row height with the font, relative to the size
+                        // each entry's height was tuned for, so nothing clips.
+                        .frame(height: testHeight(at: i) * (fontSize / testBaselineFontSize(at: i)))
                         .padding(.horizontal, 10)
                     }
                 }
@@ -275,6 +278,16 @@ private struct GalleryTab: View {
 
     private func testHeight(at i: Int) -> CGFloat {
         Self.testHeights.indices.contains(i) ? Self.testHeights[i] : 40
+    }
+
+    /// Font size each entry's tuned height assumes, used to scale heights with
+    /// the slider. Indices 8 and 9 were originally shown larger/smaller.
+    private func testBaselineFontSize(at i: Int) -> CGFloat {
+        switch i {
+        case 8: return 30
+        case 9: return 10
+        default: return 15
+        }
     }
 
     private func testMode(at i: Int) -> MTMathUILabelMode {

--- a/SwiftMathExample/ContentView.swift
+++ b/SwiftMathExample/ContentView.swift
@@ -53,41 +53,37 @@ private struct NamedFormula {
     let title: String
     let latex: String
     var mode: MTMathUILabelMode = .display
-    var fontSize: CGFloat = 20
-    var height: CGFloat = 60
 }
 
 /// Curated examples — keep in sync with MathDemoFormulas() in MathExamples.h.
 /// LaTeX strings are sourced from MathDemoFormulas() so content stays consistent;
-/// titles and per-formula display metadata live here.
+/// titles live here.
 private struct NamedFormulaMeta {
     let title: String
     var mode: MTMathUILabelMode = .display
-    var fontSize: CGFloat = 20
-    var height: CGFloat = 60
 }
 
 private let namedExampleMeta: [NamedFormulaMeta] = [
-    NamedFormulaMeta(title: "Quadratic formula", height: 80),
-    NamedFormulaMeta(title: "Cosine addition formula", height: 60),
-    NamedFormulaMeta(title: "Rogers–Ramanujan continued fraction", height: 130),
-    NamedFormulaMeta(title: "Standard deviation", height: 80),
-    NamedFormulaMeta(title: "De Morgan's law", height: 60),
-    NamedFormulaMeta(title: "Change of base", height: 70),
-    NamedFormulaMeta(title: "Compound interest limit", height: 70),
-    NamedFormulaMeta(title: "Gaussian integral", height: 70),
-    NamedFormulaMeta(title: "AM-GM inequality", height: 80),
-    NamedFormulaMeta(title: "Cauchy integral formula", height: 80),
-    NamedFormulaMeta(title: "Schrödinger's equation", fontSize: 16, height: 80),
-    NamedFormulaMeta(title: "Cauchy-Schwarz inequality", height: 80),
-    NamedFormulaMeta(title: "Stirling numbers", height: 80),
-    NamedFormulaMeta(title: "Fourier transform", height: 70),
-    NamedFormulaMeta(title: "Lorenz system", height: 110),
-    NamedFormulaMeta(title: "Cross product", fontSize: 16, height: 140),
-    NamedFormulaMeta(title: "Maxwell's equations", fontSize: 16, height: 200),
-    NamedFormulaMeta(title: "2×2 matrix multiplication", fontSize: 16, height: 90),
-    NamedFormulaMeta(title: "EM algorithm Q-function", height: 130),
-    NamedFormulaMeta(title: "Piecewise function", height: 100),
+    NamedFormulaMeta(title: "Quadratic formula"),
+    NamedFormulaMeta(title: "Cosine addition formula"),
+    NamedFormulaMeta(title: "Rogers–Ramanujan continued fraction"),
+    NamedFormulaMeta(title: "Standard deviation"),
+    NamedFormulaMeta(title: "De Morgan's law"),
+    NamedFormulaMeta(title: "Change of base"),
+    NamedFormulaMeta(title: "Compound interest limit"),
+    NamedFormulaMeta(title: "Gaussian integral"),
+    NamedFormulaMeta(title: "AM-GM inequality"),
+    NamedFormulaMeta(title: "Cauchy integral formula"),
+    NamedFormulaMeta(title: "Schrödinger's equation"),
+    NamedFormulaMeta(title: "Cauchy-Schwarz inequality"),
+    NamedFormulaMeta(title: "Stirling numbers"),
+    NamedFormulaMeta(title: "Fourier transform"),
+    NamedFormulaMeta(title: "Lorenz system"),
+    NamedFormulaMeta(title: "Cross product"),
+    NamedFormulaMeta(title: "Maxwell's equations"),
+    NamedFormulaMeta(title: "2×2 matrix multiplication"),
+    NamedFormulaMeta(title: "EM algorithm Q-function"),
+    NamedFormulaMeta(title: "Piecewise function"),
 ]
 
 private let namedExamples: [NamedFormula] = {
@@ -95,7 +91,7 @@ private let namedExamples: [NamedFormula] = {
     precondition(formulas.count == namedExampleMeta.count,
                  "namedExampleMeta (\(namedExampleMeta.count)) must match MathDemoFormulas (\(formulas.count))")
     return zip(namedExampleMeta, formulas).map { meta, latex in
-        NamedFormula(title: meta.title, latex: latex, mode: meta.mode, fontSize: meta.fontSize, height: meta.height)
+        NamedFormula(title: meta.title, latex: latex, mode: meta.mode)
     }
 }()
 
@@ -138,11 +134,12 @@ private struct ExampleCard: View {
             // Horizontal scroll so a formula wider than the screen (e.g. the
             // Rogers–Ramanujan fraction in Latin Modern) scrolls within its card
             // instead of stretching the whole column and clipping every card's left edge.
+            // No fixed height: the label reports its intrinsic content height (see
+            // MathLabel.sizeThatFits), so tall formulae aren't vertically clipped at
+            // any font size.
             ScrollView(.horizontal, showsIndicators: false) {
                 MathLabel(latex: formula.latex, fontSize: fontSize, mode: formula.mode,
                           font: font.font(size: fontSize))
-                    // Scale the card height with the font so larger sizes aren't clipped.
-                    .frame(height: formula.height * (fontSize / formula.fontSize))
             }
         }
         .padding()
@@ -180,7 +177,9 @@ private struct PlaygroundTab: View {
                 .clipShape(RoundedRectangle(cornerRadius: 10))
                 .shadow(color: .black.opacity(0.06), radius: 4, x: 0, y: 2)
 
-                // Font switcher + size slider.
+                // Font switcher + size stepper. Spacer + fixedSize keep the
+                // stepper pinned to the trailing edge so it doesn't shift as the
+                // font picker's width changes with the selected font's name.
                 HStack {
                     Picker("Font", selection: $font) {
                         ForEach(MathFont.allCases) { font in
@@ -188,8 +187,9 @@ private struct PlaygroundTab: View {
                         }
                     }
                     .pickerStyle(.menu)
-                    Slider(value: $fontSize, in: 10...40)
-                        .frame(maxWidth: 160)
+                    Spacer()
+                    Stepper("Size: \(Int(fontSize))", value: $fontSize, in: 10...40)
+                        .fixedSize()
                 }
 
                 // LaTeX editor.

--- a/SwiftMathExample/MathLabel.swift
+++ b/SwiftMathExample/MathLabel.swift
@@ -43,14 +43,24 @@ enum MathFont: String, CaseIterable, Identifiable {
     case latinModern = "Latin Modern"
     case termes = "TeX Gyre Termes"
     case xits = "XITS"
+    case newComputerModern = "New Computer Modern"
+    case pagella = "TeX Gyre Pagella"
+    case stixTwo = "STIX Two"
+    case firaMath = "Fira Math"
+    case notoSansMath = "Noto Sans Math"
 
     var id: String { rawValue }
 
     var fontName: String {
         switch self {
-        case .latinModern: return MTFontNameLatinModern
-        case .termes:      return MTFontNameTermes
-        case .xits:        return MTFontNameXITS
+        case .latinModern:      return MTFontNameLatinModern
+        case .termes:           return MTFontNameTermes
+        case .xits:             return MTFontNameXITS
+        case .newComputerModern: return MTFontNameNewComputerModern
+        case .pagella:          return MTFontNamePagella
+        case .stixTwo:          return MTFontNameSTIXTwo
+        case .firaMath:         return MTFontNameFiraMath
+        case .notoSansMath:     return MTFontNameNotoSansMath
         }
     }
 

--- a/iosMathExample/View.xib
+++ b/iosMathExample/View.xib
@@ -22,17 +22,10 @@
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TgX-F7-Ft9" userLabel="Fonts">
                     <rect key="frame" x="0.0" y="20" width="320" height="55"/>
                     <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Font" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jX6-20-7Ej" userLabel="Font">
-                            <rect key="frame" x="20" y="17" width="35" height="21"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                            <nil key="highlightedColor"/>
-                        </label>
                         <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Select Font" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="1Dd-7L-RPK">
                             <rect key="frame" x="75" y="10" width="150" height="35"/>
                             <color key="tintColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                             <constraints>
-                                <constraint firstAttribute="width" constant="150" id="CyA-dv-DuT"/>
                                 <constraint firstAttribute="height" constant="35" id="g0P-wJ-SDj"/>
                             </constraints>
                             <color key="textColor" white="0.10119452957923596" alpha="1" colorSpace="calibratedWhite"/>
@@ -60,11 +53,9 @@
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     <constraints>
                         <constraint firstItem="1HJ-UO-PhD" firstAttribute="leading" secondItem="1Dd-7L-RPK" secondAttribute="trailing" constant="20" id="0Rl-Fc-egH"/>
-                        <constraint firstItem="1Dd-7L-RPK" firstAttribute="centerY" secondItem="jX6-20-7Ej" secondAttribute="centerY" id="8v1-zn-J5U"/>
                         <constraint firstAttribute="bottom" secondItem="rTW-h3-GpQ" secondAttribute="bottom" id="UrJ-3Q-LUk"/>
                         <constraint firstAttribute="trailing" secondItem="rTW-h3-GpQ" secondAttribute="trailing" id="V4c-mL-jDf"/>
-                        <constraint firstItem="jX6-20-7Ej" firstAttribute="leading" secondItem="TgX-F7-Ft9" secondAttribute="leading" constant="20" id="ZaS-xG-iMP"/>
-                        <constraint firstItem="1Dd-7L-RPK" firstAttribute="leading" secondItem="jX6-20-7Ej" secondAttribute="trailing" constant="20" id="irc-C9-y2q"/>
+                        <constraint firstItem="1Dd-7L-RPK" firstAttribute="leading" secondItem="TgX-F7-Ft9" secondAttribute="leading" constant="20" id="irc-C9-y2q"/>
                         <constraint firstItem="1Dd-7L-RPK" firstAttribute="top" secondItem="TgX-F7-Ft9" secondAttribute="top" constant="10" id="k2c-EJ-vB4"/>
                         <constraint firstItem="rTW-h3-GpQ" firstAttribute="leading" secondItem="TgX-F7-Ft9" secondAttribute="leading" id="kM0-FE-TvF"/>
                         <constraint firstAttribute="bottom" secondItem="1Dd-7L-RPK" secondAttribute="bottom" constant="10" id="nVe-HW-eXq"/>

--- a/iosMathExample/example/ViewController.m
+++ b/iosMathExample/example/ViewController.m
@@ -99,8 +99,10 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
 
     // Add a global font-size slider above the scroll view.
     // The XIB pins scrollView.top to the Render panel's bottom; find that
-    // constraint, capture the Render panel reference, lower its priority, and
-    // insert the slider between the Render panel and the scroll view.
+    // constraint, capture the Render panel reference, deactivate it, and insert
+    // the slider between the Render panel and the scroll view. (Deactivating
+    // rather than lowering priority: XIB constraints are required (1000), and
+    // mutating an active constraint's priority to/from required throws.)
     UIView* renderPanelRef = nil;
     for (NSLayoutConstraint* c in self.view.constraints) {
         // Match only scrollView.top == <renderPanel>.bottom. Checking the other
@@ -109,12 +111,12 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
         if (c.firstItem == self.scrollView && c.firstAttribute == NSLayoutAttributeTop
             && c.secondAttribute == NSLayoutAttributeBottom) {
             renderPanelRef = c.secondItem;
-            c.priority = UILayoutPriorityDefaultLow;
+            c.active = NO;
             break;
         } else if (c.secondItem == self.scrollView && c.secondAttribute == NSLayoutAttributeTop
                    && c.firstAttribute == NSLayoutAttributeBottom) {
             renderPanelRef = c.firstItem;
-            c.priority = UILayoutPriorityDefaultLow;
+            c.active = NO;
             break;
         }
     }

--- a/iosMathExample/example/ViewController.m
+++ b/iosMathExample/example/ViewController.m
@@ -85,6 +85,42 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
 
     self.latexField.delegate = self;
 
+    // Add a global font-size slider above the scroll view.
+    // The XIB pins scrollView.top to the Render panel's bottom; find that
+    // constraint, capture the Render panel reference, lower its priority, and
+    // insert the slider between the Render panel and the scroll view.
+    UIView* renderPanelRef = nil;
+    for (NSLayoutConstraint* c in self.view.constraints) {
+        if (c.firstItem == self.scrollView && c.firstAttribute == NSLayoutAttributeTop) {
+            renderPanelRef = c.secondItem;
+            c.priority = UILayoutPriorityDefaultLow;
+            break;
+        } else if (c.secondItem == self.scrollView && c.secondAttribute == NSLayoutAttributeTop) {
+            renderPanelRef = c.firstItem;
+            c.priority = UILayoutPriorityDefaultLow;
+            break;
+        }
+    }
+    UISlider* sizeSlider = [[UISlider alloc] init];
+    sizeSlider.translatesAutoresizingMaskIntoConstraints = NO;
+    sizeSlider.minimumValue = 10;
+    sizeSlider.maximumValue = 40;
+    sizeSlider.value = 15;
+    [sizeSlider addTarget:self action:@selector(sizeChanged:) forControlEvents:UIControlEventValueChanged];
+    [self.view addSubview:sizeSlider];
+    NSMutableArray<NSLayoutConstraint*>* sliderConstraints = [NSMutableArray arrayWithArray:@[
+        [sizeSlider.leadingAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.leadingAnchor constant:10],
+        [sizeSlider.trailingAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.trailingAnchor constant:-10],
+        [self.scrollView.topAnchor constraintEqualToAnchor:sizeSlider.bottomAnchor constant:4],
+    ]];
+    if (renderPanelRef) {
+        [sliderConstraints addObject:[sizeSlider.topAnchor constraintEqualToAnchor:renderPanelRef.bottomAnchor constant:4]];
+    } else {
+        // Fallback: pin slider to the scroll view's existing top position.
+        [sliderConstraints addObject:[sizeSlider.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor constant:180]];
+    }
+    [NSLayoutConstraint activateConstraints:sliderConstraints];
+
     UIView* contentView = [[UIView alloc] init];
     [self addFullSizeView:contentView to:self.scrollView];
     // set the size of the content view
@@ -157,9 +193,7 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
     self.labels[6].contentInsets = UIEdgeInsetsMake(0, 20, 0, 0);
     self.labels[7].backgroundColor = highlight;
     self.labels[7].labelMode = kMTMathUILabelModeText;
-    self.labels[8].fontSize = 30;
     self.labels[8].textAlignment = kMTTextAlignmentCenter;
-    self.labels[9].fontSize = 10;
     self.labels[9].textAlignment = kMTTextAlignmentCenter;
     self.labels[17].labelMode = kMTMathUILabelModeText;
     self.labels[18].labelMode = kMTMathUILabelModeText;
@@ -254,6 +288,15 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
     constraint.active = YES;
 }
 
+#pragma mark Actions
+
+- (void)sizeChanged:(UISlider *)sender
+{
+    CGFloat size = (CGFloat)sender.value;
+    for (MTMathUILabel* label in self.demoLabels) { label.fontSize = size; }
+    for (MTMathUILabel* label in self.labels)     { label.fontSize = size; }
+}
+
 #pragma mark Buttons
 - (void)applyFontWithName:(NSString *)name
 {
@@ -301,7 +344,9 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
 {
     self = [super init];
     if (self) {
-        self.fontNames = @[@"Latin Modern Math", @"TeX Gyre Termes", @"XITS Math"];
+        self.fontNames = @[@"Latin Modern Math", @"TeX Gyre Termes", @"XITS Math",
+                           @"New Computer Modern", @"TeX Gyre Pagella", @"STIX Two",
+                           @"Fira Math", @"Noto Sans Math"];
     }
     return self;
 }
@@ -327,6 +372,8 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
     // Not static: extern const NSString* values aren't compile-time constants.
     NSString *const kFontKeys[] = {
         MTFontNameLatinModern, MTFontNameTermes, MTFontNameXITS,
+        MTFontNameNewComputerModern, MTFontNamePagella, MTFontNameSTIXTwo,
+        MTFontNameFiraMath, MTFontNameNotoSansMath,
     };
     self.controller.fontField.text = self.fontNames[row];
     [self.controller.fontField resignFirstResponder];

--- a/iosMathExample/example/ViewController.m
+++ b/iosMathExample/example/ViewController.m
@@ -32,6 +32,14 @@
 
 @property (nonatomic, nonnull) NSMutableArray<MTMathUILabel*>* demoLabels;
 @property (nonatomic, nonnull) NSMutableArray<MTMathUILabel*>* labels;
+// Height constraints + their startup constants, so the size slider can rescale
+// each label (and the content view) instead of clipping at larger font sizes.
+// Demo labels render at fontSize 15; test labels at the default 20.
+@property (nonatomic, nonnull) NSMutableArray<NSLayoutConstraint*>* demoHeightConstraints;
+@property (nonatomic, nonnull) NSMutableArray<NSLayoutConstraint*>* testHeightConstraints;
+@property (nonatomic, nonnull) NSMutableArray<NSNumber*>* demoBaseHeights;
+@property (nonatomic, nonnull) NSMutableArray<NSNumber*>* testBaseHeights;
+@property (nonatomic) NSLayoutConstraint* contentHeightConstraint;
 @property (weak, nonatomic) IBOutlet UITextField *fontField;
 @property (nonatomic) FontPickerDelegate* pickerDelegate;
 @property (weak, nonatomic) IBOutlet UITextField *colorField;
@@ -56,6 +64,10 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
     if (self) {
         self.demoLabels = [[NSMutableArray alloc] init];
         self.labels = [[NSMutableArray alloc] init];
+        self.demoHeightConstraints = [[NSMutableArray alloc] init];
+        self.testHeightConstraints = [[NSMutableArray alloc] init];
+        self.demoBaseHeights = [[NSMutableArray alloc] init];
+        self.testBaseHeights = [[NSMutableArray alloc] init];
     }
     return self;
 }
@@ -91,11 +103,16 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
     // insert the slider between the Render panel and the scroll view.
     UIView* renderPanelRef = nil;
     for (NSLayoutConstraint* c in self.view.constraints) {
-        if (c.firstItem == self.scrollView && c.firstAttribute == NSLayoutAttributeTop) {
+        // Match only scrollView.top == <renderPanel>.bottom. Checking the other
+        // end's attribute avoids accidentally matching scrollView.top anchored to
+        // the safe area layout guide's top, which would pin the slider off-screen.
+        if (c.firstItem == self.scrollView && c.firstAttribute == NSLayoutAttributeTop
+            && c.secondAttribute == NSLayoutAttributeBottom) {
             renderPanelRef = c.secondItem;
             c.priority = UILayoutPriorityDefaultLow;
             break;
-        } else if (c.secondItem == self.scrollView && c.secondAttribute == NSLayoutAttributeTop) {
+        } else if (c.secondItem == self.scrollView && c.secondAttribute == NSLayoutAttributeTop
+                   && c.firstAttribute == NSLayoutAttributeBottom) {
             renderPanelRef = c.firstItem;
             c.priority = UILayoutPriorityDefaultLow;
             break;
@@ -133,9 +150,12 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
     NSArray<NSString*>* demoFormulas = MathDemoFormulas();
     for (NSUInteger i = 0; i < demoFormulas.count; i++) {
         CGFloat height = HeightAtIndex(demoHeights, sizeof(demoHeights)/sizeof(CGFloat), i, 60);
-        MTMathUILabel* label = [self createMathLabel:demoFormulas[i] withHeight:height];
+        MTMathUILabel* label = [[MTMathUILabel alloc] init];
+        label.latex = demoFormulas[i];
         label.fontSize = 15;
         [self.demoLabels addObject:label];
+        [self.demoHeightConstraints addObject:[self setHeight:height forView:label]];
+        [self.demoBaseHeights addObject:@(height)];
     }
 
     [self addLabelAsSubview:self.demoLabels[0] to:contentView];
@@ -165,7 +185,11 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
     NSArray<NSString*>* testFormulas = MathTestFormulas();
     for (NSUInteger i = 0; i < testFormulas.count; i++) {
         CGFloat height = HeightAtIndex(testHeights, sizeof(testHeights)/sizeof(CGFloat), i, 40);
-        [self.labels addObject:[self createMathLabel:testFormulas[i] withHeight:height]];
+        MTMathUILabel* label = [[MTMathUILabel alloc] init];
+        label.latex = testFormulas[i];
+        [self.labels addObject:label];
+        [self.testHeightConstraints addObject:[self setHeight:height forView:label]];
+        [self.testBaseHeights addObject:@(height)];
     }
 
     CGFloat totalHeight = 10; // top inset
@@ -178,7 +202,7 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
         totalHeight += HeightAtIndex(testHeights, sizeof(testHeights)/sizeof(CGFloat), i, 40);
         totalHeight += 10;
     }
-    [self setHeight:totalHeight forView:contentView];
+    self.contentHeightConstraint = [self setHeight:totalHeight forView:contentView];
 
     // Rendering properties that are not shared (alignment, mode, color, insets, fontSize).
     UIColor* highlight = [UIColor colorWithHue:0.15 saturation:0.2 brightness:1.0 alpha:1.0];
@@ -221,14 +245,6 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
     [self setVerticalGap:10 between:array[idx - 1] and:array[idx]];
 }
 
--(MTMathUILabel*) createMathLabel:(NSString*) latex withHeight:(CGFloat) height
-{
-    MTMathUILabel* label = [[MTMathUILabel alloc] init];
-    [self setHeight:height forView:label];
-    label.latex = latex;
-    return label;
-}
-
 #pragma mark Constraints
 - (void)addFullSizeView:(UIView *)view to:(UIView*) parent
 {
@@ -245,7 +261,7 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
                                                                      views:views]];
 }
 
-- (void) setHeight:(CGFloat) height forView:(UIView*) view
+- (NSLayoutConstraint*) setHeight:(CGFloat) height forView:(UIView*) view
 {
     view.translatesAutoresizingMaskIntoConstraints = false;
     // Add height constraint
@@ -255,6 +271,7 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
                                                                   attribute:NSLayoutAttributeNotAnAttribute multiplier:1
                                                                    constant:height];
     constraint.active = YES;
+    return constraint;
 }
 
 - (void) setEqualWidths:(UIView*) view1 andView:(UIView*) view2
@@ -293,8 +310,23 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
 - (void)sizeChanged:(UISlider *)sender
 {
     CGFloat size = (CGFloat)sender.value;
-    for (MTMathUILabel* label in self.demoLabels) { label.fontSize = size; }
-    for (MTMathUILabel* label in self.labels)     { label.fontSize = size; }
+    // Scale each label's height from its startup baseline so formulas grow with
+    // the font instead of being clipped by the fixed startup heights.
+    CGFloat total = 10; // top inset
+    for (NSUInteger i = 0; i < self.demoLabels.count; i++) {
+        self.demoLabels[i].fontSize = size;
+        CGFloat h = self.demoBaseHeights[i].doubleValue * (size / 15.0);
+        self.demoHeightConstraints[i].constant = h;
+        total += h + 10;
+    }
+    total += 30; // gap between sections
+    for (NSUInteger i = 0; i < self.labels.count; i++) {
+        self.labels[i].fontSize = size;
+        CGFloat h = self.testBaseHeights[i].doubleValue * (size / 20.0);
+        self.testHeightConstraints[i].constant = h;
+        total += h + 10;
+    }
+    self.contentHeightConstraint.constant = total;
 }
 
 #pragma mark Buttons

--- a/iosMathExample/example/ViewController.m
+++ b/iosMathExample/example/ViewController.m
@@ -44,6 +44,7 @@
 @property (nonatomic) FontPickerDelegate* pickerDelegate;
 @property (weak, nonatomic) IBOutlet UITextField *colorField;
 @property (nonatomic) ColorPickerDelegate* colorPickerDelegate;
+@property (nonatomic) UILabel* sizeLabel;
 @property (weak, nonatomic) IBOutlet MTMathUILabel *mathLabel;
 @property (weak, nonatomic) IBOutlet UITextField *latexField;
 
@@ -97,54 +98,50 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
 
     self.latexField.delegate = self;
 
-    // Add a global font-size slider above the scroll view.
-    // The XIB pins scrollView.top to the Render panel's bottom; find that
-    // constraint, capture the Render panel reference, deactivate it, and insert
-    // the slider between the Render panel and the scroll view. (Deactivating
-    // rather than lowering priority: XIB constraints are required (1000), and
-    // mutating an active constraint's priority to/from required throws.)
-    UIView* renderPanelRef = nil;
-    for (NSLayoutConstraint* c in self.view.constraints) {
-        // Match only scrollView.top == <renderPanel>.bottom. Checking the other
-        // end's attribute avoids accidentally matching scrollView.top anchored to
-        // the safe area layout guide's top, which would pin the slider off-screen.
-        if (c.firstItem == self.scrollView && c.firstAttribute == NSLayoutAttributeTop
-            && c.secondAttribute == NSLayoutAttributeBottom) {
-            renderPanelRef = c.secondItem;
-            c.active = NO;
-            break;
-        } else if (c.secondItem == self.scrollView && c.secondAttribute == NSLayoutAttributeTop
-                   && c.firstAttribute == NSLayoutAttributeBottom) {
-            renderPanelRef = c.firstItem;
-            c.active = NO;
-            break;
-        }
-    }
-    UISlider* sizeSlider = [[UISlider alloc] init];
-    sizeSlider.translatesAutoresizingMaskIntoConstraints = NO;
-    sizeSlider.minimumValue = 10;
-    sizeSlider.maximumValue = 40;
-    sizeSlider.value = 15;
-    [sizeSlider addTarget:self action:@selector(sizeChanged:) forControlEvents:UIControlEventValueChanged];
-    [self.view addSubview:sizeSlider];
-    NSMutableArray<NSLayoutConstraint*>* sliderConstraints = [NSMutableArray arrayWithArray:@[
-        [sizeSlider.leadingAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.leadingAnchor constant:10],
-        [sizeSlider.trailingAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.trailingAnchor constant:-10],
-        [self.scrollView.topAnchor constraintEqualToAnchor:sizeSlider.bottomAnchor constant:4],
+    // Global font-size control in the top row, beside the font + colour fields.
+    // A stepper (rather than a slider) shows the exact point size and keeps a
+    // fixed footprint, so it doesn't drift as the selected font name changes.
+    UIView* fontsPanel = self.fontField.superview;
+    self.sizeLabel = [[UILabel alloc] init];
+    self.sizeLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    self.sizeLabel.font = [UIFont systemFontOfSize:14];
+    [fontsPanel addSubview:self.sizeLabel];
+
+    UIStepper* sizeStepper = [[UIStepper alloc] init];
+    sizeStepper.translatesAutoresizingMaskIntoConstraints = NO;
+    sizeStepper.minimumValue = 10;
+    sizeStepper.maximumValue = 40;
+    sizeStepper.stepValue = 1;
+    sizeStepper.value = 15;
+    [sizeStepper addTarget:self action:@selector(sizeChanged:) forControlEvents:UIControlEventValueChanged];
+    [fontsPanel addSubview:sizeStepper];
+    // Row order: font field → colour field → size label → stepper. The stepper is
+    // anchored to the trailing safe area and the colour/size controls have fixed
+    // (intrinsic) widths, so the font field — which had its fixed width removed in
+    // the XIB — absorbs the remaining space. Everything stays on-screen and
+    // tappable at any width (iPhone 16 Pro included).
+    [NSLayoutConstraint activateConstraints:@[
+        [self.sizeLabel.leadingAnchor constraintEqualToAnchor:self.colorField.trailingAnchor constant:12],
+        [self.sizeLabel.centerYAnchor constraintEqualToAnchor:self.colorField.centerYAnchor],
+        [sizeStepper.leadingAnchor constraintEqualToAnchor:self.sizeLabel.trailingAnchor constant:8],
+        [sizeStepper.centerYAnchor constraintEqualToAnchor:self.colorField.centerYAnchor],
+        [sizeStepper.trailingAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.trailingAnchor constant:-12],
     ]];
-    if (renderPanelRef) {
-        [sliderConstraints addObject:[sizeSlider.topAnchor constraintEqualToAnchor:renderPanelRef.bottomAnchor constant:4]];
-    } else {
-        // Fallback: pin slider to the scroll view's existing top position.
-        [sliderConstraints addObject:[sizeSlider.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor constant:180]];
-    }
-    [NSLayoutConstraint activateConstraints:sliderConstraints];
+    // Let the font field shrink to fit the row rather than the size controls.
+    [self.fontField setContentHuggingPriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
+    [self.fontField setContentCompressionResistancePriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
+    [self updateSizeLabel:sizeStepper.value];
 
     UIView* contentView = [[UIView alloc] init];
     [self addFullSizeView:contentView to:self.scrollView];
-    // set the size of the content view
-    // Disable horizontal scrolling.
-    [self setEqualWidths:contentView andView:self.scrollView];
+    // Let the content view grow wider than the viewport so wide formulae (e.g.
+    // Rogers–Ramanujan in Latin Modern, or any formula at a large font size) can
+    // be reached by scrolling horizontally instead of being clipped. It still
+    // fills the viewport when every formula is narrower (low-priority equal width).
+    [contentView.widthAnchor constraintGreaterThanOrEqualToAnchor:self.scrollView.widthAnchor].active = YES;
+    NSLayoutConstraint* contentFillsWidth = [contentView.widthAnchor constraintEqualToAnchor:self.scrollView.widthAnchor];
+    contentFillsWidth.priority = UILayoutPriorityDefaultLow;
+    contentFillsWidth.active = YES;
     // Demo formulae — LaTeX strings from MathExamples.h
     static const CGFloat demoHeights[] = {
         60, 40, 120, 60, 40, 40, 40, 40, 60, 40, 40, 60, 60, 60, 70, 70, 140, 60, 90, 60
@@ -276,21 +273,15 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
     return constraint;
 }
 
-- (void) setEqualWidths:(UIView*) view1 andView:(UIView*) view2
-{
-    NSLayoutConstraint* constraint = [NSLayoutConstraint constraintWithItem:view1
-                                                                  attribute:NSLayoutAttributeWidth
-                                                                  relatedBy:NSLayoutRelationEqual toItem:view2
-                                                                  attribute:NSLayoutAttributeWidth multiplier:1 constant:0];
-    constraint.active = YES;
-}
-
 - (void) addLabelAsSubview:(UIView*) label to:(UIView*) parent
 {
     label.translatesAutoresizingMaskIntoConstraints = NO;
     NSDictionary *views = NSDictionaryOfVariableBindings(label);
     [parent addSubview:label];
-    [NSLayoutConstraint activateConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-(10)-[label]-(10)-|"
+    // Pin the label's leading edge; leave the trailing as a >= gap so the label
+    // keeps its natural (intrinsic) width and pushes the content view wider than
+    // the viewport when needed, enabling horizontal scrolling instead of clipping.
+    [NSLayoutConstraint activateConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-(10)-[label]-(>=10)-|"
                                                                                     options:0
                                                                                     metrics:nil
                                                                                       views:views]];
@@ -309,9 +300,15 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
 
 #pragma mark Actions
 
-- (void)sizeChanged:(UISlider *)sender
+- (void)updateSizeLabel:(CGFloat)size
+{
+    self.sizeLabel.text = [NSString stringWithFormat:@"%dpt", (int)size];
+}
+
+- (void)sizeChanged:(UIStepper *)sender
 {
     CGFloat size = (CGFloat)sender.value;
+    [self updateSizeLabel:size];
     // Scale each label's height from its startup baseline so formulas grow with
     // the font instead of being clipped by the fixed startup heights.
     CGFloat total = 10; // top inset


### PR DESCRIPTION
## Goal

All three example apps list all 8 fonts and gain a font-size slider (range 10–40, default 15) that applies one global override size to every label.

**Plan:** `docs/plans/2026-05-30-add-math-fonts.md` (items 15–17)
**LLD:** `docs/lld/2026-05-30-add-math-fonts.md`

## Stack

- #209 — Bundle the 8 math fonts
- #210 — Constant-driven API + caller migration ← **base of this PR**
- **This PR** — Example apps: 8 fonts + font-size slider

## Commits

- `[item 15]` iOS example: 8-font wheel + global font-size slider
- `[item 16]` SwiftMathExample: 8 fonts (.menu) + shared font-size slider
- `[item 17]` macOS example: code-built font popup + font-size slider

## Changes per app

**iOS (`iosMathExample`):** `fontNames`/`kFontKeys` extended to 8 entries; `UISlider` (10–40pt, default 15) added in code above the scroll view; `sizeChanged:` action loops all labels; per-label `labels[8].fontSize=30` / `labels[9].fontSize=10` overrides removed.

**Swift (`SwiftMathExample`):** 5 new `MathFont` enum cases; Picker style changed from `.segmented` to `.menu`; `@State fontSize: CGFloat = 15` shared across all tabs; `Slider(value: $fontSize, in: 10...40)` in PlaygroundTab; ExampleCard and GalleryTab use shared `fontSize`.

**macOS (`MacOSMathExample`):** `NSPopUpButton` + `NSSlider` added as a code-built 36pt header above the scroll view; `changeFont:` / `changeSize:` actions wired; per-label size overrides removed.

## Testing

All three apps build (`BUILD SUCCEEDED`). No storyboard/XIB edits.