### PR TITLE
fix(FUN-5): replace NSAssert in getNextCharacter with unconditional bounds guard

### DIFF
--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -74,7 +74,15 @@ NSString *const MTParseError = @"ParseError";
 // gets the next character and moves the pointer ahead
 - (unichar) getNextCharacter
 {
-    NSAssert([self hasCharacters], @"Retrieving character at index %d beyond length %lu", _currentChar, (unsigned long)_length);
+    if (![self hasCharacters]) {
+        // Defense-in-depth: all current call sites pre-check hasCharacters,
+        // but guard unconditionally so a future missed check cannot produce
+        // an out-of-bounds heap read in release builds (NS_BLOCK_ASSERTIONS
+        // compiled out NSAssert, leaving the old code unprotected).
+        [self setError:MTParseErrorInternalError
+               message:@"Retrieving character beyond the end of the input"];
+        return 0;
+    }
     return _chars[_currentChar++];
 }
 

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -2866,4 +2866,26 @@ static NSArray* getTestDataLargeDelimiters() {
     XCTAssertEqualObjects([MTMathListBuilder mathListToString:list], @"\\underset{b}{\\overset{a}{X}}");
 }
 
+// FUN-5: getNextCharacter bounds check (defense-in-depth)
+//
+// The fix in FUN-5 replaces the NSAssert in getNextCharacter with an
+// unconditional guard. Because every call site already pre-checks
+// hasCharacters before calling getNextCharacter, the new guard is dead code
+// on any currently-reachable path — there is no public API input that
+// exercises the past-end branch. This test therefore serves as a regression
+// check: it exercises the hot path of getNextCharacter heavily (via \frac
+// parsing, which calls getNextCharacter many times) and confirms that the
+// unconditional guard does not alter normal parsing behavior.
+- (void)testGetNextCharacterBoundsGuardDoesNotAffectValidParsing
+{
+    // A multi-token expression that forces getNextCharacter through many
+    // iterations, including inside nested fraction arguments.
+    NSError *error = nil;
+    MTMathList *list = [MTMathListBuilder buildFromString:@"\\frac{1+x}{2}" error:&error];
+    XCTAssertNil(error, @"Valid \\frac expression must parse without error");
+    XCTAssertNotNil(list, @"Valid \\frac expression must produce a non-nil list");
+    XCTAssertEqual(list.atoms.count, (NSUInteger)1);
+    XCTAssertEqual(((MTMathAtom *)list.atoms[0]).type, kMTMathAtomFraction);
+}
+
 @end


### PR DESCRIPTION
## Summary

- Fixes FUN-5 (issues.md#L223): `getNextCharacter` protected its array read only with `NSAssert`, which is compiled out in release builds (`NS_BLOCK_ASSERTIONS`), leaving an unchecked heap read if any call site ever calls past the end of input.
- Replaces the `NSAssert` with an unconditional `if (![self hasCharacters])` guard that sets `MTParseErrorInternalError` and returns `0` — consistent with the parser's existing `setError:` convention.
- All current call sites pre-check `hasCharacters` before calling `getNextCharacter`, so this is defense-in-depth with no behavior change on any currently-reachable path.
- Adds a regression test (`testGetNextCharacterBoundsGuardDoesNotAffectValidParsing`) confirming that valid `\frac` parsing is unaffected.

## Files changed

- `iosMath/lib/MTMathListBuilder.m` — replace `NSAssert` with unconditional guard (~+8/-1 LOC)
- `iosMathTests/MTMathListBuilderTest.m` — add regression test

## Test plan

- [x] `swift build` passes (no warnings)
- [x] `swift test` — all 293 tests pass, including new regression test
- [x] New guard is identical in Debug and Release builds (unconditional `if`, not `NSAssert`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)