### PR TITLE
The four over/under commands end-to-end (\overset, \underset, \stackrel, \stackbin)

### DIFF
--- a/iosMath/lib/MTMathAtomFactory.h
+++ b/iosMath/lib/MTMathAtomFactory.h
@@ -15,6 +15,29 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/// The role a parsed argument plays when the builder assembles an over/under stack.
+typedef NS_ENUM(NSUInteger, MTStackArgRole) {
+    kMTStackArgBase,
+    kMTStackArgOver,
+    kMTStackArgUnder,
+};
+
+/// Describes one over/under stack command: its static (Extensible) rows, the ordered
+/// argument roles the builder reads, the math class it forces, and whether it instead
+/// inherits the class from a lone Bin/Rel base atom.
+@interface MTMathStackCommandSpec : NSObject
+@property (nonatomic, readonly, nullable) MTMathStackConstruction* overConstruction;
+@property (nonatomic, readonly, nullable) MTMathStackConstruction* underConstruction;
+@property (nonatomic, readonly) MTMathAtomType displayClass;
+@property (nonatomic, readonly) NSArray<NSNumber*>* argRoles;
+@property (nonatomic, readonly) BOOL inheritsClass;
+- (instancetype)initWithOver:(nullable MTMathStackConstruction*)over
+                       under:(nullable MTMathStackConstruction*)under
+                displayClass:(MTMathAtomType)displayClass
+                    argRoles:(NSArray<NSNumber*>*)argRoles
+               inheritsClass:(BOOL)inheritsClass;
+@end
+
 FOUNDATION_EXPORT NSString *const MTSymbolMultiplication;
 FOUNDATION_EXPORT NSString *const MTSymbolDivision;
 FOUNDATION_EXPORT NSString *const MTSymbolFractionSlash;
@@ -125,6 +148,17 @@ FOUNDATION_EXPORT NSString *const MTSymbolDegree;
  non-canonical constructions). This is the inverse of stackAtomForCommand:. */
 + (nullable NSString*) stackCommandForStack:(MTMathStack*)stack
     NS_SWIFT_NAME(stackCommand(for:));
