### PR TITLE
fix(REN-3): \color and \colorbox atoms now receive inter-element spacing

### DIFF
--- a/iosMath/render/internal/MTTypesetter.m
+++ b/iosMath/render/internal/MTTypesetter.m
@@ -635,6 +635,8 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
                 if (_currentLine.length > 0) {
                     [self addDisplayLine];
                 }
+                // Color is spaced as Ord (see getInterElementSpaceArrayIndexForType).
+                [self addInterElementSpace:prevNode currentType:atom.type];
                 MTMathColor* colorAtom = (MTMathColor*) atom;
                 MTDisplay* display = [MTTypesetter createLineForMathList:colorAtom.innerList font:_font style:_style];
                 display.localTextColor = [MTColor colorFromHexString:colorAtom.colorString];
@@ -649,6 +651,8 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
                 if (_currentLine.length > 0) {
                     [self addDisplayLine];
                 }
+                // Colorbox is spaced as Ord (see getInterElementSpaceArrayIndexForType).
+                [self addInterElementSpace:prevNode currentType:atom.type];
                 MTMathColorbox* colorboxAtom = (MTMathColorbox*) atom;
                 MTDisplay* display = [MTTypesetter createLineForMathList:colorboxAtom.innerList font:_font style:_style];
 

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -2804,11 +2804,8 @@
                   @"Second sub-display should be CTLine for '+z'");
     MTCTLineDisplay* plusZLine = (MTCTLineDisplay*)sub1;
 
-    // The gap between end of the color group and the start of "+z" is the
-    // binary-operator gap (4 mu) because the typesetter sees color (Ord) then BinOp.
-    // But because + is a BinaryOperator and z is Ordinary, the actual inter-element
-    // space between color (Ord) and + (BinOp, left of the line) is medium (4mu).
-    // The "+z" CTLine starts at the position where the typesetter placed it.
+    // The color group is Ord and '+' is a BinaryOperator, so the gap between them
+    // is the Ord->BinOp inter-element space: medium (4 mu).
     CGFloat expectedGap = 4.0 * self.font.mathTable.muUnit;
     CGFloat actualGap = plusZLine.position.x - (colorSub.position.x + colorSub.width);
     XCTAssertEqualWithAccuracy(actualGap, expectedGap, 0.01,

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -2725,4 +2725,95 @@
     XCTAssertLessThan(nestedStack.over.ascent, baselineStack.over.ascent);
 }
 
