### PR TITLE
fix: swap \frac/\atop literals in MTFraction.stringValue (FUN-3)

### DIFF
--- a/iosMath/lib/MTMathList.m
+++ b/iosMath/lib/MTMathList.m
@@ -339,9 +339,9 @@ static NSString* fractionCommandForDelimiterPair(NSString* leftDelimiter, NSStri
 {
     NSMutableString* str = [[NSMutableString alloc] init];
     if (self.hasRule) {
-        [str appendString:@"\\atop"];
-    } else {
         [str appendString:@"\\frac"];
+    } else {
+        [str appendString:@"\\atop"];
     }
     if (self.leftDelimiter || self.rightDelimiter) {
         [str appendFormat:@"[%@][%@]", self.leftDelimiter, self.rightDelimiter];

--- a/iosMathTests/MTMathListTest.m
+++ b/iosMathTests/MTMathListTest.m
@@ -818,4 +818,33 @@ _XCTPrimitiveAssertNotEqual(test, expression1, @#expression1, expression2, @#exp
     }
 }
 
+// Regression test for FUN-3: MTFraction.stringValue had \frac and \atop swapped.
+- (void) testFractionStringValueRuledUsesFrac
+{
+    // A fraction created with hasRule:YES is the standard ruled \frac form.
+    MTFraction *frac = [[MTFraction alloc] initWithRule:YES];
+    frac.numerator = [MTMathList new];
+    frac.denominator = [MTMathList new];
+
+    NSString *sv = frac.stringValue;
+    XCTAssertTrue([sv containsString:@"\\frac"],
+                  @"ruled fraction stringValue should contain \\frac, got: %@", sv);
+    XCTAssertFalse([sv containsString:@"\\atop"],
+                   @"ruled fraction stringValue must not contain \\atop, got: %@", sv);
+}
+
+- (void) testFractionStringValueRulelessUsesAtop
+{
+    // A fraction created with hasRule:NO is the rule-less \atop form.
+    MTFraction *frac = [[MTFraction alloc] initWithRule:NO];
+    frac.numerator = [MTMathList new];
+    frac.denominator = [MTMathList new];
+
+    NSString *sv = frac.stringValue;
+    XCTAssertTrue([sv containsString:@"\\atop"],
+                  @"rule-less fraction stringValue should contain \\atop, got: %@", sv);
+    XCTAssertFalse([sv containsString:@"\\frac"],
+                   @"rule-less fraction stringValue must not contain \\frac, got: %@", sv);
+}
+
 @end


### PR DESCRIPTION
## Summary

- Fixes FUN-3: `-[MTFraction stringValue]` had `\frac` and `\atop` swapped — it emitted `\atop` for ruled fractions (`hasRule:YES`) and `\frac` for rule-less fractions (`hasRule:NO`), exactly backwards.
- The fix is a one-line swap of the two string literals in `iosMath/lib/MTMathList.m`, bringing `stringValue` into agreement with the already-correct `-[MTFraction appendLaTeXToString:]` and standard LaTeX semantics.
- Two regression tests added to `iosMathTests/MTMathListTest.m` (in `MTMathAtomTest`) that assert the correct command appears in `stringValue` for each case. Tests were written first and confirmed to fail before the fix.

## Linked issue

FUN-3 from `issues_simple.md`: *MTFraction.stringValue swaps `\frac` and `\atop`* (Severity: Low)

## Test plan

- [x] `testFractionStringValueRuledUsesFrac` — ruled fraction (`hasRule:YES`) stringValue contains `\frac`, not `\atop`
- [x] `testFractionStringValueRulelessUsesAtop` — rule-less fraction (`hasRule:NO`) stringValue contains `\atop`, not `\frac`
- [x] All 283 existing tests continue to pass (`swift test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)