### PR TITLE
fix(FUN-6): NULL-check malloc at three sites to prevent NULL-deref crashes

### DIFF
--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -52,9 +52,18 @@ NSString *const MTParseError = @"ParseError";
     self = [super init];
     if (self) {
         _error = nil;
-        _chars = malloc(sizeof(unichar)*str.length);
         _length = str.length;
-        [str getCharacters:_chars range:NSMakeRange(0, str.length)];
+        _chars = NULL;
+        if (_length > 0) {
+            _chars = malloc(sizeof(unichar) * _length);
+            if (_chars) {
+                [str getCharacters:_chars range:NSMakeRange(0, _length)];
+            } else {
+                // Allocation failed (e.g. huge input under memory pressure):
+                // degrade to empty input instead of dereferencing NULL.
+                _length = 0;
+            }
+        }
         _currentChar = 0;
         _currentFontStyle = kMTFontStyleDefault;
     }

--- a/iosMath/render/MTMathListDisplay.m
+++ b/iosMath/render/MTMathListDisplay.m
@@ -613,6 +613,11 @@ static BOOL isIos6Supported(void) {
         _numGlyphs = glyphs.count;
         _glyphs = malloc(sizeof(CGGlyph) * _numGlyphs);
         _positions = malloc(sizeof(CGPoint) * _numGlyphs);
+        if (_numGlyphs > 0 && (!_glyphs || !_positions)) {
+            free(_glyphs); _glyphs = NULL;
+            free(_positions); _positions = NULL;
+            _numGlyphs = 0;  // nothing to draw; CTFontDrawGlyphs is a no-op for count 0
+        }
         for (int i = 0; i < _numGlyphs; i++) {
             _glyphs[i] = glyphs[i].shortValue;
             _positions[i] = CGPointMake(0, offsets[i].floatValue);
@@ -952,6 +957,11 @@ static BOOL isIos6Supported(void) {
         _numGlyphs = glyphs.count;
         _glyphs = malloc(sizeof(CGGlyph) * _numGlyphs);
         _positions = malloc(sizeof(CGPoint) * _numGlyphs);
+        if (_numGlyphs > 0 && (!_glyphs || !_positions)) {
+            free(_glyphs); _glyphs = NULL;
+            free(_positions); _positions = NULL;
+            _numGlyphs = 0;  // nothing to draw; CTFontDrawGlyphs is a no-op for count 0
+        }
         for (int i = 0; i < _numGlyphs; i++) {
             _glyphs[i] = glyphs[i].shortValue;
             CGPoint pt;

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -2866,4 +2866,17 @@ static NSArray* getTestDataLargeDelimiters() {
     XCTAssertEqualObjects([MTMathListBuilder mathListToString:list], @"\\underset{b}{\\overset{a}{X}}");
 }
 
+// FUN-6: Verify that parsing an empty string yields an empty MTMathList with no error.
+// This exercises the _length == 0 branch end-to-end and locks in the "degrade to empty"
+// contract that the malloc-failure fallback in initWithString: also produces.
+// (The actual malloc-NULL paths are verified by code inspection; deterministically forcing
+// malloc failure in XCTest is impractical without a malloc interposer.)
+- (void)testEmptyInputParsesToEmptyList {
+    NSError *error = nil;
+    MTMathList *list = [MTMathListBuilder buildFromString:@"" error:&error];
+    XCTAssertNotNil(list, @"buildFromString:@\"\" should return a non-nil list");
+    XCTAssertEqual(list.atoms.count, (NSUInteger)0, @"empty input should produce zero atoms");
+    XCTAssertNil(error, @"empty input should produce no parse error");
+}
+
 @end


### PR DESCRIPTION
## Summary

Fixes FUN-6 (issues.md#L233) — three `malloc` calls wrote to the returned buffer immediately without a NULL check.

- **`MTMathListBuilder.m` (parser, realistic risk):** `initWithString:` now guards `malloc(sizeof(unichar)*_length)`. On NULL, sets `_length = 0` and skips `getCharacters:`, degrading to an empty `MTMathList` instead of NULL-dereferencing. `dealloc` already does `free(_chars)`; `free(NULL)` is a safe no-op.
- **`MTMathListDisplay.m` — `MTGlyphConstructionDisplay` (low-risk, hardened for consistency):** guards `_glyphs`/`_positions` allocations; on failure sets `_numGlyphs = 0` and frees any partial allocation so `draw:` becomes a `CTFontDrawGlyphs(..., 0, ...)` no-op.
- **`MTMathListDisplay.m` — `MTHorizontalGlyphAssemblyDisplay` (same pattern):** identical guard applied to the second glyph-assembly initializer.

Net change: ~+16 LOC across 2 files, no API or architecture change.

## Test plan

- [x] `swift build` — clean build, no warnings introduced
- [x] `swift test` — 293 tests, 0 failures
- [x] New test `testEmptyInputParsesToEmptyList` added to `MTMathListBuilderTest` — parses `@""`, asserts zero atoms and no error, locking in the "degrade to empty" contract that the malloc-failure fallback also produces
- [ ] `malloc`-returns-NULL branches verified by code inspection (deterministically forcing malloc failure in XCTest requires a malloc interposer and is platform-fragile; documented in solution.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)