+// REN-3: \color atoms must receive inter-element spacing before the colored sub-display.
+// Before the fix, the colored group abutted the preceding binary operator with no gap.
+// After the fix, the medium binary-operator→ordinary gap (4 mu) separates them.
+
+- (void)testColorReceivesInterElementSpacingBeforeIt {
+    // x + \color{red}y  — the colored sub-display follows the binary operator +.
+    // The gap between the end of "x+" and the start of the colored group must equal
+    // the medium space (4mu = 4 * font.mathTable.muUnit) at display style.
+    MTMathListDisplay* display = [self displayForLaTeX:@"x+\\color{#ff0000}{y}"];
+    XCTAssertNotNil(display);
+    XCTAssertEqual(display.subDisplays.count, 2u,
+                   @"Expected CTLine for 'x+' and a colored sub-display");
+
+    MTDisplay* sub0 = display.subDisplays[0];
+    XCTAssertTrue([sub0 isKindOfClass:[MTCTLineDisplay class]],
+                  @"First sub-display should be a CTLine for 'x+'");
+    MTCTLineDisplay* xPlusLine = (MTCTLineDisplay*)sub0;
+
+    MTDisplay* sub1 = display.subDisplays[1];
+    XCTAssertTrue([sub1 isKindOfClass:[MTMathListDisplay class]],
+                  @"Second sub-display should be the colored MTMathListDisplay");
+    MTMathListDisplay* colorSub = (MTMathListDisplay*)sub1;
+    XCTAssertNotNil(colorSub.localTextColor, @"Colored display must carry a localTextColor");
+
+    // The medium binary-operator gap is 4 mu = 4 * muUnit (display style, non-script).
+    CGFloat expectedGap = 4.0 * self.font.mathTable.muUnit;
+    CGFloat actualGap = colorSub.position.x - (xPlusLine.position.x + xPlusLine.width);
+    XCTAssertEqualWithAccuracy(actualGap, expectedGap, 0.01,
+                               @"Expected medium binary-op gap of %.4f pt before \\color, got %.4f pt",
+                               expectedGap, actualGap);
+}
+
+- (void)testColorboxReceivesInterElementSpacingBeforeIt {
+    // x + \colorbox{red}y — same as testColorReceivesInterElementSpacingBeforeIt
+    // but for \colorbox (kMTMathAtomColorbox).
+    MTMathListDisplay* display = [self displayForLaTeX:@"x+\\colorbox{#ff0000}{y}"];
+    XCTAssertNotNil(display);
+    XCTAssertEqual(display.subDisplays.count, 2u,
+                   @"Expected CTLine for 'x+' and a colorbox sub-display");
+
+    MTDisplay* sub0 = display.subDisplays[0];
+    XCTAssertTrue([sub0 isKindOfClass:[MTCTLineDisplay class]],
+                  @"First sub-display should be a CTLine for 'x+'");
+    MTCTLineDisplay* xPlusLine = (MTCTLineDisplay*)sub0;
+
+    MTDisplay* sub1 = display.subDisplays[1];
+    XCTAssertTrue([sub1 isKindOfClass:[MTMathListDisplay class]],
+                  @"Second sub-display should be the colorbox MTMathListDisplay");
+    MTMathListDisplay* colorboxSub = (MTMathListDisplay*)sub1;
+    XCTAssertNotNil(colorboxSub.localBackgroundColor,
+                    @"Colorbox display must carry a localBackgroundColor");
+
+    CGFloat expectedGap = 4.0 * self.font.mathTable.muUnit;
+    CGFloat actualGap = colorboxSub.position.x - (xPlusLine.position.x + xPlusLine.width);
+    XCTAssertEqualWithAccuracy(actualGap, expectedGap, 0.01,
+                               @"Expected medium binary-op gap of %.4f pt before \\colorbox, got %.4f pt",
+                               expectedGap, actualGap);
+}
+
+- (void)testSpacingAfterColorGroupIsPreserved {
+    // Regression guard: spacing AFTER a \color group already worked via the spacing table.
+    // \color{red}{x} + z — the binary-operator gap after the colored group must still be present.
+    // The display structure is: [colored MTMathListDisplay, CTLine for "+z"].
+    MTMathListDisplay* display = [self displayForLaTeX:@"\\color{#ff0000}{x}+z"];
+    XCTAssertNotNil(display);
+    XCTAssertEqual(display.subDisplays.count, 2u,
+                   @"Expected colored sub-display and a CTLine for '+z'");
+
+    MTDisplay* sub0 = display.subDisplays[0];
+    XCTAssertTrue([sub0 isKindOfClass:[MTMathListDisplay class]],
+                  @"First sub-display should be the colored MTMathListDisplay");
+    MTMathListDisplay* colorSub = (MTMathListDisplay*)sub0;
+    XCTAssertNotNil(colorSub.localTextColor);
+
+    MTDisplay* sub1 = display.subDisplays[1];
+    XCTAssertTrue([sub1 isKindOfClass:[MTCTLineDisplay class]],
+                  @"Second sub-display should be CTLine for '+z'");
+    MTCTLineDisplay* plusZLine = (MTCTLineDisplay*)sub1;
+
+    // The gap between end of the color group and the start of "+z" is the
+    // binary-operator gap (4 mu) because the typesetter sees color (Ord) then BinOp.
+    // But because + is a BinaryOperator and z is Ordinary, the actual inter-element
+    // space between color (Ord) and + (BinOp, left of the line) is medium (4mu).
+    // The "+z" CTLine starts at the position where the typesetter placed it.
+    CGFloat expectedGap = 4.0 * self.font.mathTable.muUnit;
+    CGFloat actualGap = plusZLine.position.x - (colorSub.position.x + colorSub.width);
+    XCTAssertEqualWithAccuracy(actualGap, expectedGap, 0.01,
+                               @"Spacing after \\color group must be preserved (%.4f pt), got %.4f pt",
+                               expectedGap, actualGap);
+}
+
 @end


### PR DESCRIPTION
## Summary

- `kMTMathAtomColor` and `kMTMathAtomColorbox` cases in `-createDisplayAtoms:` never called `addInterElementSpace:`, so colored groups lost their leading inter-element gap (e.g. the medium binary-operator space in `x+\color{red}y` was dropped, causing `y` to abut `+` with no gap).
- Fix adds one `[self addInterElementSpace:prevNode currentType:atom.type]` call per case, after the line flush and before `display.position = _currentPosition`, mirroring the existing text-case and inner-case patterns. Both atom types already map to Ordinary (index 0) in `getInterElementSpaceArrayIndexForType`, so no spacing-table changes are required. Net change: +2 lines in `MTTypesetter.m`.
- Three new tests in `MTTypesetterTest`: `\color` before binary-op gap (was RED, now GREEN), `\colorbox` before binary-op gap (was RED, now GREEN), regression guard that spacing *after* a `\color` group is preserved (was already GREEN).

Closes REN-3 from issues.md.

## Test plan

- [x] `swift build` passes with no warnings
- [x] `swift test` passes all 295 tests (89 in `MTTypesetterTest`, 3 new)
- [x] `testColorReceivesInterElementSpacingBeforeIt` — asserts the medium binary-op gap (4 mu = 4 × muUnit) before `\color`
- [x] `testColorboxReceivesInterElementSpacingBeforeIt` — same for `\colorbox`
- [x] `testSpacingAfterColorGroupIsPreserved` — regression guard that the already-working post-color spacing still holds

🤖 Generated with [Claude Code](https://claude.com/claude-code)