### PR TITLE
Spacing commands — kern, hspace, skip (item 4)

### DIFF
--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -1053,10 +1053,16 @@ static const NSInteger kMTMaxRecursionDepth = 150;
     if (allowEm) {
         // \hspace* is identical to \hspace; the '*' is left in the stream by the
         // lexer (readString stops at '*' since it is not alphabetic), so consume it.
-        if ([command isEqualToString:@"hspace"] && [self hasCharacters]) {
-            unichar c = [self getNextCharacter];
-            if (c != '*') {
-                [self unlookCharacter];
+        // TeX tolerates whitespace before the '*' (e.g. "\hspace *{1em}"), so skip
+        // spaces first; any skipped run is harmless when no '*' follows because
+        // readDimensionIntoMu:allowEm:command: also skips leading whitespace.
+        if ([command isEqualToString:@"hspace"]) {
+            [self skipSpaces];
+            if ([self hasCharacters]) {
+                unichar c = [self getNextCharacter];
+                if (c != '*') {
+                    [self unlookCharacter];
+                }
             }
         }
         CGFloat mu = 0;

--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -644,6 +644,104 @@ static const NSInteger kMTMaxRecursionDepth = 150;
     return mutable;
 }
 
+// Reads a TeX length dimension (e.g. "1em", "-0.5em", "3mu") from the char stream.
+// Grammar: [ws] ['{'] [ws] [sign] (digits[.digits] | .digits) [ws] unit [ws] ['}']
+// where unit ∈ {em, mu}.  On success, writes the value in mu to *outMu and returns YES.
+// On any malformed or unsupported input, sets _error (MTParseErrorInvalidCommand) and
+// returns NO.  em is converted to mu via factor 18; mu is stored as-is.
+// allowEm = NO means only mu is accepted (for \mkern/\mskip/\mspace).
+- (BOOL) readDimensionIntoMu:(CGFloat*)outMu allowEm:(BOOL)allowEm command:(NSString*)cmd
+{
+    // Skip any leading whitespace.
+    [self skipSpaces];
+
+    // Check for an optional opening brace.
+    BOOL braced = NO;
+    if ([self hasCharacters]) {
+        unichar c = [self getNextCharacter];
+        if (c == '{') {
+            braced = YES;
+        } else {
+            [self unlookCharacter];
+        }
+    }
+    // Skip whitespace after optional '{'.
+    [self skipSpaces];
+
+    // Parse optional sign.
+    CGFloat sign = 1;
+    if ([self hasCharacters]) {
+        unichar c = [self getNextCharacter];
+        if (c == '-') {
+            sign = -1;
+        } else if (c == '+') {
+            sign = 1;
+        } else {
+            [self unlookCharacter];
+        }
+    }
+
+    // Parse mantissa: digits[.digits] | .digits  (require at least one digit overall).
+    NSMutableString* num = [NSMutableString string];
+    BOOL sawDigit = NO, sawDot = NO;
+    while ([self hasCharacters]) {
+        unichar c = [self getNextCharacter];
+        if (c >= '0' && c <= '9') {
+            sawDigit = YES;
+            [num appendString:[NSString stringWithCharacters:&c length:1]];
+        } else if (c == '.' && !sawDot) {
+            sawDot = YES;
+            [num appendString:@"."];
+        } else {
+            [self unlookCharacter];
+            break;
+        }
+    }
+    if (!sawDigit) {
+        [self setError:MTParseErrorInvalidCommand
+               message:[NSString stringWithFormat:@"\\%@ expects a length", cmd]];
+        return NO;
+    }
+    // Skip whitespace between number and unit.
+    [self skipSpaces];
+
+    // Read exactly two characters for the unit.
+    NSMutableString* unit = [NSMutableString string];
+    for (int i = 0; i < 2 && [self hasCharacters]; i++) {
+        unichar c = [self getNextCharacter];
+        [unit appendString:[NSString stringWithCharacters:&c length:1]];
+    }
+
+    CGFloat factor;
+    if ([unit isEqualToString:@"em"]) {
+        if (!allowEm) {
+            [self setError:MTParseErrorInvalidCommand
+                   message:[NSString stringWithFormat:@"\\%@ expects mu units", cmd]];
+            return NO;
+        }
+        factor = 18;
+    } else if ([unit isEqualToString:@"mu"]) {
+        factor = 1;
+    } else {
+        [self setError:MTParseErrorInvalidCommand
+               message:[NSString stringWithFormat:@"\\%@ expects em or mu units, got: %@", cmd, unit]];
+        return NO;
+    }
+
+    // If braced, skip whitespace and consume the closing '}'.
+    if (braced) {
+        [self skipSpaces];
+        if (![self hasCharacters] || [self getNextCharacter] != '}') {
+            [self setError:MTParseErrorInvalidCommand
+                   message:[NSString stringWithFormat:@"\\%@ missing closing brace", cmd]];
+            return NO;
+        }
+    }
+
+    *outMu = sign * num.doubleValue * factor;
+    return YES;
+}
+
 - (void) skipSpaces
 {
     while ([self hasCharacters]) {
@@ -924,6 +1022,24 @@ static const NSInteger kMTMaxRecursionDepth = 150;
         mathColorbox.innerList = [self buildInternal:true];
         return mathColorbox;
     } else {
+        // Spacing commands: \kern, \hspace[*], \hskip, \mkern, \mskip, \mspace.
+        // The table maps each command name to @YES (em or mu allowed) or @NO (mu only).
+        NSNumber* allowEm = [MTMathListBuilder spacingCommands][command];
+        if (allowEm) {
+            // \hspace* is identical to \hspace; the '*' is left in the stream by the
+            // lexer (readString stops at '*' since it is not alphabetic), so consume it.
+            if ([command isEqualToString:@"hspace"] && [self hasCharacters]) {
+                unichar c = [self getNextCharacter];
+                if (c != '*') {
+                    [self unlookCharacter];
+                }
+            }
+            CGFloat mu = 0;
+            if (![self readDimensionIntoMu:&mu allowEm:allowEm.boolValue command:command]) {
+                return nil;   // _error already set by readDimensionIntoMu:
+            }
+            return [[MTMathSpace alloc] initWithSpace:mu];
+        }
         NSString* errorMessage = [NSString stringWithFormat:@"Invalid command \\%@", command];
         [self setError:MTParseErrorInvalidCommand message:errorMessage];
         return nil;
@@ -1200,6 +1316,24 @@ static const NSInteger kMTMaxRecursionDepth = 150;
                             };
     });
     return styleToCommands;
+}
+
+// Maps each spacing command to whether em units are allowed (YES => em or mu; NO => mu only).
++ (NSDictionary<NSString*, NSNumber*>*) spacingCommands
+{
+    static NSDictionary* commands = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        commands = @{
+            @"kern":    @YES,   // em or mu
+            @"hspace":  @YES,   // also handles \hspace* (the '*' is consumed in the dispatch)
+            @"hskip":   @YES,
+            @"mkern":   @NO,    // mu only
+            @"mskip":   @NO,
+            @"mspace":  @NO,
+        };
+    });
+    return commands;
 }
 
 + (MTMathList *)buildFromString:(NSString *)str

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -1507,6 +1507,8 @@ static NSArray* getTestDataParseErrors() {
               @[@"\\hspace{abc}", @(MTParseErrorInvalidCommand)],   // no number/unit
               @[@"\\hspace{}", @(MTParseErrorInvalidCommand)],      // empty
               @[@"\\mkern{1em}", @(MTParseErrorInvalidCommand)],    // mu required for \mkern
+              @[@"\\kern1pt", @(MTParseErrorInvalidCommand)],      // valid number, unsupported unit
+              @[@"\\kern1xx", @(MTParseErrorInvalidCommand)],      // valid number, unknown unit
               ];
 };
 
