### PR TITLE
Behavior-preserving refactor — remove dead row-style state, share limit-gap math

### DIFF
--- a/iosMath/lib/MTMathList.h
+++ b/iosMath/lib/MTMathList.h
@@ -499,17 +499,13 @@ typedef NS_ENUM(NSUInteger, MTMathStackConstructionKind) {
 
 // MathList fields (kind == kMTMathStackConstructionMathList)
 @property (nonatomic, readonly, nullable) MTMathList* list;
-@property (nonatomic, readonly) MTLineStyle listStyle;
-@property (nonatomic, readonly) BOOL listCramped;
 
 // Rule fields (kind == kMTMathStackConstructionRule)
 /// Rule thickness in points. 0 means use the font's default.
 @property (nonatomic, readonly) CGFloat ruleThickness;
 
 + (instancetype)extensibleWithGlyph:(NSString*)glyph;
-+ (instancetype)mathListWithList:(MTMathList*)list
-                           style:(MTLineStyle)style
-                         cramped:(BOOL)cramped;
++ (instancetype)mathListWithList:(MTMathList*)list;
 + (instancetype)ruleWithThickness:(CGFloat)thickness;
 
 @end

--- a/iosMath/lib/MTMathList.m
+++ b/iosMath/lib/MTMathList.m
@@ -1173,15 +1173,11 @@ static NSString* fractionCommandForDelimiterPair(NSString* leftDelimiter, NSStri
 }
 
 + (instancetype)mathListWithList:(MTMathList*)list
-                           style:(MTLineStyle)style
-                         cramped:(BOOL)cramped
 {
     NSParameterAssert(list);
     MTMathStackConstruction* c = [[self alloc] init];
     c->_kind = kMTMathStackConstructionMathList;
     c->_list = [list copy];
-    c->_listStyle = style;
-    c->_listCramped = cramped;
     return c;
 }
 
@@ -1199,8 +1195,6 @@ static NSString* fractionCommandForDelimiterPair(NSString* leftDelimiter, NSStri
     copy->_kind = _kind;
     copy->_glyph = [_glyph copyWithZone:zone];
     copy->_list = [_list copyWithZone:zone];
-    copy->_listStyle = _listStyle;
-    copy->_listCramped = _listCramped;
     copy->_ruleThickness = _ruleThickness;
     return copy;
 }
@@ -1245,16 +1239,10 @@ static NSString* fractionCommandForDelimiterPair(NSString* leftDelimiter, NSStri
     MTMathStack* newStack = [super finalized];
     newStack.innerList = newStack.innerList.finalized;
     if (newStack.over && newStack.over.kind == kMTMathStackConstructionMathList) {
-        MTMathStackConstruction* overConst = newStack.over;
-        newStack.over = [MTMathStackConstruction mathListWithList:overConst.list.finalized
-                                                           style:overConst.listStyle
-                                                         cramped:overConst.listCramped];
+        newStack.over = [MTMathStackConstruction mathListWithList:newStack.over.list.finalized];
     }
     if (newStack.under && newStack.under.kind == kMTMathStackConstructionMathList) {
-        MTMathStackConstruction* underConst = newStack.under;
-        newStack.under = [MTMathStackConstruction mathListWithList:underConst.list.finalized
-                                                            style:underConst.listStyle
-                                                          cramped:underConst.listCramped];
+        newStack.under = [MTMathStackConstruction mathListWithList:newStack.under.list.finalized];
     }
     return newStack;
 }

--- a/iosMath/render/internal/MTTypesetter.m
+++ b/iosMath/render/internal/MTTypesetter.m
@@ -2042,9 +2042,10 @@ typedef NS_ENUM(NSUInteger, MTStackRole) {
 
         case kMTMathStackConstructionMathList: {
             return [MTTypesetter createLineForMathList:construction.list
-                                                 font:_font
-                                                style:construction.listStyle
-                                              cramped:construction.listCramped];
+                                                  font:_font
+                                                 style:self.scriptStyle
+                                               cramped:(role == kMTStackRoleOver ? self.superScriptCramped
+                                                                                 : self.subscriptCramped)];
         }
 
         case kMTMathStackConstructionRule:

--- a/iosMath/render/internal/MTTypesetter.m
+++ b/iosMath/render/internal/MTTypesetter.m
@@ -1707,6 +1707,18 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
     }
 }
 
