### PR TITLE
fix(SEC-1): add recursion-depth cap to MTMathListBuilder to prevent stack overflow

### DIFF
--- a/iosMath/lib/MTMathListBuilder.h
+++ b/iosMath/lib/MTMathListBuilder.h
@@ -87,6 +87,8 @@ typedef NS_ENUM(NSUInteger, MTParseErrors) {
     MTParseErrorInternalError,
     /// Limit control applied incorrectly
     MTParseErrorInvalidLimits,
+    /// The LaTeX nesting depth exceeded the safe parsing limit.
+    MTParseErrorNestingTooDeep,
 };
 
 @end

--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -63,6 +63,7 @@ static const NSInteger kMTMaxRecursionDepth = 150;
         [str getCharacters:_chars range:NSMakeRange(0, str.length)];
         _currentChar = 0;
         _currentFontStyle = kMTFontStyleDefault;
+        _recursionDepth = 0;
     }
     return self;
 }

--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -37,6 +37,11 @@ NSString *const MTParseError = @"ParseError";
 
 @end
 
+// Maximum recursion depth for -buildInternal:oneCharOnly:stopChar:.
+// 150 is comfortably deeper than any realistic human-authored expression yet
+// far below the thousands of frames needed to overflow a 1 MB stack.
+static const NSInteger kMTMaxRecursionDepth = 150;
+
 @implementation MTMathListBuilder {
     unichar* _chars;
     int _currentChar;
@@ -45,6 +50,7 @@ NSString *const MTParseError = @"ParseError";
     MTEnvProperties* _currentEnv;
     MTFontStyle _currentFontStyle;
     BOOL _spacesAllowed;
+    NSInteger _recursionDepth;
 }
 
 - (instancetype)initWithString:(NSString *)str
@@ -159,6 +165,12 @@ NSString *const MTParseError = @"ParseError";
 
 - (MTMathList*)buildInternal:(BOOL) oneCharOnly stopChar:(unichar) stop
 {
+    if (_recursionDepth >= kMTMaxRecursionDepth) {
+        [self setError:MTParseErrorNestingTooDeep message:@"LaTeX nesting too deep"];
+        return nil;
+    }
+    _recursionDepth++;
+    @try {
     MTMathList* list = [MTMathList new];
     NSAssert(!(oneCharOnly && (stop > 0)), @"Cannot set both oneCharOnly and stopChar.");
     MTMathAtom* prevAtom = nil;
@@ -373,6 +385,9 @@ NSString *const MTParseError = @"ParseError";
         }
     }
     return list;
+    } @finally {
+        _recursionDepth--;
+    }
 }
 
 - (NSString*) readString

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -2977,4 +2977,53 @@ static NSArray* getTestDataLargeDelimiters() {
                    @"Expected %ld atoms, got %lu", (long)count, (unsigned long)list.atoms.count);
 }
 
+// SEC-1 Test 6: Deeply nested \left..\right groups are an independent re-entry
+// point into the chokepoint (buildInternal stopChar) and must also be capped.
+- (void)testDeeplyNestedLeftRightReturnsParseError
+{
+    const NSInteger depth = 1000;
+    // Produces: \left(\left(...1...\right)\right)
+    NSMutableString* str = [NSMutableString string];
+    for (NSInteger i = 0; i < depth; i++) {
+        [str appendString:@"\\left("];
+    }
+    [str appendString:@"1"];
+    for (NSInteger i = 0; i < depth; i++) {
+        [str appendString:@"\\right)"];
+    }
+
+    NSError* error = nil;
+    MTMathList* list = [MTMathListBuilder buildFromString:str error:&error];
+    XCTAssertNil(list, @"Expected nil for depth-%ld \\left..\\right nesting", (long)depth);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.domain, MTParseError);
+    XCTAssertEqual(error.code, MTParseErrorNestingTooDeep,
+                   @"Expected MTParseErrorNestingTooDeep, got %ld", (long)error.code);
+}
+
+// SEC-1 Test 7: Deeply nested environments (\begin{matrix}..\end{matrix}) reach
+// the chokepoint via buildTable -> buildInternal, so the table path is also
+// charged against the depth cap.
+- (void)testDeeplyNestedEnvironmentsReturnsParseError
+{
+    const NSInteger depth = 1000;
+    // Produces: \begin{matrix}\begin{matrix}...1...\end{matrix}\end{matrix}
+    NSMutableString* str = [NSMutableString string];
+    for (NSInteger i = 0; i < depth; i++) {
+        [str appendString:@"\\begin{matrix}"];
+    }
+    [str appendString:@"1"];
+    for (NSInteger i = 0; i < depth; i++) {
+        [str appendString:@"\\end{matrix}"];
+    }
+
+    NSError* error = nil;
+    MTMathList* list = [MTMathListBuilder buildFromString:str error:&error];
+    XCTAssertNil(list, @"Expected nil for depth-%ld nested-environment nesting", (long)depth);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.domain, MTParseError);
+    XCTAssertEqual(error.code, MTParseErrorNestingTooDeep,
+                   @"Expected MTParseErrorNestingTooDeep, got %ld", (long)error.code);
+}
+
 @end

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -2866,4 +2866,115 @@ static NSArray* getTestDataLargeDelimiters() {
     XCTAssertEqualObjects([MTMathListBuilder mathListToString:list], @"\\underset{b}{\\overset{a}{X}}");
 }
 