@@ -3289,6 +3291,8 @@ static NSArray* getTestDataLargeDelimiters() {
 {
     // \hspace*, \hskip behave as \hspace/\kern (em or mu); \mskip, \mspace as \mkern (mu only)
     XCTAssertEqualWithAccuracy(((MTMathSpace*)[MTMathListBuilder buildFromString:@"\\hspace*{1em}"].atoms[0]).space, 18.0, 0.001);
+    // TeX tolerates whitespace between the command and the '*' (e.g. "\hspace *{1em}")
+    XCTAssertEqualWithAccuracy(((MTMathSpace*)[MTMathListBuilder buildFromString:@"\\hspace *{1em}"].atoms[0]).space, 18.0, 0.001);
     XCTAssertEqualWithAccuracy(((MTMathSpace*)[MTMathListBuilder buildFromString:@"\\hskip 1em"].atoms[0]).space, 18.0, 0.001);
     XCTAssertEqualWithAccuracy(((MTMathSpace*)[MTMathListBuilder buildFromString:@"\\mskip 4mu"].atoms[0]).space, 4.0, 0.001);
     XCTAssertEqualWithAccuracy(((MTMathSpace*)[MTMathListBuilder buildFromString:@"\\mspace{4mu}"].atoms[0]).space, 4.0, 0.001);

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -1500,6 +1500,12 @@ static NSArray* getTestDataParseErrors() {
               @[@"a % b", @(MTParseErrorInvalidCharacter)],
               @[@"a # b", @(MTParseErrorInvalidCharacter)],
               @[@"a $ b", @(MTParseErrorInvalidCharacter)],
+              // Item 4: spacing dimension parse errors
+              @[@"\\kern", @(MTParseErrorInvalidCommand)],          // missing distance at EOF
+              @[@"\\kernabc", @(MTParseErrorInvalidCommand)],       // no number/unit
+              @[@"\\hspace{abc}", @(MTParseErrorInvalidCommand)],   // no number/unit
+              @[@"\\hspace{}", @(MTParseErrorInvalidCommand)],      // empty
+              @[@"\\mkern{1em}", @(MTParseErrorInvalidCommand)],    // mu required for \mkern
               ];
 };
 
@@ -3250,6 +3256,53 @@ static NSArray* getTestDataLargeDelimiters() {
     // Serialization must stay \left< x\right>  (unchanged round-trip)
     NSString* serialized = [MTMathListBuilder mathListToString:leftRightList];
     XCTAssertEqualObjects(serialized, @"\\left< x\\right> ", @"serialized LaTeX unchanged");
+}
+
+// Item 4: spacing command parsing tests (TDD — added before implementation)
+
+- (void) testParseSpacingDimensions
+{
+    // \kern accepts em or mu; em -> value*18 mu
+    for (NSString* latex in @[@"\\kern1em", @"\\kern{1em}", @"\\kern 1em"]) {
+        MTMathList* list = [MTMathListBuilder buildFromString:latex];
+        [self checkAtomTypes:list types:@[@(kMTMathAtomSpace)] desc:latex];
+        MTMathSpace* sp = list.atoms[0];
+        XCTAssertEqualWithAccuracy(sp.space, 18.0, 0.001, @"%@", latex);
+    }
+
+    MTMathSpace* neg = [MTMathListBuilder buildFromString:@"\\kern-1em"].atoms[0];
+    XCTAssertEqualWithAccuracy(neg.space, -18.0, 0.001);
+
+    MTMathSpace* half = [MTMathListBuilder buildFromString:@"\\kern{.5em}"].atoms[0];
+    XCTAssertEqualWithAccuracy(half.space, 9.0, 0.001);
+
+    MTMathSpace* mk = [MTMathListBuilder buildFromString:@"\\mkern3mu"].atoms[0];
+    XCTAssertEqualWithAccuracy(mk.space, 3.0, 0.001);
+
+    // whitespace around the dimension, leading-zero-less decimal, sign
+    MTMathSpace* ws = [MTMathListBuilder buildFromString:@"\\hspace{ -.2em }"].atoms[0];
+    XCTAssertEqualWithAccuracy(ws.space, -3.6, 0.001);
+}
+
+- (void) testParseSpacingAliases
+{
+    // \hspace*, \hskip behave as \hspace/\kern (em or mu); \mskip, \mspace as \mkern (mu only)
+    XCTAssertEqualWithAccuracy(((MTMathSpace*)[MTMathListBuilder buildFromString:@"\\hspace*{1em}"].atoms[0]).space, 18.0, 0.001);
+    XCTAssertEqualWithAccuracy(((MTMathSpace*)[MTMathListBuilder buildFromString:@"\\hskip 1em"].atoms[0]).space, 18.0, 0.001);
+    XCTAssertEqualWithAccuracy(((MTMathSpace*)[MTMathListBuilder buildFromString:@"\\mskip 4mu"].atoms[0]).space, 4.0, 0.001);
+    XCTAssertEqualWithAccuracy(((MTMathSpace*)[MTMathListBuilder buildFromString:@"\\mspace{4mu}"].atoms[0]).space, 4.0, 0.001);
+}
+
+- (void) testParseGlueTailIgnored
+{
+    // \mkern 3mu plus 1mu -> 3mu space followed by ordinary math "plus 1mu" (no glue detection)
+    MTMathList* list = [MTMathListBuilder buildFromString:@"\\mkern 3mu plus 1mu"];
+    XCTAssertEqual(list.atoms.count > 1, YES);
+    MTMathSpace* sp = list.atoms[0];
+    XCTAssertEqual(sp.type, kMTMathAtomSpace);
+    XCTAssertEqualWithAccuracy(sp.space, 3.0, 0.001);
+    // remaining atoms are ordinary math (the literal letters p,l,u,s, ...), not spaces
+    XCTAssertNotEqual(((MTMathAtom*)list.atoms[1]).type, kMTMathAtomSpace);
 }
 
 @end

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -2980,4 +2980,21 @@
                          @"Display must contain at least one sub-display");
 }
 