+- (CGFloat) upperLimitGapFor:(MTDisplay*)limit
+{
+    return MAX(_styleFont.mathTable.upperLimitGapMin,
+               _styleFont.mathTable.upperLimitBaselineRiseMin - limit.descent);
+}
+
+- (CGFloat) lowerLimitGapFor:(MTDisplay*)limit
+{
+    return MAX(_styleFont.mathTable.lowerLimitGapMin,
+               _styleFont.mathTable.lowerLimitBaselineDropMin - limit.ascent);
+}
+
 - (MTDisplay*) addLimitsToDisplay:(MTDisplay*) display forOperator:(MTLargeOperator*) op delta:(CGFloat)delta
 {
     // If there is no subscript or superscript, just return the current display
@@ -1726,12 +1738,10 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
         NSAssert(superScript || subScript, @"Atleast one of superscript or subscript should have been present.");
         MTLargeOpLimitsDisplay* opsDisplay = [[MTLargeOpLimitsDisplay alloc] initWithNucleus:display upperLimit:superScript lowerLimit:subScript limitShift:delta/2 extraPadding:0];
         if (superScript) {
-            CGFloat upperLimitGap = MAX(_styleFont.mathTable.upperLimitGapMin, _styleFont.mathTable.upperLimitBaselineRiseMin - superScript.descent);
-            opsDisplay.upperLimitGap = upperLimitGap;
+            opsDisplay.upperLimitGap = [self upperLimitGapFor:superScript];
         }
         if (subScript) {
-            CGFloat lowerLimitGap = MAX(_styleFont.mathTable.lowerLimitGapMin, _styleFont.mathTable.lowerLimitBaselineDropMin - subScript.ascent);
-            opsDisplay.lowerLimitGap = lowerLimitGap;
+            opsDisplay.lowerLimitGap = [self lowerLimitGapFor:subScript];
         }
         opsDisplay.position = _currentPosition;
         opsDisplay.range = op.indexRange;

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -2598,4 +2598,28 @@
     XCTAssertEqualWithAccuracy(text.position.y, math.position.y, 0.001);
 }
 
+- (void)testStackMathListRowRendersAtScriptStyle
+{
+    // 6.2-a: a MathList over-row is typeset at script style derived from the live
+    // style, so for the same glyph it is smaller than the display-style base.
+    MTMathList* baseList = [MTMathList new];
+    [baseList addAtom:[MTMathAtomFactory atomForCharacter:'X']];
+    MTMathList* overList = [MTMathList new];
+    [overList addAtom:[MTMathAtomFactory atomForCharacter:'X']];
+
+    MTMathStack* stack = [MTMathStack new];
+    stack.innerList = baseList;
+    stack.over = [MTMathStackConstruction mathListWithList:overList];
+
+    MTMathList* list = [MTMathList new];
+    [list addAtom:stack];
+
+    MTMathListDisplay* display =
+        [MTTypesetter createLineForMathList:list font:self.font style:kMTLineStyleDisplay];
+    XCTAssertEqual(display.subDisplays.count, 1u);
+    MTStackDisplay* sd = (MTStackDisplay*)display.subDisplays[0];
+    XCTAssertTrue([sd.over isKindOfClass:[MTMathListDisplay class]]);
+    XCTAssertLessThan(sd.over.ascent, sd.base.ascent);
+}
+
 @end


### PR DESCRIPTION
## Goal

Delete the unreachable `listStyle`/`listCramped` parse-time fields and derive the row style at typeset time; extract the operator-limit gap formula into shared helpers. **No LaTeX behavior changes** — the existing 268-test suite stays green. This isolates the pure refactor so the follow-up feature PR's diff is small and reviewable.

This is **PR 1 of 2** in the over/under stack-commands stack (`\overset`, `\underset`, `\stackrel`, `\stackbin`).

## Design docs

- Plan: `docs/plans/2026-06-07-overset-underset-stackrel.md`
- LLD: `docs/lld/2026-06-07-overset-underset-stackrel.md`

## Commits

- `[item 1]` Remove dead row-style state; derive stack row style at typeset time
- `[item 2]` Extract `upperLimitGapFor:`/`lowerLimitGapFor:` limit-gap helpers

## Verification

- `swift test` — 268 tests, 0 failures.
- Per-commit test verification: both commits independently green.
- Item 2 is a behavior-preserving extraction guarded by the existing `MTTypesetterTest` limit tests (80 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)