### PR TITLE
Example apps — gallery + test entries for \overset/\underset/\stackrel/\stackbin

### DIFF
--- a/MacOSMathExample/AppDelegate.m
+++ b/MacOSMathExample/AppDelegate.m
@@ -109,7 +109,7 @@ static const NSUInteger kMacFontCount = 8;
     // --- Demo formulae — LaTeX strings from MathExamples.h ---
     static const CGFloat demoHeights[] = {
         60, 40, 120, 60, 40, 40, 40, 40, 60, 40, 40, 60, 60, 60, 70, 70, 140, 60, 90, 60,
-        50
+        60
     };
     NSArray<NSString*>* demoFormulas = MathDemoFormulas();
     for (NSUInteger i = 0; i < demoFormulas.count; i++) {

--- a/MacOSMathExample/AppDelegate.m
+++ b/MacOSMathExample/AppDelegate.m
@@ -108,7 +108,8 @@ static const NSUInteger kMacFontCount = 8;
 
     // --- Demo formulae — LaTeX strings from MathExamples.h ---
     static const CGFloat demoHeights[] = {
-        60, 40, 120, 60, 40, 40, 40, 40, 60, 40, 40, 60, 60, 60, 70, 70, 140, 60, 90, 60
+        60, 40, 120, 60, 40, 40, 40, 40, 60, 40, 40, 60, 60, 60, 70, 70, 140, 60, 90, 60,
+        50
     };
     NSArray<NSString*>* demoFormulas = MathDemoFormulas();
     for (NSUInteger i = 0; i < demoFormulas.count; i++) {
@@ -143,7 +144,8 @@ static const NSUInteger kMacFontCount = 8;
         40, 40, 50, 60, 50, 40, 70, 40,
         40, 40, 40, 40, 40, 50, 50, 60, 50, 50, 40, 70,
         80, 150, 60, 60, 50, 60, 50,
-        40, 60, 60, 70, 60, 60, 70, 60, 60, 60, 60
+        40, 60, 60, 70, 60, 60, 70, 60, 60, 60, 60,
+        70, 40, 40, 50, 40, 50
     };
     NSArray<NSString*>* testFormulas = MathTestFormulas();
     for (NSUInteger i = 0; i < testFormulas.count; i++) {

--- a/MathExamples.h
+++ b/MathExamples.h
@@ -274,13 +274,14 @@ static inline NSArray<NSString*>* MathTestFormulas(void) {
         @"\\textbf{Теорема:} \\; a^2 + b^2 = c^2 \\quad (\\textit{Пифагор})",
         // 86: \stackrel — Taylor series with a "by definition" relation
         @"f(x) \\stackrel{\\text{def}}{=} \\sum_{n=0}^{\\infty} \\frac{f^{(n)}(0)}{n!} x^n",
-        // 87: \stackbin — decorated plus, forced Binary class spacing
-        @"a \\stackbin{\\Delta}{+} b",
+        // 87: \stackbin — decorated plus keeps Binary-class spacing (contrast with bare +)
+        @"a + b \\quad a \\stackbin{\\Delta}{+} b",
         // 88: \overset — class inherits from base (Relation, Binary, Ordinary)
         @"a \\overset{!}{=} b \\quad x \\overset{?}{+} y \\quad \\overset{*}{A}",
-        // 89: \underset — alternative limit notation under a named operator
-        @"\\underset{x \\to 0}{\\lim}\\, \\frac{\\sin x}{x} = 1",
-        // 90: Spacing contrast — \stackrel (Relation) vs \overset (Ordinary) on the same Ord base
+        // 89: \underset — under-stack on an operator that has no natural limits subscript
+        @"\\underset{x \\in \\mathbb{R}}{\\sup}\\, f(x)",
+        // 90: Spacing contrast — Relation atoms get more horizontal padding than Ord.
+        //     \stackrel forces Relation class; \overset inherits Ord from base `c`.
         @"a \\stackrel{?}{c} b \\quad a \\overset{?}{c} b",
         // 91: Nested stacks — \overset inside the over-arg of \stackrel
         @"a \\stackrel{\\overset{n}{\\to}}{=} b",

--- a/MathExamples.h
+++ b/MathExamples.h
@@ -84,6 +84,8 @@ static inline NSArray<NSString*>* MathDemoFormulas(void) {
          "\\left( o_t - \\hat{\\mu}_m^{(s)} \\right) ^T \\cal C_m^{(s)-1} \\right) ",
         // 19: Piecewise function
         @"f(x) = \\begin{cases}\\frac{e^x}{2} & x \\geq 0 \\\\1 & x < 0\\end{cases}",
+        // 20: Ridge regression — argmin via \underset
+        @"\\hat\\theta = \\underset{\\theta}{\\arg\\min}\\, \\|y - X\\theta\\|^2 + \\lambda \\|\\theta\\|^2",
     ];
 }
 
@@ -270,6 +272,18 @@ static inline NSArray<NSString*>* MathTestFormulas(void) {
          "\\textrm{ where } \\texttt{f}(x) = x^2",
         // 85: Styled non-Latin theorem label preceding a math statement
         @"\\textbf{Теорема:} \\; a^2 + b^2 = c^2 \\quad (\\textit{Пифагор})",
+        // 86: \stackrel — Taylor series with a "by definition" relation
+        @"f(x) \\stackrel{\\text{def}}{=} \\sum_{n=0}^{\\infty} \\frac{f^{(n)}(0)}{n!} x^n",
+        // 87: \stackbin — decorated plus, forced Binary class spacing
+        @"a \\stackbin{\\Delta}{+} b",
+        // 88: \overset — class inherits from base (Relation, Binary, Ordinary)
+        @"a \\overset{!}{=} b \\quad x \\overset{?}{+} y \\quad \\overset{*}{A}",
+        // 89: \underset — alternative limit notation under a named operator
+        @"\\underset{x \\to 0}{\\lim}\\, \\frac{\\sin x}{x} = 1",
+        // 90: Spacing contrast — \stackrel (Relation) vs \overset (Ordinary) on the same Ord base
+        @"a \\stackrel{?}{c} b \\quad a \\overset{?}{c} b",
+        // 91: Nested stacks — \overset inside the over-arg of \stackrel
+        @"a \\stackrel{\\overset{n}{\\to}}{=} b",
     ];
 }
 

--- a/SwiftMathExample/ContentView.swift
+++ b/SwiftMathExample/ContentView.swift
@@ -84,6 +84,7 @@ private let namedExampleMeta: [NamedFormulaMeta] = [
     NamedFormulaMeta(title: "2×2 matrix multiplication"),
     NamedFormulaMeta(title: "EM algorithm Q-function"),
     NamedFormulaMeta(title: "Piecewise function"),
+    NamedFormulaMeta(title: "Ridge regression"),
 ]
 
 private let namedExamples: [NamedFormula] = {

--- a/SwiftMathExample/ContentView.swift
+++ b/SwiftMathExample/ContentView.swift
@@ -238,18 +238,24 @@ private struct GalleryTab: View {
         40, 40, 50, 60, 50, 40, 70, 40,
         40, 40, 40, 40, 40, 50, 50, 60, 50, 50, 40, 70,
         80, 150, 60, 60, 50, 60, 50,
-        40, 60, 60, 70, 60, 60, 70, 60, 60, 60, 60
+        40, 60, 60, 70, 60, 60, 70, 60, 60, 60, 60,
+        70, 40, 40, 50, 40, 50
     ]
 
-    private let testFormulas: [String] = MathTestFormulas()
+    private static let testFormulas: [String] = {
+        let formulas = MathTestFormulas()
+        precondition(formulas.count == testHeights.count,
+                     "testHeights (\(testHeights.count)) must match MathTestFormulas (\(formulas.count))")
+        return formulas
+    }()
 
     var body: some View {
         NavigationView {
             ScrollView {
                 VStack(alignment: .leading, spacing: 10) {
-                    ForEach(testFormulas.indices, id: \.self) { i in
+                    ForEach(Self.testFormulas.indices, id: \.self) { i in
                         MathLabel(
-                            latex: testFormulas[i],
+                            latex: Self.testFormulas[i],
                             fontSize: fontSize,
                             mode: testMode(at: i),
                             alignment: testAlignment(at: i),

--- a/iosMathExample/example/ViewController.m
+++ b/iosMathExample/example/ViewController.m
@@ -144,7 +144,8 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
     contentFillsWidth.active = YES;
     // Demo formulae — LaTeX strings from MathExamples.h
     static const CGFloat demoHeights[] = {
-        60, 40, 120, 60, 40, 40, 40, 40, 60, 40, 40, 60, 60, 60, 70, 70, 140, 60, 90, 60
+        60, 40, 120, 60, 40, 40, 40, 40, 60, 40, 40, 60, 60, 60, 70, 70, 140, 60, 90, 60,
+        50
     };
     NSArray<NSString*>* demoFormulas = MathDemoFormulas();
     for (NSUInteger i = 0; i < demoFormulas.count; i++) {
@@ -179,7 +180,8 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
         40, 40, 50, 60, 50, 40, 70, 40,
         40, 40, 40, 40, 40, 50, 50, 60, 50, 50, 40, 70,
         80, 150, 60, 60, 50, 60, 50,
-        40, 60, 60, 70, 60, 60, 70, 60, 60, 60, 60
+        40, 60, 60, 70, 60, 60, 70, 60, 60, 60, 60,
+        70, 40, 40, 50, 40, 50
     };
     NSArray<NSString*>* testFormulas = MathTestFormulas();
     for (NSUInteger i = 0; i < testFormulas.count; i++) {

--- a/iosMathExample/example/ViewController.m
+++ b/iosMathExample/example/ViewController.m
@@ -145,7 +145,7 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
     // Demo formulae — LaTeX strings from MathExamples.h
     static const CGFloat demoHeights[] = {
         60, 40, 120, 60, 40, 40, 40, 40, 60, 40, 40, 60, 60, 60, 70, 70, 140, 60, 90, 60,
-        50
+        60
     };
     NSArray<NSString*>* demoFormulas = MathDemoFormulas();
     for (NSUInteger i = 0; i < demoFormulas.count; i++) {


### PR DESCRIPTION
## Summary

Follow-up to #219, which added the four over/under stack commands. This PR adds curated example-app entries showcasing them.

**Gallery (`MathDemoFormulas`)** — one famous equation:
- **Ridge regression** — `\hat\theta = \underset{\theta}{\arg\min}\, \|y - X\theta\|^2 + \lambda \|\theta\|^2` (the iconic `\underset{}{\arg\min}` idiom)

**Feature showcase (`MathTestFormulas`)** — six entries:
- `\stackrel` — Taylor series with `\stackrel{\text{def}}{=}`
- `\stackbin` — decorated plus, forced Binary class spacing
- `\overset` — class inheritance: Relation / Binary / Ordinary on the same construct
- `\underset` — alternative `\lim` notation
- Spacing contrast — `a\stackrel{?}{c}b` vs `a\overset{?}{c}b` (visualizes the PR #219 spacing invariant)
- Nested stacks — `\overset` inside `\stackrel`'s over-arg

Also extends the demo + test height arrays in `iosMathExample/example/ViewController.m` and `MacOSMathExample/AppDelegate.m`, and adds the matching `"Ridge regression"` title to `SwiftMathExample`'s `namedExampleMeta` (the file enforces a count-match precondition).

## Test plan
- [x] `swift build` — passes
- [x] `swift test` — 126 tests pass (no new code paths exercised; LaTeX uses constructs already covered by `MTMathListBuilderTest` / `MTTypesetterTest`)
- [x] iOS Xcode build — passes
- [x] macOS Xcode build — passes
- [ ] Run iosMathExample / MacOSMathExample / SwiftMathExample apps and visually verify the new gallery entry and test entries render as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)