### PR TITLE
Fix SPM consumer build: qualify cross-directory header imports (#215)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
             ],
             publicHeadersPath: ".",
             cSettings: [
+                .headerSearchPath("."),
                 .headerSearchPath("lib"),
                 .headerSearchPath("render"),
                 .headerSearchPath("render/internal"),
@@ -33,6 +34,7 @@ let package = Package(
             path: "iosMathTests",
             exclude: ["en.lproj"],
             cSettings: [
+                .headerSearchPath("../iosMath"),
                 .headerSearchPath("../iosMath/lib"),
                 .headerSearchPath("../iosMath/render"),
                 .headerSearchPath("../iosMath/render/internal"),
@@ -43,6 +45,7 @@ let package = Package(
             dependencies: ["iosMath"],
             path: "iosMathSwiftTests",
             cSettings: [
+                .headerSearchPath("../iosMath"),
                 .headerSearchPath("../iosMath/lib"),
                 .headerSearchPath("../iosMath/render"),
                 .headerSearchPath("../iosMath/render/internal"),
@@ -50,6 +53,15 @@ let package = Package(
             swiftSettings: [
                 .swiftLanguageMode(.v5),
             ]
+        ),
+        // Regression guard for issue #215. Imports `iosMath` purely as a Clang
+        // module with NO header search paths, reproducing how an external SPM
+        // consumer builds the module. If a public header reintroduces a bare
+        // cross-directory `#import`, this target fails to compile.
+        .testTarget(
+            name: "iosMathConsumerTests",
+            dependencies: ["iosMath"],
+            path: "iosMathConsumerTests"
         ),
     ]
 )

--- a/iosMath/render/MTFontManager.h
+++ b/iosMath/render/MTFontManager.h
@@ -13,7 +13,7 @@
 @import CoreText;
 
 #import "MTFont.h"
-#import "MTMathList.h"
+#import "lib/MTMathList.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/iosMath/render/MTMathListDisplay.h
+++ b/iosMath/render/MTMathListDisplay.h
@@ -18,7 +18,7 @@
 #import "MTConfig.h"
 
 #import "MTFont.h"
-#import "MTMathList.h"
+#import "lib/MTMathList.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/iosMath/render/MTMathUILabel.h
+++ b/iosMath/render/MTMathUILabel.h
@@ -15,7 +15,7 @@
 #import "MTConfig.h"
 
 #import "MTFont.h"
-#import "MTMathList.h"
+#import "lib/MTMathList.h"
 #import "MTMathListDisplay.h"
 
 /**

--- a/iosMathConsumerTests/iosMathModuleConsumerTests.swift
+++ b/iosMathConsumerTests/iosMathModuleConsumerTests.swift
@@ -1,0 +1,41 @@
+// iosMathModuleConsumerTests.swift
+// Regression test for issue #215: "Clang dependency scanning failure,
+// fatal error: MTMathList.h not found."
+//
+// This target deliberately depends on `iosMath` and imports it *purely as a
+// Clang module*, with NO header search paths configured in Package.swift. That
+// reproduces exactly how a downstream Swift Package Manager consumer builds the
+// module: from `module.modulemap` against the package's public-headers root,
+// without iosMath's target-internal `lib`/`render` search paths.
+//
+// The bug was that public headers in `render/` imported sibling headers in
+// `lib/` by bare filename (e.g. `#import "MTMathList.h"`), which only resolves
+// when the internal `lib` search path is present. External consumers (and this
+// target) lack that path, so building the module failed with
+// "'MTMathList.h' file not found".
+//
+// If that regression returns, this target FAILS TO COMPILE — `import iosMath`
+// forces the module (all module-map headers) to build. The assertions below are
+// secondary; the real guard is that this file compiles at all. Referencing a
+// `render/` type (MTMathUILabel) and a `lib/` type (MTMathList) together keeps
+// the cross-directory include in the compiled surface.
+
+import XCTest
+import iosMath
+
+final class iosMathModuleConsumerTests: XCTestCase {
+
+    // Exercises the render -> lib cross-directory include path. MTMathUILabel
+    // lives in render/ and pulls in MTMathList from lib/.
+    @MainActor
+    func testModuleBuildsAndRendersCrossDirectoryTypes() {
+        let label = MTMathUILabel()
+        label.latex = #"\frac{1}{2}"#
+        XCTAssertNotNil(label.mathList)
+        XCTAssertNil(label.error)
+
+        // Use the lib/ type directly as well so it stays in the consumed surface.
+        let list: MTMathList? = label.mathList
+        XCTAssertNotNil(list)
+    }
+}


### PR DESCRIPTION
Fixes #215.

## Problem

Adding iosMath as a Swift Package Manager dependency fails to build:

```
fatal error: 'MTMathList.h' file not found
... could not build module 'iosMath'
```

The bundled demo and `swift build`/`swift test` all work, so the bug only hits downstream consumers.

## Root cause

Public headers in `render/` imported sibling headers from `lib/` by **bare filename**:

```objc
// render/MTMathUILabel.h
#import "MTMathList.h"   // actually lives in lib/
```

That basename only resolves via the `lib` header search path in `cSettings`, which is **target-internal** — applied when SPM compiles iosMath's own sources, but **not** when a downstream consumer builds the `iosMath` Clang module from `module.modulemap`. The consumer's module build only has the public-headers root on its include path, so the cross-directory include fails. (Xcode 16's explicit-modules dependency scanning surfaces it as the error above.)

## Fix

- Qualify the `render -> lib` imports as `lib/MTMathList.h` so they resolve from the package's public-headers root, which *is* exposed to consumers.
- Add that root to each target's header search paths so internal builds keep resolving the qualified path.

## Regression test

New `iosMathConsumerTests` target imports `iosMath` purely as a Clang module **with no header search paths**, reproducing exactly how an external SPM consumer builds it. The existing test targets can't catch this — their `cSettings` carry the internal `lib`/`render` paths, which leak into the implicit module build and mask the bug.

Verified RED/GREEN: reverting one header to the bare import makes the new target fail with the exact #215 error; with the fix it passes. Full suite: 267 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)