### PR TITLE
smallmatrix + gathered environments

### DIFF
--- a/iosMath/lib/MTMathAtomFactory.m
+++ b/iosMath/lib/MTMathAtomFactory.m
@@ -26,6 +26,14 @@ NSString *const MTSymbolInfinity = @"\u221E"; // \infty
 NSString *const MTSymbolAngle = @"\u2220"; // \angle
 NSString *const MTSymbolDegree = @"\u00B0"; // \circ
 
+// Inter-column spacing for \begin{smallmatrix}, in mu. amsmath separates smallmatrix
+// columns with \thickspace = 5mu, measured under \scriptstyle (amsmath.dtx); KaTeX
+// mirrors this as 0.2778em = 5/18em (src/environments/array.ts). We store the honest
+// 5mu here and let the renderer scale the gap to the Script cell style
+// (MTTypesetter -cellStyleForTable:, PR 1), so the rendered gap is 5 * scriptScaleDown
+// outer-mu -- font-exact, with no pre-scaled magic factor baked into the model.
+static const CGFloat kSmallMatrixInterColumnSpacing = 5;
+
 @implementation MTMathStackCommandSpec
 - (instancetype)initWithOver:(nullable MTMathStackConstruction*)over
                        under:(nullable MTMathStackConstruction*)under
@@ -484,6 +492,12 @@ NSString *const MTSymbolDegree = @"\u00B0"; // \circ
         MTMathAtom* space = [self atomForLatexSymbolName:@","];
         inner.innerList = [MTMathList mathListWithAtoms:space, table, nil];
         return inner;
