### PR TITLE
fix(FUN-8): copy style/spacer atom per cell in tableWithEnvironment:rows:error:

### DIFF
--- a/iosMath/lib/MTMathAtomFactory.m
+++ b/iosMath/lib/MTMathAtomFactory.m
@@ -385,7 +385,7 @@ NSString *const MTSymbolDegree = @"\u00B0"; // \circ
         for (int i = 0; i < table.cells.count; i++) {
             NSArray<MTMathList*>* row = table.cells[i];
             for (int j = 0; j < row.count; j++) {
-                [row[j] insertAtom:style atIndex:0];
+                [row[j] insertAtom:[style copy] atIndex:0];
             }
         }
         // Add delimiters
@@ -421,7 +421,7 @@ NSString *const MTSymbolDegree = @"\u00B0"; // \circ
         for (int i = 0; i < table.cells.count; i++) {
             NSArray<MTMathList*>* row = table.cells[i];
             if (row.count > 1) {
-                [row[1] insertAtom:spacer atIndex:0];
+                [row[1] insertAtom:[spacer copy] atIndex:0];
             }
         }
         table.interRowAdditionalSpacing = 1;
@@ -472,7 +472,7 @@ NSString *const MTSymbolDegree = @"\u00B0"; // \circ
         for (int i = 0; i < table.cells.count; i++) {
             NSArray<MTMathList*>* row = table.cells[i];
             for (int j = 0; j < row.count; j++) {
-                [row[j] insertAtom:style atIndex:0];
+                [row[j] insertAtom:[style copy] atIndex:0];
             }
         }
         // Add delimiters

--- a/iosMath/lib/MTMathAtomFactory.m
+++ b/iosMath/lib/MTMathAtomFactory.m
@@ -380,12 +380,13 @@ NSString *const MTSymbolDegree = @"\u00B0"; // \circ
         table.environment = @"matrix";
         table.interRowAdditionalSpacing = 0;
         table.interColumnSpacing = 18;
-        // All the lists are in textstyle
+        // All the lists are in textstyle. MTMathStyle is immutable, so the same instance can be
+        // shared across every cell without aliasing.
         MTMathAtom* style = [[MTMathStyle alloc] initWithStyle:kMTLineStyleText];
         for (int i = 0; i < table.cells.count; i++) {
             NSArray<MTMathList*>* row = table.cells[i];
             for (int j = 0; j < row.count; j++) {
-                [row[j] insertAtom:[style copy] atIndex:0];
+                [row[j] insertAtom:style atIndex:0];
             }
         }
         // Add delimiters
@@ -467,12 +468,13 @@ NSString *const MTSymbolDegree = @"\u00B0"; // \circ
         table.interColumnSpacing = 18;
         [table setAlignment:kMTColumnAlignmentLeft forColumn:0];
         [table setAlignment:kMTColumnAlignmentLeft forColumn:1];
-        // All the lists are in textstyle
+        // All the lists are in textstyle. MTMathStyle is immutable, so the same instance can be
+        // shared across every cell without aliasing.
         MTMathAtom* style = [[MTMathStyle alloc] initWithStyle:kMTLineStyleText];
         for (int i = 0; i < table.cells.count; i++) {
             NSArray<MTMathList*>* row = table.cells[i];
             for (int j = 0; j < row.count; j++) {
-                [row[j] insertAtom:[style copy] atIndex:0];
+                [row[j] insertAtom:style atIndex:0];
             }
         }
         // Add delimiters

--- a/iosMath/lib/MTMathList.m
+++ b/iosMath/lib/MTMathList.m
@@ -898,10 +898,11 @@ static NSString* fractionCommandForDelimiterPair(NSString* leftDelimiter, NSStri
     return op;
 }
 