+
+/** Returns the MTMathStackCommandSpec for the given LaTeX command name, or nil if the
+ command is not a known stack command. Includes all eight stretchy commands and the four
+ two-argument MathList commands: overset, underset, stackrel, stackbin. */
++ (nullable MTMathStackCommandSpec*) stackCommandSpec:(NSString*)command;
+
+/** Returns the math class to inherit from the base list for \overset / \underset.
+ Option I: if the base list is a single atom of type BinaryOperator or Relation, that
+ type is returned (intrinsic class, read before finalize's Bin->Ord reclassification).
+ In all other cases returns kMTMathAtomOrdinary. */
++ (MTMathAtomType) inheritedDisplayClassForBase:(MTMathList*)base;
 
 /** Creates a new boundary atom for the given delimiter name. If the delimiter name
  is not recognized it returns nil. A delimiter name can be a single character such

--- a/iosMath/lib/MTMathAtomFactory.m
+++ b/iosMath/lib/MTMathAtomFactory.m
@@ -26,25 +26,19 @@ NSString *const MTSymbolInfinity = @"\u221E"; // \infty
 NSString *const MTSymbolAngle = @"\u2220"; // \angle
 NSString *const MTSymbolDegree = @"\u00B0"; // \circ
 
-/// File-private value type carrying the over/under spec and displayClass for one command.
-@interface MTMathStackCommandSpec : NSObject
-@property (nonatomic, readonly, nullable) MTMathStackConstruction* overConstruction;
-@property (nonatomic, readonly, nullable) MTMathStackConstruction* underConstruction;
-@property (nonatomic, readonly) MTMathAtomType displayClass;
-- (instancetype)initWithOver:(nullable MTMathStackConstruction*)over
-                       under:(nullable MTMathStackConstruction*)under
-                displayClass:(MTMathAtomType)displayClass;
-@end
-
 @implementation MTMathStackCommandSpec
 - (instancetype)initWithOver:(nullable MTMathStackConstruction*)over
                        under:(nullable MTMathStackConstruction*)under
-                displayClass:(MTMathAtomType)displayClass {
+                displayClass:(MTMathAtomType)displayClass
+                    argRoles:(NSArray<NSNumber*>*)argRoles
+               inheritsClass:(BOOL)inheritsClass {
     self = [super init];
     if (self) {
         _overConstruction = over;
         _underConstruction = under;
         _displayClass = displayClass;
+        _argRoles = [argRoles copy];
+        _inheritsClass = inheritsClass;
     }
     return self;
 }
@@ -1133,15 +1127,20 @@ NSString *const MTSymbolDegree = @"\u00B0"; // \circ
         MTMathStackConstruction* overBrace      = [MTMathStackConstruction extensibleWithGlyph:@"\u23DE"];
         MTMathStackConstruction* underBrace     = [MTMathStackConstruction extensibleWithGlyph:@"\u23DF"];
 
+        NSArray* baseOnly = @[@(kMTStackArgBase)];
         stackCommands = @{
-            @"overrightarrow":     [[MTMathStackCommandSpec alloc] initWithOver:rightArrow     under:nil       displayClass:kMTMathAtomOrdinary],
-            @"overleftarrow":      [[MTMathStackCommandSpec alloc] initWithOver:leftArrow      under:nil       displayClass:kMTMathAtomOrdinary],
-            @"overleftrightarrow": [[MTMathStackCommandSpec alloc] initWithOver:leftRightArrow under:nil       displayClass:kMTMathAtomOrdinary],
-            @"underrightarrow":    [[MTMathStackCommandSpec alloc] initWithOver:nil            under:rightArrow     displayClass:kMTMathAtomOrdinary],
-            @"underleftarrow":     [[MTMathStackCommandSpec alloc] initWithOver:nil            under:leftArrow      displayClass:kMTMathAtomOrdinary],
-            @"underleftrightarrow":[[MTMathStackCommandSpec alloc] initWithOver:nil            under:leftRightArrow displayClass:kMTMathAtomOrdinary],
-            @"overbrace":          [[MTMathStackCommandSpec alloc] initWithOver:overBrace      under:nil       displayClass:kMTMathAtomOrdinary],
-            @"underbrace":         [[MTMathStackCommandSpec alloc] initWithOver:nil            under:underBrace     displayClass:kMTMathAtomOrdinary],
+            @"overrightarrow":     [[MTMathStackCommandSpec alloc] initWithOver:rightArrow     under:nil            displayClass:kMTMathAtomOrdinary argRoles:baseOnly inheritsClass:NO],
+            @"overleftarrow":      [[MTMathStackCommandSpec alloc] initWithOver:leftArrow      under:nil            displayClass:kMTMathAtomOrdinary argRoles:baseOnly inheritsClass:NO],
+            @"overleftrightarrow": [[MTMathStackCommandSpec alloc] initWithOver:leftRightArrow under:nil            displayClass:kMTMathAtomOrdinary argRoles:baseOnly inheritsClass:NO],
+            @"underrightarrow":    [[MTMathStackCommandSpec alloc] initWithOver:nil            under:rightArrow     displayClass:kMTMathAtomOrdinary argRoles:baseOnly inheritsClass:NO],
+            @"underleftarrow":     [[MTMathStackCommandSpec alloc] initWithOver:nil            under:leftArrow      displayClass:kMTMathAtomOrdinary argRoles:baseOnly inheritsClass:NO],
+            @"underleftrightarrow":[[MTMathStackCommandSpec alloc] initWithOver:nil            under:leftRightArrow displayClass:kMTMathAtomOrdinary argRoles:baseOnly inheritsClass:NO],
+            @"overbrace":          [[MTMathStackCommandSpec alloc] initWithOver:overBrace      under:nil            displayClass:kMTMathAtomOrdinary argRoles:baseOnly inheritsClass:NO],
+            @"underbrace":         [[MTMathStackCommandSpec alloc] initWithOver:nil            under:underBrace     displayClass:kMTMathAtomOrdinary argRoles:baseOnly inheritsClass:NO],
+            @"overset":            [[MTMathStackCommandSpec alloc] initWithOver:nil under:nil displayClass:kMTMathAtomOrdinary       argRoles:@[@(kMTStackArgOver),  @(kMTStackArgBase)] inheritsClass:YES],
+            @"underset":           [[MTMathStackCommandSpec alloc] initWithOver:nil under:nil displayClass:kMTMathAtomOrdinary       argRoles:@[@(kMTStackArgUnder), @(kMTStackArgBase)] inheritsClass:YES],
+            @"stackrel":           [[MTMathStackCommandSpec alloc] initWithOver:nil under:nil displayClass:kMTMathAtomRelation       argRoles:@[@(kMTStackArgOver),  @(kMTStackArgBase)] inheritsClass:NO],
+            @"stackbin":           [[MTMathStackCommandSpec alloc] initWithOver:nil under:nil displayClass:kMTMathAtomBinaryOperator argRoles:@[@(kMTStackArgOver),  @(kMTStackArgBase)] inheritsClass:NO],
         };
     }
     return stackCommands;
@@ -1158,6 +1157,24 @@ NSString *const MTSymbolDegree = @"\u00B0"; // \circ
     stack.under = spec.underConstruction;
     stack.displayClass = spec.displayClass;
     return stack;
+}
+
++ (nullable MTMathStackCommandSpec*) stackCommandSpec:(NSString*)command
+{
+    return [self stackCommands][command];
+}
+
++ (MTMathAtomType) inheritedDisplayClassForBase:(MTMathList*)base
+{
+    // Option I: inherit a lone Bin/Rel base atom's INTRINSIC class (read before
+    // finalize's Bin->Ord reclassification, matching amsmath \binrel@); else Ordinary.
+    if (base.atoms.count == 1) {
+        MTMathAtomType t = ((MTMathAtom*)base.atoms[0]).type;
+        if (t == kMTMathAtomBinaryOperator || t == kMTMathAtomRelation) {
+            return t;
+        }
+    }
+    return kMTMathAtomOrdinary;
 }
 
 /// Returns a canonical key string encoding the over/under glyphs plus displayClass.

--- a/iosMath/lib/MTMathAtomFactory.m
+++ b/iosMath/lib/MTMathAtomFactory.m
@@ -1209,6 +1209,10 @@ static NSString* StackCommandKey(MTMathStackConstruction* _Nullable over,
 {
     BOOL overML  = stack.over  && stack.over.kind  == kMTMathStackConstructionMathList;
     BOOL underML = stack.under && stack.under.kind == kMTMathStackConstructionMathList;
+    if (overML && underML) {
+        // Composite programmatic stack — no single LaTeX command covers it.
+        return nil;
+    }
     if (overML || underML) {
         // Realizes the LLD reverse-map table: under->\underset (any class);
         // over+Relation->\stackrel; over+Binary->\stackbin; over+else->\overset.

--- a/iosMath/lib/MTMathAtomFactory.m
+++ b/iosMath/lib/MTMathAtomFactory.m
@@ -1207,8 +1207,21 @@ static NSString* StackCommandKey(MTMathStackConstruction* _Nullable over,
 
 + (nullable NSString*) stackCommandForStack:(MTMathStack*)stack
 {
-    // Only Extensible constructions are in the Phase-1 table; non-Extensible
-    // (MathList / Rule) or constructions with non-canonical field values won't match.
+    BOOL overML  = stack.over  && stack.over.kind  == kMTMathStackConstructionMathList;
+    BOOL underML = stack.under && stack.under.kind == kMTMathStackConstructionMathList;
+    if (overML || underML) {
+        // Realizes the LLD reverse-map table: under->\underset (any class);
+        // over+Relation->\stackrel; over+Binary->\stackbin; over+else->\overset.
+        if (underML) {
+            return @"underset";
+        }
+        switch (stack.displayClass) {
+            case kMTMathAtomRelation:       return @"stackrel";
+            case kMTMathAtomBinaryOperator: return @"stackbin";
+            default:                        return @"overset";
+        }
+    }
+    // Existing Extensible path (unchanged).
     if (stack.over && stack.over.kind != kMTMathStackConstructionExtensible) {
         return nil;
     }

--- a/iosMath/lib/MTMathList.m
+++ b/iosMath/lib/MTMathList.m
@@ -1250,11 +1250,24 @@ static NSString* fractionCommandForDelimiterPair(NSString* leftDelimiter, NSStri
 - (void)appendLaTeXToString:(NSMutableString *)str
 {
     NSString* cmd = [MTMathAtomFactory stackCommandForStack:self];
-    if (cmd) {
-        [str appendFormat:@"\\%@{%@}", cmd, [MTMathListBuilder mathListToString:self.innerList]];
+    BOOL overIsMathList  = self.over  && self.over.kind  == kMTMathStackConstructionMathList;
+    BOOL underIsMathList = self.under && self.under.kind == kMTMathStackConstructionMathList;
+    NSString* inner = [MTMathListBuilder mathListToString:self.innerList];
+    if (overIsMathList && underIsMathList) {
+        // Programmatic stack with both rows: nested \underset{under}{\overset{over}{base}}.
+        [str appendFormat:@"\\underset{%@}{\\overset{%@}{%@}}",
+             [MTMathListBuilder mathListToString:self.under.list],
+             [MTMathListBuilder mathListToString:self.over.list],
+             inner];
+    } else if (cmd && (overIsMathList || underIsMathList)) {
+        MTMathList* row = overIsMathList ? self.over.list : self.under.list;
+        [str appendFormat:@"\\%@{%@}{%@}", cmd, [MTMathListBuilder mathListToString:row], inner];
+    } else if (cmd) {
+        // Extensible (single-arg) commands, unchanged.
+        [str appendFormat:@"\\%@{%@}", cmd, inner];
     } else {
         // Programmatically-built stack with non-canonical constructions — emit only the inner list.
-        [str appendString:[MTMathListBuilder mathListToString:self.innerList]];
+        [str appendString:inner];
     }
 }
 

--- a/iosMath/lib/MTMathList.m
+++ b/iosMath/lib/MTMathList.m
@@ -1249,17 +1249,21 @@ static NSString* fractionCommandForDelimiterPair(NSString* leftDelimiter, NSStri
 
 - (void)appendLaTeXToString:(NSMutableString *)str
 {
-    NSString* cmd = [MTMathAtomFactory stackCommandForStack:self];
     BOOL overIsMathList  = self.over  && self.over.kind  == kMTMathStackConstructionMathList;
     BOOL underIsMathList = self.under && self.under.kind == kMTMathStackConstructionMathList;
     NSString* inner = [MTMathListBuilder mathListToString:self.innerList];
     if (overIsMathList && underIsMathList) {
-        // Programmatic stack with both rows: nested \underset{under}{\overset{over}{base}}.
+        // Programmatic both-rows stack: no single command exists, so emit nested
+        // \underset{under}{\overset{over}{base}}. Reparses to two nested stacks
+        // (equivalent, not byte-identical — see LLD §6.5).
         [str appendFormat:@"\\underset{%@}{\\overset{%@}{%@}}",
              [MTMathListBuilder mathListToString:self.under.list],
              [MTMathListBuilder mathListToString:self.over.list],
              inner];
-    } else if (cmd && (overIsMathList || underIsMathList)) {
+        return;
+    }
+    NSString* cmd = [MTMathAtomFactory stackCommandForStack:self];
+    if (cmd && (overIsMathList || underIsMathList)) {
         MTMathList* row = overIsMathList ? self.over.list : self.under.list;
         [str appendFormat:@"\\%@{%@}{%@}", cmd, [MTMathListBuilder mathListToString:row], inner];
     } else if (cmd) {

--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -789,9 +789,33 @@ NSString *const MTParseError = @"ParseError";
         under.innerList = [self buildInternal:true];
         return under;
     } else {
-        MTMathStack* stack = [MTMathAtomFactory stackAtomForCommand:command];
-        if (stack) {
-            stack.innerList = [self buildInternal:true];
+        MTMathStackCommandSpec* spec = [MTMathAtomFactory stackCommandSpec:command];
+        if (spec) {
+            MTMathStack* stack = [MTMathStack new];
+            stack.over  = spec.overConstruction;   // static glyph row or nil
+            stack.under = spec.underConstruction;
+            MTMathList* base = nil;
+            for (NSNumber* role in spec.argRoles) {
+                MTMathList* arg = [self buildInternal:true];
+                if (_error) {
+                    return nil;
+                }
+                switch (role.unsignedIntegerValue) {
+                    case kMTStackArgBase:
+                        base = arg;
+                        stack.innerList = arg;
+                        break;
+                    case kMTStackArgOver:
+                        stack.over = [MTMathStackConstruction mathListWithList:arg];
+                        break;
+                    case kMTStackArgUnder:
+                        stack.under = [MTMathStackConstruction mathListWithList:arg];
+                        break;
+                }
+            }
+            stack.displayClass = spec.inheritsClass
+                ? [MTMathAtomFactory inheritedDisplayClassForBase:base]
+                : spec.displayClass;
             return stack;
         }
     }

--- a/iosMath/render/internal/MTTypesetter.m
+++ b/iosMath/render/internal/MTTypesetter.m
@@ -2078,8 +2078,12 @@ typedef NS_ENUM(NSUInteger, MTStackRole) {
     MTDisplay* overDisp  = stack.over  ? [self buildStackConstruction:stack.over  forWidth:targetWidth role:kMTStackRoleOver  range:stack.indexRange] : nil;
     MTDisplay* underDisp = stack.under ? [self buildStackConstruction:stack.under forWidth:targetWidth role:kMTStackRoleUnder range:stack.indexRange] : nil;
 
-    CGFloat overGap  = _styleFont.mathTable.stretchStackGapAboveMin;
-    CGFloat underGap = _styleFont.mathTable.stretchStackGapBelowMin;
+    CGFloat overGap  = (stack.over.kind  == kMTMathStackConstructionMathList)
+                       ? [self upperLimitGapFor:overDisp]
+                       : _styleFont.mathTable.stretchStackGapAboveMin;
+    CGFloat underGap = (stack.under.kind == kMTMathStackConstructionMathList)
+                       ? [self lowerLimitGapFor:underDisp]
+                       : _styleFont.mathTable.stretchStackGapBelowMin;
 
     CGFloat totalWidth = MAX(baseDisplay.width,
                          MAX(overDisp  ? overDisp.width  : 0,

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -2827,4 +2827,43 @@ static NSArray* getTestDataLargeDelimiters() {
     XCTAssertNil(inner.under);
 }
 
+- (void)testOversetRoundTrip
+{
+    NSArray<NSArray*>* cases = @[
+        @[@"\\stackrel{?}{=}", @"\\stackrel{?}{=}"],
+        @[@"\\stackbin{x}{+}", @"\\stackbin{x}{+}"],
+        @[@"\\underset{b}{x}", @"\\underset{b}{x}"],
+        @[@"\\overset{a}{x}",  @"\\overset{a}{x}"],
+        @[@"\\overset{a}{+}",  @"\\stackbin{a}{+}"],  // inherited Binary canonicalizes to \stackbin
+        @[@"\\overset{!}{=}",  @"\\stackrel{!}{=}"],  // inherited Relation canonicalizes to \stackrel
+    ];
+    for (NSArray* c in cases) {
+        MTMathList* list = [MTMathListBuilder buildFromString:c[0]];
+        XCTAssertNotNil(list, @"%@", c[0]);
+        NSString* latex = [MTMathListBuilder mathListToString:list];
+        XCTAssertEqualObjects(latex, c[1], @"%@", c[0]);
+        // Round-trip is at least an equivalent fixed point (re-parse + re-serialize stable).
+        NSString* latex2 = [MTMathListBuilder mathListToString:[MTMathListBuilder buildFromString:latex]];
+        XCTAssertEqualObjects(latex2, c[1], @"%@", c[0]);
+    }
+}
+
+- (void)testProgrammaticBothRowsSerializeNested
+{
+    // A stack carrying both over and under MathList rows emits nested commands.
+    MTMathStack* stack = [MTMathStack new];
+    MTMathList* base = [MTMathList new];
+    [base addAtom:[MTMathAtomFactory atomForCharacter:'X']];
+    MTMathList* top = [MTMathList new];
+    [top addAtom:[MTMathAtomFactory atomForCharacter:'a']];
+    MTMathList* bot = [MTMathList new];
+    [bot addAtom:[MTMathAtomFactory atomForCharacter:'b']];
+    stack.innerList = base;
+    stack.over = [MTMathStackConstruction mathListWithList:top];
+    stack.under = [MTMathStackConstruction mathListWithList:bot];
+    MTMathList* list = [MTMathList new];
+    [list addAtom:stack];
+    XCTAssertEqualObjects([MTMathListBuilder mathListToString:list], @"\\underset{b}{\\overset{a}{X}}");
+}
+
 @end

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -2760,4 +2760,71 @@ static NSArray* getTestDataLargeDelimiters() {
     XCTAssertEqual([MTMathAtomFactory inheritedDisplayClassForBase:[MTMathList new]], kMTMathAtomOrdinary);
 }
 
+- (void)testOversetParsesStructureAndClass
+{
+    NSArray<NSArray*>* cases = @[
+        // latex, expected displayClass, hasOver, hasUnder
+        @[@"\\stackrel{?}{=}", @(kMTMathAtomRelation),       @YES, @NO],
+        @[@"\\stackbin{x}{+}", @(kMTMathAtomBinaryOperator), @YES, @NO],
+        @[@"\\overset{!}{=}",  @(kMTMathAtomRelation),       @YES, @NO],
+        @[@"\\overset{a}{+}",  @(kMTMathAtomBinaryOperator), @YES, @NO],
+        @[@"\\overset{a}{x}",  @(kMTMathAtomOrdinary),       @YES, @NO],
+        @[@"\\overset{a}{x+y}",@(kMTMathAtomOrdinary),       @YES, @NO],
+        @[@"\\underset{b}{=}", @(kMTMathAtomRelation),       @NO,  @YES],
+        @[@"\\underset{b}{x}", @(kMTMathAtomOrdinary),       @NO,  @YES],
+    ];
+    for (NSArray* c in cases) {
+        NSString* latex = c[0];
+        MTMathList* list = [MTMathListBuilder buildFromString:latex];
+        XCTAssertNotNil(list, @"%@", latex);
+        XCTAssertEqual(list.atoms.count, 1u, @"%@", latex);
+        MTMathStack* stack = list.atoms[0];
+        XCTAssertEqual(stack.type, kMTMathAtomStack, @"%@", latex);
+        XCTAssertEqual(stack.displayClass, [c[1] unsignedIntegerValue], @"%@", latex);
+        XCTAssertNotNil(stack.innerList, @"%@", latex);
+        if ([c[2] boolValue]) {
+            XCTAssertNotNil(stack.over, @"%@", latex);
+            XCTAssertEqual(stack.over.kind, kMTMathStackConstructionMathList, @"%@", latex);
+        } else {
+            XCTAssertNil(stack.over, @"%@", latex);
+        }
+        if ([c[3] boolValue]) {
+            XCTAssertNotNil(stack.under, @"%@", latex);
+            XCTAssertEqual(stack.under.kind, kMTMathStackConstructionMathList, @"%@", latex);
+        } else {
+            XCTAssertNil(stack.under, @"%@", latex);
+        }
+    }
+}
+
+- (void)testOversetMissingArgsAreGraceful
+{
+    // Matches \frac: missing args at EOF produce empty rows, no crash, no parse error.
+    for (NSString* latex in @[@"\\overset", @"\\overset{a}", @"\\underset", @"\\stackrel{a}"]) {
+        NSError* error = nil;
+        MTMathList* list = [MTMathListBuilder buildFromString:latex error:&error];
+        XCTAssertNotNil(list, @"%@", latex);
+        XCTAssertNil(error, @"%@", latex);
+        XCTAssertEqual(list.atoms.count, 1u, @"%@", latex);
+        XCTAssertEqual(((MTMathAtom*)list.atoms[0]).type, kMTMathAtomStack, @"%@", latex);
+    }
+}
+
+- (void)testOversetNestingParse
+{
+    // \underset{b}{\overset{a}{X}} -> outer under-stack whose base is an inner over-stack.
+    MTMathList* list = [MTMathListBuilder buildFromString:@"\\underset{b}{\\overset{a}{X}}"];
+    XCTAssertNotNil(list);
+    XCTAssertEqual(list.atoms.count, 1u);
+    MTMathStack* outer = list.atoms[0];
+    XCTAssertEqual(outer.type, kMTMathAtomStack);
+    XCTAssertNotNil(outer.under);
+    XCTAssertNil(outer.over);
+    XCTAssertEqual(outer.innerList.atoms.count, 1u);
+    MTMathStack* inner = outer.innerList.atoms[0];
+    XCTAssertEqual(inner.type, kMTMathAtomStack);
+    XCTAssertNotNil(inner.over);
+    XCTAssertNil(inner.under);
+}
+
 @end

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -2712,4 +2712,52 @@ static NSArray* getTestDataLargeDelimiters() {
     XCTAssertEqualObjects(((MTTextAtom *)list.atoms[0]).text, @"Привет");
 }
 
+- (void)testStackCommandSpecArgRoles
+{
+    MTMathStackCommandSpec* overset = [MTMathAtomFactory stackCommandSpec:@"overset"];
+    XCTAssertNotNil(overset);
+    XCTAssertEqualObjects(overset.argRoles, (@[@(kMTStackArgOver), @(kMTStackArgBase)]));
+    XCTAssertTrue(overset.inheritsClass);
+
+    MTMathStackCommandSpec* underset = [MTMathAtomFactory stackCommandSpec:@"underset"];
+    XCTAssertEqualObjects(underset.argRoles, (@[@(kMTStackArgUnder), @(kMTStackArgBase)]));
+    XCTAssertTrue(underset.inheritsClass);
+
+    MTMathStackCommandSpec* stackrel = [MTMathAtomFactory stackCommandSpec:@"stackrel"];
+    XCTAssertFalse(stackrel.inheritsClass);
+    XCTAssertEqual(stackrel.displayClass, kMTMathAtomRelation);
+
+    MTMathStackCommandSpec* stackbin = [MTMathAtomFactory stackCommandSpec:@"stackbin"];
+    XCTAssertEqual(stackbin.displayClass, kMTMathAtomBinaryOperator);
+
+    // Existing stretchy command keeps a base-only role list.
+    MTMathStackCommandSpec* over = [MTMathAtomFactory stackCommandSpec:@"overrightarrow"];
+    XCTAssertEqualObjects(over.argRoles, (@[@(kMTStackArgBase)]));
+    XCTAssertFalse(over.inheritsClass);
+
+    XCTAssertNil([MTMathAtomFactory stackCommandSpec:@"overfoo"]);
+}
+
+- (void)testInheritedDisplayClassForBase
+{
+    MTMathList* (^one)(unichar) = ^MTMathList*(unichar ch) {
+        MTMathList* l = [MTMathList new];
+        [l addAtom:[MTMathAtomFactory atomForCharacter:ch]];
+        return l;
+    };
+    // Lone relation '=' -> Relation; lone binary '+' -> Binary (intrinsic, pre-finalize).
+    XCTAssertEqual([MTMathAtomFactory inheritedDisplayClassForBase:one('=')], kMTMathAtomRelation);
+    XCTAssertEqual([MTMathAtomFactory inheritedDisplayClassForBase:one('+')], kMTMathAtomBinaryOperator);
+    // Lone ordinary letter -> Ordinary.
+    XCTAssertEqual([MTMathAtomFactory inheritedDisplayClassForBase:one('x')], kMTMathAtomOrdinary);
+    // Multi-atom base -> Ordinary.
+    MTMathList* multi = [MTMathList new];
+    [multi addAtom:[MTMathAtomFactory atomForCharacter:'x']];
+    [multi addAtom:[MTMathAtomFactory atomForCharacter:'+']];
+    [multi addAtom:[MTMathAtomFactory atomForCharacter:'y']];
+    XCTAssertEqual([MTMathAtomFactory inheritedDisplayClassForBase:multi], kMTMathAtomOrdinary);
+    // Empty base -> Ordinary.
+    XCTAssertEqual([MTMathAtomFactory inheritedDisplayClassForBase:[MTMathList new]], kMTMathAtomOrdinary);
+}
+
 @end

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -2622,4 +2622,50 @@
     XCTAssertLessThan(sd.over.ascent, sd.base.ascent);
 }
 
+- (void)testOversetUsesLimitGapAndCentering
+{
+    MTMathListDisplay* display = [self displayForLaTeX:@"\\overset{a}{X}"];
+    XCTAssertNotNil(display);
+    XCTAssertEqual(display.subDisplays.count, 1u);
+    MTStackDisplay* stack = (MTStackDisplay*)display.subDisplays[0];
+    XCTAssertTrue([stack isKindOfClass:[MTStackDisplay class]]);
+    XCTAssertNotNil(stack.over);
+    XCTAssertNil(stack.under);
+    XCTAssertTrue([stack.over isKindOfClass:[MTMathListDisplay class]]);
+
+    // 6.4-b: over-row uses the operator-limit gap, NOT stretchStackGapAboveMin.
+    CGFloat limitGap = MAX(self.font.mathTable.upperLimitGapMin,
+                           self.font.mathTable.upperLimitBaselineRiseMin - stack.over.descent);
+    CGFloat expectedOverY = stack.base.ascent + limitGap + stack.over.descent;
+    XCTAssertEqualWithAccuracy(stack.over.position.y, expectedOverY, 0.01);
+
+    // total width = max(base, over); narrower row is centered.
+    CGFloat totalWidth = MAX(stack.base.width, stack.over.width);
+    XCTAssertEqualWithAccuracy(display.width, totalWidth, 0.01);
+    XCTAssertEqualWithAccuracy(stack.over.position.x, (totalWidth - stack.over.width) / 2.0, 0.01);
+    XCTAssertEqualWithAccuracy(stack.base.position.x, (totalWidth - stack.base.width) / 2.0, 0.01);
+}
+
+- (void)testUndersetUsesLowerLimitGap
+{
+    MTMathListDisplay* display = [self displayForLaTeX:@"\\underset{b}{X}"];
+    MTStackDisplay* stack = (MTStackDisplay*)display.subDisplays[0];
+    XCTAssertNotNil(stack.under);
+    XCTAssertNil(stack.over);
+    CGFloat limitGap = MAX(self.font.mathTable.lowerLimitGapMin,
+                           self.font.mathTable.lowerLimitBaselineDropMin - stack.under.ascent);
+    CGFloat expectedUnderY = -(stack.base.descent + limitGap + stack.under.ascent);
+    XCTAssertEqualWithAccuracy(stack.under.position.y, expectedUnderY, 0.01);
+}
+
+- (void)testStretchyOverrightarrowStillUsesStretchGap
+{
+    // Regression: the stretchy path keeps stretchStackGapAboveMin (unchanged by 6.4-b).
+    MTMathListDisplay* display = [self displayForLaTeX:@"\\overrightarrow{x}"];
+    MTStackDisplay* stack = (MTStackDisplay*)display.subDisplays[0];
+    CGFloat gapAbove = self.font.mathTable.stretchStackGapAboveMin;
+    CGFloat expectedAscent = stack.base.ascent + gapAbove + stack.over.ascent + stack.over.descent;
+    XCTAssertEqualWithAccuracy(display.ascent, expectedAscent, 0.01);
+}
+
 @end

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -2668,4 +2668,61 @@
     XCTAssertEqualWithAccuracy(display.ascent, expectedAscent, 0.01);
 }
 
+// Helper for the spacing tests below. For `a Z b` where Z renders as its own
+// MTStackDisplay, isolates the inter-element space (left + right) around Z by
+// subtracting Z's width from the gap between the surrounding `a` and `b` lines.
+- (CGFloat)gapAroundStackInLaTeX:(NSString*)latex
+{
+    MTMathListDisplay* display = [self displayForLaTeX:latex];
+    XCTAssertEqual(display.subDisplays.count, 3u, @"%@: expected [line(a), stack, line(b)]", latex);
+    MTDisplay* a = display.subDisplays[0];
+    MTStackDisplay* z = (MTStackDisplay*)display.subDisplays[1];
+    MTDisplay* b = display.subDisplays[2];
+    XCTAssertTrue([z isKindOfClass:[MTStackDisplay class]], @"%@: middle is not a stack", latex);
+    return (b.position.x - (a.position.x + a.width)) - z.width;
+}
+
+- (void)testStackrelForcesRelationSpacing
+{
+    // 6.3: \stackrel forces Relation class regardless of base; spacing must match.
+    CGFloat stackrelGap = [self gapAroundStackInLaTeX:@"a\\stackrel{?}{=}b"];
+    CGFloat oversetOrdGap = [self gapAroundStackInLaTeX:@"a\\overset{?}{c}b"];
+    // Relation -> Ord and Ord -> Relation are both NSThick; Ord -> Ord is None.
+    // So the relation case must have strictly more space than the ordinary case.
+    XCTAssertGreaterThan(stackrelGap, oversetOrdGap + 0.5);
+}
+
+- (void)testOversetInheritsBinaryClassForSpacing
+{
+    // 6.3 inheritance: \overset over a lone Binary base inherits Binary class.
+    CGFloat binGap = [self gapAroundStackInLaTeX:@"a\\overset{x}{+}b"];
+    CGFloat ordGap = [self gapAroundStackInLaTeX:@"a\\overset{x}{c}b"];
+    CGFloat relGap = [self gapAroundStackInLaTeX:@"a\\stackrel{x}{=}b"];
+    // Binary -> Ord is NSMedium, larger than Ord-Ord (None) and smaller than Relation (NSThick).
+    XCTAssertGreaterThan(binGap, ordGap + 0.5);
+    XCTAssertLessThan(binGap, relGap - 0.5);
+}
+
+- (void)testOversetRowRendersAtScriptScriptWhenNestedInSuperscript
+{
+    // 6.2-a: stack rows derive their style live from the surrounding style.
+    // At display style the over-row is script; inside a superscript (script) the
+    // over-row must drop further to scriptScript and be visibly smaller.
+    MTMathListDisplay* baseline = [self displayForLaTeX:@"\\overset{a}{=}"];
+    XCTAssertEqual(baseline.subDisplays.count, 1u);
+    MTStackDisplay* baselineStack = (MTStackDisplay*)baseline.subDisplays[0];
+    XCTAssertTrue([baselineStack isKindOfClass:[MTStackDisplay class]]);
+
+    MTMathListDisplay* nested = [self displayForLaTeX:@"x^{\\overset{a}{=}}"];
+    XCTAssertEqual(nested.subDisplays.count, 2u);
+    MTMathListDisplay* superscript = (MTMathListDisplay*)nested.subDisplays[1];
+    XCTAssertTrue([superscript isKindOfClass:[MTMathListDisplay class]]);
+    XCTAssertEqual(superscript.type, kMTLinePositionSuperscript);
+    XCTAssertEqual(superscript.subDisplays.count, 1u);
+    MTStackDisplay* nestedStack = (MTStackDisplay*)superscript.subDisplays[0];
+    XCTAssertTrue([nestedStack isKindOfClass:[MTStackDisplay class]]);
+
+    XCTAssertLessThan(nestedStack.over.ascent, baselineStack.over.ascent);
+}
+
 @end


### PR DESCRIPTION
## Goal

Parse, lay out, and serialize `\overset`, `\underset`, `\stackrel`, `\stackbin` end-to-end through the existing `MTMathStack` IR and `makeStack:` path. Rows render at script style (derived live) with TeX operator-limit gap metrics shared with the `\sum\limits` path. Math class is forced (`\stackrel`→Relation, `\stackbin`→Binary) or inherited from a lone Bin/Rel base atom (`\overset`/`\underset`).

This is **PR 2 of 2**, stacked on PR 1.

## Stack

- **PR 1** (base): #218 — behavior-preserving refactor (remove dead row-style state, share limit-gap math). This PR targets `feature/overset-pr1`.

## Design docs

- Plan: `docs/plans/2026-06-07-overset-underset-stackrel.md` (items 3–6)
- LLD: `docs/lld/2026-06-07-overset-underset-stackrel.md`

## Commits

- `[item 3]` Add public `MTMathStackCommandSpec`, four-command table, class-inheritance helper
- `[item 4]` Parse `\overset`/`\underset`/`\stackrel`/`\stackbin` via spec-driven builder loop
- `[item 5]` Use operator-limit gaps for MathList stack rows in `makeStack:`
- `[item 6]` Serialize MathList stacks to `\overset`/`\underset`/`\stackrel`/`\stackbin`

## Verification

- `swift test` — 278 tests, 0 failures (per-commit verified: each of the 4 commits independently green).
- Xcode iOS scheme (`iosMath`): 242 tests, **TEST SUCCEEDED**.

## Deviation worth a reviewer's eye

The item 6 commit additionally fixes a **pre-existing** Xcode build break (not caused by this feature): the earlier SPM header-import change (#215) rewrote public render-header imports to `lib/MTMathList.h` but never updated the `.xcodeproj` header search paths, so the Xcode targets failed to build. To meet the plan's "both Xcode schemes green" requirement, this PR adds the four `HEADER_SEARCH_PATHS` subdirectories and `USE_HEADERMAP = NO` to `iosMath.xcodeproj` and `MacOSMath.xcodeproj`. This is build-config only (no source behavior change) but is outside the feature's nominal scope — flagging it explicitly.

Note: the `MacOSMath` scheme has no test targets configured in its TestAction (pre-existing); macOS test coverage is provided by `swift test`. The macOS scheme **BUILD SUCCEEDED** after the header fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)