+// Item 4: spacing command typesetter advance tests (TDD — added before implementation)
+
+- (void) testSpacingAdvances
+{
+    // \mkern18mu advances by the same width as \kern1em in the current style
+    MTMathListDisplay* mk = [self displayForLaTeX:@"x\\mkern18mu y"];
+    MTMathListDisplay* k  = [self displayForLaTeX:@"x\\kern1em y"];
+    XCTAssertEqualWithAccuracy(mk.width, k.width, 0.01);
+
+    // positive vs negative \hspace move the pen the opposite way
+    MTMathListDisplay* pos = [self displayForLaTeX:@"x\\hspace{1em}y"];
+    MTMathListDisplay* neg = [self displayForLaTeX:@"x\\hspace{-1em}y"];
+    MTMathListDisplay* plain = [self displayForLaTeX:@"xy"];
+    XCTAssertGreaterThan(pos.width, plain.width);
+    XCTAssertLessThan(neg.width, plain.width);
+}
+
 @end


### PR DESCRIPTION
## Goal

Recognize `\kern`, `\mkern`, `\hspace`, `\hspace*`, `\hskip`, `\mskip`, `\mspace` via a new `em`/`mu` length scanner that emits the existing `MTMathSpace` atom. No new atom, no new display — touches only `MTMathListBuilder.m` (plus tests).