+    } else if ([env isEqualToString:@"smallmatrix"]) {
+        // Compact inline matrix: script-style cells, no delimiters, center default.
+        table.interRowAdditionalSpacing = 0;
+        table.interColumnSpacing = kSmallMatrixInterColumnSpacing;
+        table.cellStyle = kMTLineStyleScript;
+        return table;
     }
     if (error) {
         NSString* message = [NSString stringWithFormat:@"Unknown environment: %@", env];

--- a/iosMath/lib/MTMathAtomFactory.m
+++ b/iosMath/lib/MTMathAtomFactory.m
@@ -445,7 +445,7 @@ static const CGFloat kSmallMatrixInterColumnSpacing = 5;
         [table setAlignment:kMTColumnAlignmentRight forColumn:0];
         [table setAlignment:kMTColumnAlignmentLeft forColumn:1];
         return table;
-    } else if ([env isEqualToString:@"displaylines"] || [env isEqualToString:@"gather"]) {
+    } else if ([env isEqualToString:@"displaylines"] || [env isEqualToString:@"gather"] || [env isEqualToString:@"gathered"]) {
         if (table.numColumns != 1) {
             NSString* message = [NSString stringWithFormat:@"%@ environment can only have 1 column", env];
             if (error != nil) {

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -1485,6 +1485,27 @@ static NSArray* getTestDataLeftRight() {
     }
 }
 
+- (void) testGathered
+{
+    NSString *str = @"\\begin{gathered} x \\\\ y \\end{gathered}";
+    MTMathList* list = [MTMathListBuilder buildFromString:str];
+
+    XCTAssertNotNil(list);
+    XCTAssertEqualObjects(@(list.atoms.count), @1);
+    MTMathTable* table = list.atoms[0];
+    XCTAssertEqual(table.type, kMTMathAtomTable);
+    XCTAssertEqualObjects(table.environment, @"gathered");
+    XCTAssertEqual(table.interRowAdditionalSpacing, 1);
+    XCTAssertEqual(table.interColumnSpacing, 0);
+    XCTAssertEqual(table.numRows, 2);
+    XCTAssertEqual(table.numColumns, 1);
+    XCTAssertEqual([table getAlignmentForColumn:0], kMTColumnAlignmentCenter);
+
+    // single centered column, no injected atoms — straight round-trip
+    NSString* latex = [MTMathListBuilder mathListToString:list];
+    XCTAssertEqualObjects(latex, @"\\begin{gathered}x\\\\ y\\end{gathered}");
+}
+
 static NSArray* getTestDataParseErrors() {
     return @[
               @[@"}a", @(MTParseErrorMismatchBraces)],
@@ -1519,6 +1540,7 @@ static NSArray* getTestDataParseErrors() {
               @[@"\\begin{matrix} \\notacommand \\end{matrix}", @(MTParseErrorInvalidCommand)],
               @[@"\\begin{displaylines} x & y \\end{displaylines}", @(MTParseErrorInvalidNumColumns)],
               @[@"\\begin{eqalign} x \\end{eqalign}", @(MTParseErrorInvalidNumColumns)],
+              @[@"\\begin{gathered} x & y \\end{gathered}", @(MTParseErrorInvalidNumColumns)],
               @[@"\\nolimits", @(MTParseErrorInvalidLimits)],
               @[@"\\frac\\limits{1}{2}", @(MTParseErrorInvalidLimits)],
               // REN-6: generalized-fraction commands are illegal in one-char script slots

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -1242,6 +1242,42 @@ static NSArray* getTestDataLeftRight() {
     XCTAssertEqualObjects(latex, @"\\begin{matrix}x&y\\\\ z&w\\end{matrix}");
 }
 
+- (void) testSmallMatrix
+{
+    NSString *str = @"\\begin{smallmatrix} x & y \\\\ z & w \\end{smallmatrix}";
+    MTMathList* list = [MTMathListBuilder buildFromString:str];
+
+    XCTAssertNotNil(list);
+    XCTAssertEqualObjects(@(list.atoms.count), @1);
+    MTMathTable* table = list.atoms[0];
+    XCTAssertEqual(table.type, kMTMathAtomTable);
+    XCTAssertEqualObjects(table.nucleus, @"");
+    XCTAssertEqualObjects(table.environment, @"smallmatrix");
+    XCTAssertEqual(table.interRowAdditionalSpacing, 0);
+    // Honest amsmath value: \thickspace = 5mu, stored unscaled. PR 1's renderer
+    // scales it to the Script cell style at layout time (5 * scriptScaleDown outer-mu).
+    XCTAssertEqual(table.interColumnSpacing, 5);
+    XCTAssertEqual(table.numRows, 2);
+    XCTAssertEqual(table.numColumns, 2);
+    // Cells render in scriptstyle, stored on the table rather than per-cell.
+    XCTAssertEqual(table.cellStyle, kMTLineStyleScript);
+
+    for (int i = 0; i < 2; i++) {
+        MTColumnAlignment alignment = [table getAlignmentForColumn:i];
+        XCTAssertEqual(alignment, kMTColumnAlignmentCenter);
+        for (int j = 0; j < 2; j++) {
+            MTMathList* cell = table.cells[j][i];
+            XCTAssertEqual(cell.atoms.count, 1);
+            MTMathAtom* atom = cell.atoms[0];
+            XCTAssertEqual(atom.type, kMTMathAtomVariable);
+        }
+    }
+
+    // round-trip: cells carry no injected style atom (style is on table.cellStyle)
+    NSString* latex = [MTMathListBuilder mathListToString:list];
+    XCTAssertEqualObjects(latex, @"\\begin{smallmatrix}x&y\\\\ z&w\\end{smallmatrix}");
+}
+
 - (void) testPMatrix
 {
     NSString *str = @"\\begin{pmatrix} x & y \\\\ z & w \\end{pmatrix}";

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -3245,4 +3245,40 @@
                                @"Ord->Ord: no space after the group");
 }
 
+- (void) testSmallMatrixColumnGap
+{
+    // The stored 5mu \thickspace renders scaled to the Script cell style (PR 1):
+    // gap = 5 * muUnit * scriptScaleDown. Using identical cells makes every column
+    // the same width, so center alignment adds no offset and the gap between the two
+    // columns is exactly col1.x - col0.x - col0.width.
+    MTMathList* list = [MTMathListBuilder buildFromString:@"\\begin{smallmatrix} a & a \\\\ a & a \\end{smallmatrix}"];
+    XCTAssertNotNil(list);
+
+    MTMathListDisplay* display = [MTTypesetter createLineForMathList:list font:self.font style:kMTLineStyleDisplay];
+    MTMathListDisplay* table = (MTMathListDisplay*) display.subDisplays[0];
+    MTMathListDisplay* row0 = (MTMathListDisplay*) table.subDisplays[0];
+    XCTAssertEqual(row0.subDisplays.count, 2);
+    MTDisplay* col0 = row0.subDisplays[0];
+    MTDisplay* col1 = row0.subDisplays[1];
+
+    CGFloat expectedGap = 5.0 * self.font.mathTable.muUnit * self.font.mathTable.scriptScaleDown;
+    CGFloat actualGap = col1.position.x - col0.position.x - col0.width;
+    XCTAssertEqualWithAccuracy(actualGap, expectedGap, 0.01);
+}
+
+- (void) testSmallMatrixCompactVsMatrix
+{
+    // Script-size cells + the tighter \thickspace gap make smallmatrix more compact
+    // than the textstyle matrix in both width and height.
+    MTMathList* small  = [MTMathListBuilder buildFromString:@"\\begin{smallmatrix} a & b \\\\ c & d \\end{smallmatrix}"];
+    MTMathList* matrix = [MTMathListBuilder buildFromString:@"\\begin{matrix} a & b \\\\ c & d \\end{matrix}"];
+    XCTAssertNotNil(small);
+    XCTAssertNotNil(matrix);
+
+    MTMathListDisplay* smallDisp  = [MTTypesetter createLineForMathList:small  font:self.font style:kMTLineStyleDisplay];
+    MTMathListDisplay* matrixDisp = [MTTypesetter createLineForMathList:matrix font:self.font style:kMTLineStyleDisplay];
+    XCTAssertLessThan(smallDisp.width, matrixDisp.width);
+    XCTAssertLessThan(smallDisp.ascent, matrixDisp.ascent);
+}
+
 @end

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -3281,4 +3281,20 @@
     XCTAssertLessThan(smallDisp.ascent, matrixDisp.ascent);
 }
 
+- (void) testGatheredMatchesGather
+{
+    MTMathList* gathered = [MTMathListBuilder buildFromString:@"\\begin{gathered} a+b \\\\ c+d \\end{gathered}"];
+    MTMathList* gather   = [MTMathListBuilder buildFromString:@"\\begin{gather} a+b \\\\ c+d \\end{gather}"];
+    XCTAssertNotNil(gathered);
+    XCTAssertNotNil(gather);
+
+    MTMathListDisplay* gatheredDisp = [MTTypesetter createLineForMathList:gathered font:self.font style:kMTLineStyleDisplay];
+    MTMathListDisplay* gatherDisp   = [MTTypesetter createLineForMathList:gather   font:self.font style:kMTLineStyleDisplay];
+
+    // gathered is layout-identical to gather (LLD §4 assumption): same factory branch.
+    XCTAssertEqualWithAccuracy(gatheredDisp.width,   gatherDisp.width,   0.01);
+    XCTAssertEqualWithAccuracy(gatheredDisp.ascent,  gatherDisp.ascent,  0.01);
+    XCTAssertEqualWithAccuracy(gatheredDisp.descent, gatherDisp.descent, 0.01);
+}
+
 @end


### PR DESCRIPTION
## Goal

Add the two subordinate amsmath environments that need no parser-argument changes — purely additive `MTMathAtomFactory` branches plus serialization and layout coverage. `smallmatrix` is a script-size centered matrix with no delimiters whose honest amsmath gap (5 mu `\thickspace`) renders correctly thanks to PR 1's cell-style scaling; `gathered` is layout-identical to the existing `gather`.

## Stack

- PR 1 (base): #245 — Typesetter cell-style gap scaling
- **PR 2 (this):** smallmatrix + gathered
- PR 3 (next): alignedat

This PR is based on `feature/subordinate-envs-pr1` and will auto-retarget to `master` once PR 1 merges.

## Design docs

- Plan: `docs/plans/2026-06-30-smallmatrix-gathered-alignedat.md` (PR 2 section)
- LLD: `docs/lld/2026-06-30-smallmatrix-gathered-alignedat.md`

## Commits

- `[item 3] Add smallmatrix environment (script-style centered matrix)` — new factory branch + `kSmallMatrixInterColumnSpacing = 5`; widened serialization style-strip. Test `testSmallMatrix`.
- `[item 4] Add smallmatrix layout tests (gap fidelity + compactness)` — `testSmallMatrixColumnGap`, `testSmallMatrixCompactVsMatrix`.
- `[item 5] Add gathered environment (folds into gather branch)` — widened the `displaylines`/`gather` condition. Test `testGathered` + stray-`&` error row.
- `[item 6] Add gathered/gather layout parity test` — `testGatheredMatchesGather`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)