-// A style atom is a non-rendering control marker: its nucleus is never drawn (and scripts are
-// already forbidden via -scriptsAllowed). Reject any attempt to give it a nucleus so callers
-// can't silently store meaningless state on it. The empty string is permitted so the inherited
-// -copyWithZone: (which assigns self.nucleus) keeps working.
+// A style atom is a non-rendering control marker: the typesetter reads only its `style`, never
+// its nucleus/type/fontStyle, and scripts are already forbidden via -scriptsAllowed. Make it
+// fully immutable so the same instance can be shared across table cells without aliasing bugs.
+// Each setter permits only the value that the inherited -copyWithZone: assigns (so copying keeps
+// working) and rejects anything else.
 - (void)setNucleus:(NSString *)nucleus
 {
     if (nucleus.length > 0) {
@@ -910,6 +911,26 @@ static NSString* fractionCommandForDelimiterPair(NSString* leftDelimiter, NSStri
                                         userInfo:nil];
     }
     [super setNucleus:nucleus];
+}
+
+- (void)setType:(MTMathAtomType)type
+{
+    if (type != kMTMathAtomStyle) {
+        @throw [[NSException alloc] initWithName:@"Error"
+                                          reason:@"The type of a style atom cannot be changed."
+                                        userInfo:nil];
+    }
+    [super setType:type];
+}
+
+- (void)setFontStyle:(MTFontStyle)fontStyle
+{
+    if (fontStyle != kMTFontStyleDefault) {
+        @throw [[NSException alloc] initWithName:@"Error"
+                                          reason:@"Font style cannot be set on a style atom; it is a non-rendering control marker."
+                                        userInfo:nil];
+    }
+    [super setFontStyle:fontStyle];
 }
 
 - (void)appendLaTeXToString:(NSMutableString *)str

--- a/iosMath/lib/MTMathList.m
+++ b/iosMath/lib/MTMathList.m
@@ -898,6 +898,20 @@ static NSString* fractionCommandForDelimiterPair(NSString* leftDelimiter, NSStri
     return op;
 }
 
