### PR TITLE
fix(SEC-4): getDefaultStyle() falls back for unknown chars instead of crashing

### DIFF
--- a/iosMath/render/internal/MTTypesetter.m
+++ b/iosMath/render/internal/MTTypesetter.m
@@ -223,11 +223,11 @@ UTF32Char getDefaultStyle(unichar ch) {
         // . is treated as a number in our code, but it doesn't change fonts.
         return ch;
     } else {
-        @throw [NSException exceptionWithName:@"IllegalCharacter"
-                                       reason:[NSString stringWithFormat:@"Unknown character %d for default style.", ch]
-                                     userInfo:nil];
+        // Unknown character for the default style (e.g. a symbol placed in a
+        // Variable/Number atom via the public API). Fall back to the character
+        // as-is rather than crashing the render path. (SEC-4)
+        return ch;
     }
-    return ch;
 }
 
 static const UTF32Char kMTUnicodeMathCapitalScriptStart = 0x1D49C;

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -2745,4 +2745,20 @@
                          @"Display must contain at least one sub-display");
 }
 
+// SEC-4: the same getDefaultStyle() crash applied to Number atoms with an
+// unmapped nucleus (the code path is shared via changeFont). Cover it explicitly.
+- (void)testSEC4_nonDigitNumberNucleusDoesNotCrash {
+    MTMathList* mathList = [[MTMathList alloc] init];
+    MTMathAtom* atom = [MTMathAtom atomWithType:kMTMathAtomNumber value:@"@"];
+    [mathList addAtom:atom];
+
+    // Must not throw; must return a non-nil display object.
+    MTMathListDisplay* display = [MTTypesetter createLineForMathList:mathList
+                                                               font:self.font
+                                                              style:kMTLineStyleDisplay];
+    XCTAssertNotNil(display, @"Render of non-digit Number atom must not crash");
+    XCTAssertGreaterThan(display.subDisplays.count, (NSUInteger)0,
+                         @"Display must contain at least one sub-display");
+}
+
 @end

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -2725,4 +2725,24 @@
     XCTAssertLessThan(nestedStack.over.ascent, baselineStack.over.ascent);
 }
 
+// SEC-4: getDefaultStyle() formerly threw IllegalCharacter for non-Latin/digit/Greek
+// nuclei, crashing the host app on the render path. Verify the fallback is safe.
+- (void)testSEC4_nonLatinVariableNucleusDoesNotCrash {
+    // Build a math list with a Variable atom whose nucleus is '@' — a character
+    // outside Latin letters, digits, Greek letters, and '.'.
+    // Previously this caused an IllegalCharacter NSException in getDefaultStyle()
+    // which propagated uncaught through the render path and crashed the host app.
+    MTMathList* mathList = [[MTMathList alloc] init];
+    MTMathAtom* atom = [MTMathAtom atomWithType:kMTMathAtomVariable value:@"@"];
+    [mathList addAtom:atom];
+
+    // Must not throw; must return a non-nil display object.
+    MTMathListDisplay* display = [MTTypesetter createLineForMathList:mathList
+                                                               font:self.font
+                                                              style:kMTLineStyleDisplay];
+    XCTAssertNotNil(display, @"Render of non-Latin/Greek Variable atom must not crash");
+    XCTAssertGreaterThan(display.subDisplays.count, (NSUInteger)0,
+                         @"Display must contain at least one sub-display");
+}
+
 @end


### PR DESCRIPTION
## Summary

Fixes **SEC-4**: `getDefaultStyle()` in `MTTypesetter.m` threw an uncaught `IllegalCharacter` `NSException` when rendering any `Variable` or `Number` atom whose nucleus was not a Latin letter, digit, Greek letter, or `.`. The exception propagated uncaught through the entire render path (no `@try/@catch` exists in `MTMathUILabel`, `MTMathListDisplay`, or `MTTypesetter`) and crashed the host app.

- **Root cause**: the `else` branch of `getDefaultStyle()` (line 226) threw `NSException` instead of falling back.
- **Fix**: replace the `@throw` with `return ch;`, matching the existing idiom used by every other branch in that function (roman, number, `.`) and matching the "default treatment" comments throughout the file.
- **Impact**: previously-crashing nuclei (e.g. `@`, `#`, `$` placed in `kMTMathAtomVariable`) now render in the upright default font rather than crashing.

## Test plan

- [x] Added `testSEC4_nonLatinVariableNucleusDoesNotCrash` to `MTTypesetterTest.m` — builds a `Variable` atom with nucleus `@"@"` and asserts `createLineForMathList:font:style:` returns a non-nil display without throwing.
- [x] Test was written first (TDD), confirmed to fail with `IllegalCharacter` before the fix, and passes after.
- [x] All 293 Swift Package Manager tests pass (`swift test`).
- [x] No regressions: all 87 existing `MTTypesetterTest` cases pass.

## Explicitly deferred (out of scope per solution doc)

- **(b)** `addAtom:` / `setSubScript:` / `setSuperScript:` throws — converting these to `NSError`/`BOOL`-return forms would change public method signatures across `MTMathList.h` and all call sites. Architectural change, deferred.
- **(c)** `MTFontMathTable` init throw on plist version mismatch — only fires on build-integrity/packaging errors, not normal public-API usage. Deferred.

Full rationale in `.claude/engineering-manager/2026-06-11-issues/tasks/t4/solution.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)