### PR TITLE
fix(FUN-7): restore _currentEnv on all error paths in buildTable:firstList:row:

### DIFF
--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -977,6 +977,7 @@ NSString *const MTParseError = @"ParseError";
         MTMathList* list = [self buildInternal:NO];
         if (!list) {
             // If there is an error building the list, bail out early.
+            _currentEnv = oldEnv;
             return nil;
         }
         rows[currentRow][currentCol] = list;
@@ -993,12 +994,14 @@ NSString *const MTParseError = @"ParseError";
     }
     if (!_currentEnv.ended && _currentEnv.envName) {
         [self setError:MTParseErrorMissingEnd message:@"Missing \\end"];
+        _currentEnv = oldEnv;
         return nil;
     }
     NSError* error;
     MTMathAtom* table = [MTMathAtomFactory tableWithEnvironment:_currentEnv.envName rows:rows error:&error];
     if (!table && !_error) {
         _error = error;
+        _currentEnv = oldEnv;
         return nil;
     }
     // reinstate the old env.


### PR DESCRIPTION
## Summary

- Three early `return nil;` paths in `-[MTMathListBuilder buildTable:firstList:row:]` skipped the `_currentEnv = oldEnv` restoration that the success path correctly performed, leaving the builder's environment pointer stale after any parse failure inside a table/matrix environment.
- Fix: add `_currentEnv = oldEnv;` before each of the three early returns — the `buildInternal:` failure path, the `MTParseErrorMissingEnd` path, and the `tableWithEnvironment:rows:error:` failure path.
- This is a **latent/defensive** fix: the builder sets `_error` on every error path and then unwinds without inspecting `_currentEnv` again, so no current call sequence observes the leaked pointer. The fix eliminates a future trap if error-handling or builder-reuse semantics change.

Closes FUN-7 (issues.md#L243).

## Changes

- `iosMath/lib/MTMathListBuilder.m` — +3 lines, 1 file, no API or behavior change.

## Test plan

- [x] `swift build` — passes (Build complete)
- [x] `swift test` — all tests pass, 0 failures (`Test Suite 'All tests' passed`)
- No new tests added: the fix is behavior-preserving for all existing paths; `MTMathListBuilderTest` already covers valid table parsing and `MTParseErrorMissingEnd` error cases. The leaked `_currentEnv` is not externally observable today (builder is single-use-per-parse, unwinds immediately on `_error`), so no meaningful new assertion is possible beyond confirming existing error cases still return the same `nil` + error code — which the existing suite already asserts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)