+#pragma mark - SEC-1: Recursion depth cap
+
+// SEC-1 Test 1: Thousands of nested braces must surface as a parse error,
+// not a stack-overflow crash. The test passing at all proves the process
+// did not crash.
+- (void)testDeeplyNestedBracesReturnsParseError
+{
+    const NSInteger depth = 1000;
+    NSMutableString* str = [NSMutableString string];
+    for (NSInteger i = 0; i < depth; i++) {
+        [str appendString:@"{"];
+    }
+    [str appendString:@"1"];
+    for (NSInteger i = 0; i < depth; i++) {
+        [str appendString:@"}"];
+    }
+
+    NSError* error = nil;
+    MTMathList* list = [MTMathListBuilder buildFromString:str error:&error];
+    XCTAssertNil(list, @"Expected nil for depth-%ld nesting", (long)depth);
+    XCTAssertNotNil(error, @"Expected error for depth-%ld nesting", (long)depth);
+    XCTAssertEqual(error.domain, MTParseError);
+    XCTAssertEqual(error.code, MTParseErrorNestingTooDeep,
+                   @"Expected MTParseErrorNestingTooDeep, got %ld", (long)error.code);
+}
+
+// SEC-1 Test 2: Thousands of nested superscripts must surface as a parse error.
+- (void)testDeeplyNestedSuperscriptsReturnsParseError
+{
+    const NSInteger depth = 1000;
+    // Produces: x^{x^{x^{...}}}
+    NSMutableString* str = [NSMutableString stringWithString:@"x"];
+    for (NSInteger i = 0; i < depth; i++) {
+        [str appendString:@"^{x"];
+    }
+    for (NSInteger i = 0; i < depth; i++) {
+        [str appendString:@"}"];
+    }
+
+    NSError* error = nil;
+    MTMathList* list = [MTMathListBuilder buildFromString:str error:&error];
+    XCTAssertNil(list, @"Expected nil for depth-%ld superscript nesting", (long)depth);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.domain, MTParseError);
+    XCTAssertEqual(error.code, MTParseErrorNestingTooDeep,
+                   @"Expected MTParseErrorNestingTooDeep, got %ld", (long)error.code);
+}
+
+// SEC-1 Test 3: Thousands of nested \frac commands must surface as a parse error.
+- (void)testDeeplyNestedFracReturnsParseError
+{
+    const NSInteger depth = 1000;
+    // Produces: \frac{1}{\frac{1}{\frac{...}}}
+    NSMutableString* str = [NSMutableString string];
+    for (NSInteger i = 0; i < depth; i++) {
+        [str appendString:@"\\frac{1}{"];
+    }
+    [str appendString:@"1"];
+    for (NSInteger i = 0; i < depth; i++) {
+        [str appendString:@"}"];
+    }
+
+    NSError* error = nil;
+    MTMathList* list = [MTMathListBuilder buildFromString:str error:&error];
+    XCTAssertNil(list, @"Expected nil for depth-%ld \\frac nesting", (long)depth);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.domain, MTParseError);
+    XCTAssertEqual(error.code, MTParseErrorNestingTooDeep,
+                   @"Expected MTParseErrorNestingTooDeep, got %ld", (long)error.code);
+}
+
+// SEC-1 Test 4: Moderate nesting (well under the cap) must still parse successfully.
+- (void)testModerateNestingStillParses
+{
+    // 20 nested brace groups — should be far below the 150-frame cap.
+    const NSInteger depth = 20;
+    NSMutableString* str = [NSMutableString string];
+    for (NSInteger i = 0; i < depth; i++) {
+        [str appendString:@"{"];
+    }
+    [str appendString:@"1"];
+    for (NSInteger i = 0; i < depth; i++) {
+        [str appendString:@"}"];
+    }
+
+    NSError* error = nil;
+    MTMathList* list = [MTMathListBuilder buildFromString:str error:&error];
+    XCTAssertNotNil(list, @"Expected successful parse for depth-%ld nesting", (long)depth);
+    XCTAssertNil(error, @"Unexpected error: %@", error);
+}
+
+// SEC-1 Test 5: Many sibling groups (wide-not-deep) must not trigger the cap.
+// This confirms the cap measures recursion depth, not the total number of groups
+// (i.e. the counter is correctly decremented on return).
+- (void)testManySiblingGroupsDoNotTriggerDepthCap
+{
+    // 500 single-character brace groups: {a}{b}{c}...
+    const NSInteger count = 500;
+    NSMutableString* str = [NSMutableString string];
+    for (NSInteger i = 0; i < count; i++) {
+        [str appendString:@"{a}"];
+    }
+
+    NSError* error = nil;
+    MTMathList* list = [MTMathListBuilder buildFromString:str error:&error];
+    XCTAssertNotNil(list, @"Expected successful parse for %ld sibling groups", (long)count);
+    XCTAssertNil(error, @"Unexpected error for sibling groups: %@", error);
+    XCTAssertEqual(list.atoms.count, (NSUInteger)count,
+                   @"Expected %ld atoms, got %lu", (long)count, (unsigned long)list.atoms.count);
+}
+
 @end