This is **PR 2** of the box-and-spacing layer. It is **independent of PR 1** and based directly on `master`.

## Commits

- `[item 4]` Add em/mu dimension scanner and spacing commands emitting MTMathSpace

## Implementation

- `+spacingCommands` — dispatch table: `kern`/`hspace`/`hskip` accept em or mu; `mkern`/`mskip`/`mspace` are mu-only.
- `-readDimensionIntoMu:allowEm:command:` — scanner handling optional `{…}`, sign, decimal mantissa, surrounding whitespace, and `em`/`mu` units. Malformed/unsupported input sets `MTParseErrorInvalidCommand`.
- Spacing branch in `-atomForCommand:` — consumes the optional `*` for `\hspace*`, calls the scanner, returns `[[MTMathSpace alloc] initWithSpace:mu]`.

## Tests

- `MTMathListBuilderTest`: `testParseSpacingDimensions`, `testParseSpacingAliases`, `testParseGlueTailIgnored`, + 5 error cases in `getTestDataParseErrors()`.
- `MTTypesetterTest`: `testSpacingAdvances`.
- Full suite: 301 tests, 0 failures. `swift build` clean.

## References

- Plan: `docs/plans/2026-06-28-box-spacing-layer.md` (PR 2, Task 4)
- LLD: `docs/lld/2026-06-28-box-spacing-layer.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