+// A style atom is a non-rendering control marker: its nucleus is never drawn (and scripts are
+// already forbidden via -scriptsAllowed). Reject any attempt to give it a nucleus so callers
+// can't silently store meaningless state on it. The empty string is permitted so the inherited
+// -copyWithZone: (which assigns self.nucleus) keeps working.
+- (void)setNucleus:(NSString *)nucleus
+{
+    if (nucleus.length > 0) {
+        @throw [[NSException alloc] initWithName:@"Error"
+                                          reason:@"Nucleus cannot be set on a style atom; it is a non-rendering control marker."
+                                        userInfo:nil];
+    }
+    [super setNucleus:nucleus];
+}
+
 - (void)appendLaTeXToString:(NSMutableString *)str
 {
     NSString* command = [MTMathListBuilder styleToCommands][@(self.style)];

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -1403,12 +1403,18 @@ static NSArray* getTestDataLeftRight() {
 }
 
 // FUN-8: Regression — tableWithEnvironment:rows:error: must insert a distinct atom copy
-// into each cell rather than aliasing the same object across cells. We exercise the actual
-// failure mode: mutating one cell's leading atom must NOT bleed into the other cells. If the
-// bug is present every cell shares one atom object, so mutating it changes them all at once.
+// into each cell rather than aliasing the same object across cells.
+//
+// The two inserted atoms are asymmetric:
+//   - matrix/cases insert an MTMathStyle, a non-rendering control marker. It is immutable
+//     (style is readonly, scripts throw, and -setNucleus: now throws), so the only thing that
+//     can go wrong is the *objects* being shared. We assert they are distinct instances.
+//   - eqalign/aligned insert a plain ordinary atom (the relation spacer). That atom is fully
+//     mutable and its nucleus renders, so we exercise the real failure mode: mutating one
+//     cell's spacer must NOT bleed into the others. With the bug all cells share one object.
 - (void) testTableCellsHaveIndependentLeadingAtoms
 {
-    // matrix: every cell gets an MTMathStyle inserted at index 0.
+    // matrix: every cell gets an (immutable) MTMathStyle inserted at index 0.
     {
         NSString *str = @"\\begin{matrix} a & b \\\\ c & d \\end{matrix}";
         MTMathList *list = [MTMathListBuilder buildFromString:str];
@@ -1417,14 +1423,13 @@ static NSArray* getTestDataLeftRight() {
         MTMathAtom *atom00 = table.cells[0][0].atoms[0];
         MTMathAtom *atom01 = table.cells[0][1].atoms[0];
         MTMathAtom *atom10 = table.cells[1][0].atoms[0];
-        // Mutate the leading atom of cell (0,0). The others must be untouched.
-        atom00.nucleus = @"MUTATED";
-        XCTAssertEqualObjects(atom00.nucleus, @"MUTATED");
-        XCTAssertNotEqualObjects(atom01.nucleus, @"MUTATED", @"matrix: mutating cell (0,0) leaked into (0,1) — shared style atom (FUN-8)");
-        XCTAssertNotEqualObjects(atom10.nucleus, @"MUTATED", @"matrix: mutating cell (0,0) leaked into (1,0) — shared style atom (FUN-8)");
+        // Each cell must own a distinct style instance — not the same shared object.
+        XCTAssertNotIdentical(atom00, atom01, @"matrix row0 cells share the same style atom (FUN-8)");
+        XCTAssertNotIdentical(atom00, atom10, @"matrix row0/row1 cells share the same style atom (FUN-8)");
+        XCTAssertNotIdentical(atom01, atom10, @"matrix row0/row1 cells share the same style atom (FUN-8)");
     }
 
-    // cases: every cell also gets an MTMathStyle inserted at index 0.
+    // cases: every cell also gets an (immutable) MTMathStyle inserted at index 0.
     {
         NSString *str = @"\\begin{cases} a & b \\\\ c & d \\end{cases}";
         MTMathList *list = [MTMathListBuilder buildFromString:str];
@@ -1436,13 +1441,12 @@ static NSArray* getTestDataLeftRight() {
         MTMathAtom *atom00 = table.cells[0][0].atoms[0];
         MTMathAtom *atom01 = table.cells[0][1].atoms[0];
         MTMathAtom *atom10 = table.cells[1][0].atoms[0];
-        atom00.nucleus = @"MUTATED";
-        XCTAssertEqualObjects(atom00.nucleus, @"MUTATED");
-        XCTAssertNotEqualObjects(atom01.nucleus, @"MUTATED", @"cases: mutating cell (0,0) leaked into (0,1) — shared style atom (FUN-8)");
-        XCTAssertNotEqualObjects(atom10.nucleus, @"MUTATED", @"cases: mutating cell (0,0) leaked into (1,0) — shared style atom (FUN-8)");
+        XCTAssertNotIdentical(atom00, atom01, @"cases row0 cells share the same style atom (FUN-8)");
+        XCTAssertNotIdentical(atom00, atom10, @"cases row0/row1 cells share the same style atom (FUN-8)");
+        XCTAssertNotIdentical(atom01, atom10, @"cases row0/row1 cells share the same style atom (FUN-8)");
     }
 
-    // aligned: every second-column cell gets an ordinary spacer atom inserted at index 0.
+    // aligned: every second-column cell gets a mutable ordinary spacer atom inserted at index 0.
     {
         NSString *str = @"\\begin{aligned} a & b \\\\ c & d \\end{aligned}";
         MTMathList *list = [MTMathListBuilder buildFromString:str];
@@ -1451,10 +1455,23 @@ static NSArray* getTestDataLeftRight() {
         // Column 1 cells (index 1 in each row) carry the spacer at atoms[0].
         MTMathAtom *spacer0 = table.cells[0][1].atoms[0];
         MTMathAtom *spacer1 = table.cells[1][1].atoms[0];
+        // Mutate row0's spacer. With the aliasing bug this is the same object as row1's, so the
+        // change would leak. The spacer is an ordinary atom whose nucleus renders, so this is a
+        // meaningful mutation.
         spacer0.nucleus = @"MUTATED";
         XCTAssertEqualObjects(spacer0.nucleus, @"MUTATED");
         XCTAssertNotEqualObjects(spacer1.nucleus, @"MUTATED", @"aligned: mutating row0 spacer leaked into row1 — shared spacer atom (FUN-8)");
     }
+}
+
+// FUN-8: a style atom is a non-rendering control marker, so it must reject a nucleus.
+- (void) testStyleAtomRejectsNucleus
+{
+    MTMathStyle *style = [[MTMathStyle alloc] initWithStyle:kMTLineStyleText];
+    XCTAssertThrows(style.nucleus = @"x", @"style atom must reject a non-empty nucleus");
+    XCTAssertNoThrow(style.nucleus = @"", @"empty nucleus must remain allowed so copying works");
+    // A round-trip copy (which assigns nucleus internally) must not throw.
+    XCTAssertNoThrow([style copy]);
 }
 
 - (void) testDisplayLines

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -1438,6 +1438,7 @@ static NSArray* getTestDataLeftRight() {
     XCTAssertThrows(style.fontStyle = kMTFontStyleBold, @"style atom must reject a font style");
     // Scripts are already forbidden for style atoms via -scriptsAllowed.
     XCTAssertThrows(style.subScript = [MTMathListBuilder buildFromString:@"x"], @"style atom must reject a subscript");
+    XCTAssertThrows(style.superScript = [MTMathListBuilder buildFromString:@"x"], @"style atom must reject a superscript");
     // The values copyWithZone: assigns must remain allowed so deep copying still works.
     XCTAssertNoThrow(style.nucleus = @"");
     XCTAssertNoThrow(style.type = kMTMathAtomStyle);

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -1402,6 +1402,56 @@ static NSArray* getTestDataLeftRight() {
     }
 }
 
+// FUN-8: Regression — tableWithEnvironment:rows:error: must insert a distinct atom copy
+// into each cell rather than aliasing the same object across cells. If the bug is present,
+// all cells share one atom object and the three XCTAssertNotEqual calls below fail.
+- (void) testTableCellsHaveIndependentLeadingAtoms
+{
+    // matrix: every cell gets an MTMathStyle inserted at index 0.
+    {
+        NSString *str = @"\\begin{matrix} a & b \\\\ c & d \\end{matrix}";
+        MTMathList *list = [MTMathListBuilder buildFromString:str];
+        XCTAssertNotNil(list);
+        MTMathTable *table = list.atoms[0];
+        MTMathAtom *atom00 = table.cells[0][0].atoms[0];
+        MTMathAtom *atom01 = table.cells[0][1].atoms[0];
+        MTMathAtom *atom10 = table.cells[1][0].atoms[0];
+        // Each cell must own a distinct object — not the same shared instance.
+        XCTAssertNotEqual(atom00, atom01, @"matrix row0 cells share the same style atom (FUN-8)");
+        XCTAssertNotEqual(atom00, atom10, @"matrix row0/row1 cells share the same style atom (FUN-8)");
+        XCTAssertNotEqual(atom01, atom10, @"matrix row0/row1 cells share the same style atom (FUN-8)");
+    }
+
+    // cases: every cell also gets an MTMathStyle inserted at index 0.
+    {
+        NSString *str = @"\\begin{cases} a & b \\\\ c & d \\end{cases}";
+        MTMathList *list = [MTMathListBuilder buildFromString:str];
+        XCTAssertNotNil(list);
+        // cases wraps the table in an MTInner.
+        MTInner *inner = list.atoms[0];
+        XCTAssertEqual(inner.type, kMTMathAtomInner);
+        MTMathTable *table = inner.innerList.atoms[1]; // index 0 is the comma spacer
+        MTMathAtom *atom00 = table.cells[0][0].atoms[0];
+        MTMathAtom *atom01 = table.cells[0][1].atoms[0];
+        MTMathAtom *atom10 = table.cells[1][0].atoms[0];
+        XCTAssertNotEqual(atom00, atom01, @"cases row0 cells share the same style atom (FUN-8)");
+        XCTAssertNotEqual(atom00, atom10, @"cases row0/row1 cells share the same style atom (FUN-8)");
+        XCTAssertNotEqual(atom01, atom10, @"cases row0/row1 cells share the same style atom (FUN-8)");
+    }
+
+    // aligned: every second-column cell gets an ordinary spacer atom inserted at index 0.
+    {
+        NSString *str = @"\\begin{aligned} a & b \\\\ c & d \\end{aligned}";
+        MTMathList *list = [MTMathListBuilder buildFromString:str];
+        XCTAssertNotNil(list);
+        MTMathTable *table = list.atoms[0];
+        // Column 1 cells (index 1 in each row) carry the spacer at atoms[0].
+        MTMathAtom *spacer0 = table.cells[0][1].atoms[0];
+        MTMathAtom *spacer1 = table.cells[1][1].atoms[0];
+        XCTAssertNotEqual(spacer0, spacer1, @"aligned col-1 cells share the same spacer atom (FUN-8)");
+    }
+}
+
 - (void) testDisplayLines
 {
     NSString *str1 = @"\\begin{displaylines}x\\\\ y\\end{displaylines}";

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -1403,8 +1403,9 @@ static NSArray* getTestDataLeftRight() {
 }
 
 // FUN-8: Regression — tableWithEnvironment:rows:error: must insert a distinct atom copy
-// into each cell rather than aliasing the same object across cells. If the bug is present,
-// all cells share one atom object and the XCTAssertNotIdentical calls below fail.
+// into each cell rather than aliasing the same object across cells. We exercise the actual
+// failure mode: mutating one cell's leading atom must NOT bleed into the other cells. If the
+// bug is present every cell shares one atom object, so mutating it changes them all at once.
 - (void) testTableCellsHaveIndependentLeadingAtoms
 {
     // matrix: every cell gets an MTMathStyle inserted at index 0.
@@ -1416,10 +1417,11 @@ static NSArray* getTestDataLeftRight() {
         MTMathAtom *atom00 = table.cells[0][0].atoms[0];
         MTMathAtom *atom01 = table.cells[0][1].atoms[0];
         MTMathAtom *atom10 = table.cells[1][0].atoms[0];
-        // Each cell must own a distinct object — not the same shared instance.
-        XCTAssertNotIdentical(atom00, atom01, @"matrix row0 cells share the same style atom (FUN-8)");
-        XCTAssertNotIdentical(atom00, atom10, @"matrix row0/row1 cells share the same style atom (FUN-8)");
-        XCTAssertNotIdentical(atom01, atom10, @"matrix row0/row1 cells share the same style atom (FUN-8)");
+        // Mutate the leading atom of cell (0,0). The others must be untouched.
+        atom00.nucleus = @"MUTATED";
+        XCTAssertEqualObjects(atom00.nucleus, @"MUTATED");
+        XCTAssertNotEqualObjects(atom01.nucleus, @"MUTATED", @"matrix: mutating cell (0,0) leaked into (0,1) — shared style atom (FUN-8)");
+        XCTAssertNotEqualObjects(atom10.nucleus, @"MUTATED", @"matrix: mutating cell (0,0) leaked into (1,0) — shared style atom (FUN-8)");
     }
 
     // cases: every cell also gets an MTMathStyle inserted at index 0.
@@ -1434,9 +1436,10 @@ static NSArray* getTestDataLeftRight() {
         MTMathAtom *atom00 = table.cells[0][0].atoms[0];
         MTMathAtom *atom01 = table.cells[0][1].atoms[0];
         MTMathAtom *atom10 = table.cells[1][0].atoms[0];
-        XCTAssertNotIdentical(atom00, atom01, @"cases row0 cells share the same style atom (FUN-8)");
-        XCTAssertNotIdentical(atom00, atom10, @"cases row0/row1 cells share the same style atom (FUN-8)");
-        XCTAssertNotIdentical(atom01, atom10, @"cases row0/row1 cells share the same style atom (FUN-8)");
+        atom00.nucleus = @"MUTATED";
+        XCTAssertEqualObjects(atom00.nucleus, @"MUTATED");
+        XCTAssertNotEqualObjects(atom01.nucleus, @"MUTATED", @"cases: mutating cell (0,0) leaked into (0,1) — shared style atom (FUN-8)");
+        XCTAssertNotEqualObjects(atom10.nucleus, @"MUTATED", @"cases: mutating cell (0,0) leaked into (1,0) — shared style atom (FUN-8)");
     }
 
     // aligned: every second-column cell gets an ordinary spacer atom inserted at index 0.
@@ -1448,7 +1451,9 @@ static NSArray* getTestDataLeftRight() {
         // Column 1 cells (index 1 in each row) carry the spacer at atoms[0].
         MTMathAtom *spacer0 = table.cells[0][1].atoms[0];
         MTMathAtom *spacer1 = table.cells[1][1].atoms[0];
-        XCTAssertNotIdentical(spacer0, spacer1, @"aligned col-1 cells share the same spacer atom (FUN-8)");
+        spacer0.nucleus = @"MUTATED";
+        XCTAssertEqualObjects(spacer0.nucleus, @"MUTATED");
+        XCTAssertNotEqualObjects(spacer1.nucleus, @"MUTATED", @"aligned: mutating row0 spacer leaked into row1 — shared spacer atom (FUN-8)");
     }
 }
 

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -1404,7 +1404,7 @@ static NSArray* getTestDataLeftRight() {
 
 // FUN-8: Regression — tableWithEnvironment:rows:error: must insert a distinct atom copy
 // into each cell rather than aliasing the same object across cells. If the bug is present,
-// all cells share one atom object and the three XCTAssertNotEqual calls below fail.
+// all cells share one atom object and the XCTAssertNotIdentical calls below fail.
 - (void) testTableCellsHaveIndependentLeadingAtoms
 {
     // matrix: every cell gets an MTMathStyle inserted at index 0.
@@ -1417,9 +1417,9 @@ static NSArray* getTestDataLeftRight() {
         MTMathAtom *atom01 = table.cells[0][1].atoms[0];
         MTMathAtom *atom10 = table.cells[1][0].atoms[0];
         // Each cell must own a distinct object — not the same shared instance.
-        XCTAssertNotEqual(atom00, atom01, @"matrix row0 cells share the same style atom (FUN-8)");
-        XCTAssertNotEqual(atom00, atom10, @"matrix row0/row1 cells share the same style atom (FUN-8)");
-        XCTAssertNotEqual(atom01, atom10, @"matrix row0/row1 cells share the same style atom (FUN-8)");
+        XCTAssertNotIdentical(atom00, atom01, @"matrix row0 cells share the same style atom (FUN-8)");
+        XCTAssertNotIdentical(atom00, atom10, @"matrix row0/row1 cells share the same style atom (FUN-8)");
+        XCTAssertNotIdentical(atom01, atom10, @"matrix row0/row1 cells share the same style atom (FUN-8)");
     }
 
     // cases: every cell also gets an MTMathStyle inserted at index 0.
@@ -1434,9 +1434,9 @@ static NSArray* getTestDataLeftRight() {
         MTMathAtom *atom00 = table.cells[0][0].atoms[0];
         MTMathAtom *atom01 = table.cells[0][1].atoms[0];
         MTMathAtom *atom10 = table.cells[1][0].atoms[0];
-        XCTAssertNotEqual(atom00, atom01, @"cases row0 cells share the same style atom (FUN-8)");
-        XCTAssertNotEqual(atom00, atom10, @"cases row0/row1 cells share the same style atom (FUN-8)");
-        XCTAssertNotEqual(atom01, atom10, @"cases row0/row1 cells share the same style atom (FUN-8)");
+        XCTAssertNotIdentical(atom00, atom01, @"cases row0 cells share the same style atom (FUN-8)");
+        XCTAssertNotIdentical(atom00, atom10, @"cases row0/row1 cells share the same style atom (FUN-8)");
+        XCTAssertNotIdentical(atom01, atom10, @"cases row0/row1 cells share the same style atom (FUN-8)");
     }
 
     // aligned: every second-column cell gets an ordinary spacer atom inserted at index 0.
@@ -1448,7 +1448,7 @@ static NSArray* getTestDataLeftRight() {
         // Column 1 cells (index 1 in each row) carry the spacer at atoms[0].
         MTMathAtom *spacer0 = table.cells[0][1].atoms[0];
         MTMathAtom *spacer1 = table.cells[1][1].atoms[0];
-        XCTAssertNotEqual(spacer0, spacer1, @"aligned col-1 cells share the same spacer atom (FUN-8)");
+        XCTAssertNotIdentical(spacer0, spacer1, @"aligned col-1 cells share the same spacer atom (FUN-8)");
     }
 }
 

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -1402,75 +1402,46 @@ static NSArray* getTestDataLeftRight() {
     }
 }
 
-// FUN-8: Regression — tableWithEnvironment:rows:error: must insert a distinct atom copy
-// into each cell rather than aliasing the same object across cells.
+// FUN-8: Regression — in eqalign/split/aligned, tableWithEnvironment:rows:error: prepends a
+// relation spacer to every second-column cell. That spacer is a plain *mutable* ordinary atom,
+// so each cell must get its own copy: mutating one cell's spacer must NOT bleed into the others.
+// With the aliasing bug all cells share one object and the mutation leaks.
 //
-// The two inserted atoms are asymmetric:
-//   - matrix/cases insert an MTMathStyle, a non-rendering control marker. It is immutable
-//     (style is readonly, scripts throw, and -setNucleus: now throws), so the only thing that
-//     can go wrong is the *objects* being shared. We assert they are distinct instances.
-//   - eqalign/aligned insert a plain ordinary atom (the relation spacer). That atom is fully
-//     mutable and its nucleus renders, so we exercise the real failure mode: mutating one
-//     cell's spacer must NOT bleed into the others. With the bug all cells share one object.
-- (void) testTableCellsHaveIndependentLeadingAtoms
+// matrix/cases also prepend a leading atom (an MTMathStyle), but that one is deliberately the
+// *same shared instance* across cells — which is safe because MTMathStyle is immutable. That
+// invariant is covered by -testStyleAtomIsImmutable below rather than here.
+- (void) testTableSpacerCellsAreIndependent
 {
-    // matrix: every cell gets an (immutable) MTMathStyle inserted at index 0.
-    {
-        NSString *str = @"\\begin{matrix} a & b \\\\ c & d \\end{matrix}";
-        MTMathList *list = [MTMathListBuilder buildFromString:str];
-        XCTAssertNotNil(list);
-        MTMathTable *table = list.atoms[0];
-        MTMathAtom *atom00 = table.cells[0][0].atoms[0];
-        MTMathAtom *atom01 = table.cells[0][1].atoms[0];
-        MTMathAtom *atom10 = table.cells[1][0].atoms[0];
-        // Each cell must own a distinct style instance — not the same shared object.
-        XCTAssertNotIdentical(atom00, atom01, @"matrix row0 cells share the same style atom (FUN-8)");
-        XCTAssertNotIdentical(atom00, atom10, @"matrix row0/row1 cells share the same style atom (FUN-8)");
-        XCTAssertNotIdentical(atom01, atom10, @"matrix row0/row1 cells share the same style atom (FUN-8)");
-    }
-
-    // cases: every cell also gets an (immutable) MTMathStyle inserted at index 0.
-    {
-        NSString *str = @"\\begin{cases} a & b \\\\ c & d \\end{cases}";
-        MTMathList *list = [MTMathListBuilder buildFromString:str];
-        XCTAssertNotNil(list);
-        // cases wraps the table in an MTInner.
-        MTInner *inner = list.atoms[0];
-        XCTAssertEqual(inner.type, kMTMathAtomInner);
-        MTMathTable *table = inner.innerList.atoms[1]; // index 0 is the comma spacer
-        MTMathAtom *atom00 = table.cells[0][0].atoms[0];
-        MTMathAtom *atom01 = table.cells[0][1].atoms[0];
-        MTMathAtom *atom10 = table.cells[1][0].atoms[0];
-        XCTAssertNotIdentical(atom00, atom01, @"cases row0 cells share the same style atom (FUN-8)");
-        XCTAssertNotIdentical(atom00, atom10, @"cases row0/row1 cells share the same style atom (FUN-8)");
-        XCTAssertNotIdentical(atom01, atom10, @"cases row0/row1 cells share the same style atom (FUN-8)");
-    }
-
-    // aligned: every second-column cell gets a mutable ordinary spacer atom inserted at index 0.
-    {
-        NSString *str = @"\\begin{aligned} a & b \\\\ c & d \\end{aligned}";
-        MTMathList *list = [MTMathListBuilder buildFromString:str];
-        XCTAssertNotNil(list);
-        MTMathTable *table = list.atoms[0];
-        // Column 1 cells (index 1 in each row) carry the spacer at atoms[0].
-        MTMathAtom *spacer0 = table.cells[0][1].atoms[0];
-        MTMathAtom *spacer1 = table.cells[1][1].atoms[0];
-        // Mutate row0's spacer. With the aliasing bug this is the same object as row1's, so the
-        // change would leak. The spacer is an ordinary atom whose nucleus renders, so this is a
-        // meaningful mutation.
-        spacer0.nucleus = @"MUTATED";
-        XCTAssertEqualObjects(spacer0.nucleus, @"MUTATED");
-        XCTAssertNotEqualObjects(spacer1.nucleus, @"MUTATED", @"aligned: mutating row0 spacer leaked into row1 — shared spacer atom (FUN-8)");
-    }
+    NSString *str = @"\\begin{aligned} a & b \\\\ c & d \\end{aligned}";
+    MTMathList *list = [MTMathListBuilder buildFromString:str];
+    XCTAssertNotNil(list);
+    MTMathTable *table = list.atoms[0];
+    // Column 1 cells (index 1 in each row) carry the spacer at atoms[0].
+    MTMathAtom *spacer0 = table.cells[0][1].atoms[0];
+    MTMathAtom *spacer1 = table.cells[1][1].atoms[0];
+    // Mutate row0's spacer. With the aliasing bug this is the same object as row1's, so the
+    // change would leak. The spacer is an ordinary atom whose nucleus renders, so this is a
+    // meaningful mutation.
+    spacer0.nucleus = @"MUTATED";
+    XCTAssertEqualObjects(spacer0.nucleus, @"MUTATED");
+    XCTAssertNotEqualObjects(spacer1.nucleus, @"MUTATED", @"aligned: mutating row0 spacer leaked into row1 — shared spacer atom (FUN-8)");
 }
 
-// FUN-8: a style atom is a non-rendering control marker, so it must reject a nucleus.
-- (void) testStyleAtomRejectsNucleus
+// FUN-8: a style atom is a non-rendering control marker (the typesetter reads only its `style`).
+// It must be fully immutable so matrix/cases can share one instance across all cells safely.
+- (void) testStyleAtomIsImmutable
 {
     MTMathStyle *style = [[MTMathStyle alloc] initWithStyle:kMTLineStyleText];
+    // nucleus, type and fontStyle are all meaningless for a style atom and must be rejected.
     XCTAssertThrows(style.nucleus = @"x", @"style atom must reject a non-empty nucleus");
-    XCTAssertNoThrow(style.nucleus = @"", @"empty nucleus must remain allowed so copying works");
-    // A round-trip copy (which assigns nucleus internally) must not throw.
+    XCTAssertThrows(style.type = kMTMathAtomOrdinary, @"style atom must reject a type change");
+    XCTAssertThrows(style.fontStyle = kMTFontStyleBold, @"style atom must reject a font style");
+    // Scripts are already forbidden for style atoms via -scriptsAllowed.
+    XCTAssertThrows(style.subScript = [MTMathListBuilder buildFromString:@"x"], @"style atom must reject a subscript");
+    // The values copyWithZone: assigns must remain allowed so deep copying still works.
+    XCTAssertNoThrow(style.nucleus = @"");
+    XCTAssertNoThrow(style.type = kMTMathAtomStyle);
+    XCTAssertNoThrow(style.fontStyle = kMTFontStyleDefault);
     XCTAssertNoThrow([style copy]);
 }
 


### PR DESCRIPTION
## Summary

Fixes **FUN-8**: `+[MTMathAtomFactory tableWithEnvironment:rows:error:]` allocated a single leading atom — an `MTMathStyle` (matrix/cases) or an ordinary spacer `MTMathAtom` (eqalign/split/aligned) — and inserted that **same object reference** into every table cell. Any client that mutated one cell's leading atom would silently mutate every other cell in the table.

The two inserted atoms are not the same kind of thing, so they get different treatment:

### `MTMathStyle` (matrix / pmatrix / … / cases) — made immutable, sharing is now safe

An `MTMathStyle` is a **non-rendering control marker**: the typesetter reads only its `style`, never its `nucleus`, `type`, or `fontStyle`, and scripts are already forbidden via `-scriptsAllowed`. Storing any of that state on it is meaningless. Rather than defensively copying it, we make the class genuinely immutable:

- `-setNucleus:`, `-setType:`, and `-setFontStyle:` now throw on any value other than the one `-copyWithZone:` legitimately assigns (empty nucleus, `kMTMathAtomStyle`, `kMTFontStyleDefault`), so deep copying still works.
- `style` was already `readonly`; sub/superscripts already throw.

With the atom immutable, the same instance can be shared across every matrix/cases cell with no aliasing risk, so the per-cell `[style copy]` is **removed** — sharing is intentional and documented.

### Ordinary spacer (eqalign / split / aligned) — copied per cell

The relation spacer is a plain `kMTMathAtomOrdinary` atom (empty nucleus) whose only job is to give the following `=`/relation its left inter-element spacing. It is a fully **mutable** atom and its nucleus renders, so it genuinely must not be shared — each cell gets `[spacer copy]`.

No public LaTeX-level behaviour changes: `MTTypesetter` re-copies via `finalized`, so rendering is unaffected.

## Test plan

- [x] `testTableSpacerCellsAreIndependent` — mutates one aligned cell's spacer and asserts the other cells are unaffected. Exercises the real failure mode (object sharing → mutation leak); fails when `[spacer copy]` is reverted.
- [x] `testStyleAtomIsImmutable` — asserts `nucleus`/`type`/`fontStyle`/subscript are all rejected on a style atom, while the copy-compatible values stay allowed and `[style copy]` still works.
- [x] Full `swift test` suite: **294 tests, 0 failures**.