### PR DESCRIPTION
## Summary

Fixes **SEC-1** (Highest severity) from the iosMath security/quality audit.

`MTMathListBuilder` parsed LaTeX by recursive descent with no depth limit. Every nesting construct — `{…}`, `^`, `_`, `\frac`, `\sqrt`, accents, `\left…\right`, table cells — re-enters `-buildInternal:oneCharOnly:stopChar:`. A few thousand nested braces or `x^{x^{…}}` exhaust the 1 MB call stack and crash the host app with an uncatchable `SIGSEGV`. Any app rendering user-supplied or network-supplied LaTeX via `MTMathUILabel.latex` was exposed to a trivial denial-of-service.

### Changes

- **`iosMath/lib/MTMathListBuilder.h`** — adds `MTParseErrorNestingTooDeep` as an additive value at the end of `MTParseErrors` (existing codes unchanged).
- **`iosMath/lib/MTMathListBuilder.m`** — adds:
  - `static const NSInteger kMTMaxRecursionDepth = 150;`
  - `NSInteger _recursionDepth;` ivar (initialized to 0 in `-initWithString:`)
  - Guard at the top of `-buildInternal:oneCharOnly:stopChar:` (the sole recursion chokepoint): rejects inputs exceeding the cap with `setError:MTParseErrorNestingTooDeep` and returns `nil`; uses `@try/@finally` to balance the counter across all early-return paths.
- **`iosMathTests/MTMathListBuilderTest.m`** — five new tests (SEC-1 block):
  1. 1 000 nested braces → `MTParseErrorNestingTooDeep` (no crash)
  2. 1 000 nested superscripts → `MTParseErrorNestingTooDeep`
  3. 1 000 nested `\frac` → `MTParseErrorNestingTooDeep`
  4. 20-deep nesting (under cap) → parses successfully
  5. 500 sibling groups (wide, not deep) → parses successfully (confirms `@finally` decrement works)

The typesetter (`MTTypesetter`) is protected for free: a tree that would recurse >150 deep is never produced, so no change to the typesetter is needed.

## Test plan

- [x] `swift build` — clean build
- [x] `swift test` — all test suites pass (`MTMathListBuilderTest` included)