### PR TITLE
TeX-faithful brace grouping (MTMathGroup) — fix #177

### DIFF
--- a/iosMath/lib/MTMathList.h
+++ b/iosMath/lib/MTMathList.h
@@ -68,6 +68,10 @@ typedef NS_ENUM(NSUInteger, MTMathAtomType)
     kMTMathAtomText = 19,
     /// A box atom (phantom/smash/lap family). Script-capable (< kMTMathAtomBoundary).
     kMTMathAtomBox = 20,
+    /// A brace group {…} in math mode — an Ord subformula whose nucleus is a
+    /// sub-mlist (== TeX Ord noad with sub_mlist / KaTeX "ordgroup").
+    /// Script-capable (< kMTMathAtomBoundary); spaced as Ordinary.
+    kMTMathAtomOrdGroup = 21,
 
     // Atoms after this point do not support subscripts or superscripts
 
@@ -643,6 +647,24 @@ typedef NS_ENUM(NSUInteger, MTBoxHAlign) {
 @property (nonatomic) BOOL drawChild;
 /// Horizontal draw offset applied when keepWidth == NO (laps).
 @property (nonatomic) MTBoxHAlign hAlign;
+
+@end
+
+/** A brace group `{…}` in math mode — an Ord subformula whose nucleus is a
+ sub-mlist. Script-capable; spaced as Ordinary. The honest analog of TeX's
+ Ord noad with a `sub_mlist` nucleus and KaTeX's `ordgroup` node. The usual
+ nucleus is empty; the grouped content lives in `innerList`, and the
+ sub/superScript fields drive scripting of the whole group. */
+@interface MTMathGroup : MTMathAtom
+
+/// Creates an empty Ord group (type = kMTMathAtomOrdGroup).
+- (instancetype) init NS_DESIGNATED_INITIALIZER;
+
+/// Throws unless type == kMTMathAtomOrdGroup.
+- (instancetype) initWithType:(MTMathAtomType)type value:(NSString *)value;
+
+/// The grouped math content.
+@property (nonatomic, nonnull) MTMathList* innerList;
 
 @end
 

--- a/iosMath/lib/MTMathList.m
+++ b/iosMath/lib/MTMathList.m
@@ -68,6 +68,8 @@ static NSString* typeToText(MTMathAtomType type) {
             return @"Text";
         case kMTMathAtomBox:
             return @"Box";
+        case kMTMathAtomOrdGroup:
+            return @"Ord Group";
         case kMTMathAtomBoundary:
             return @"Boundary";
         case kMTMathAtomSpace:
@@ -157,6 +159,9 @@ static NSString* fractionCommandForDelimiterPair(NSString* leftDelimiter, NSStri
 
         case kMTMathAtomBox:
             return [[MTMathBox alloc] init];
+
+        case kMTMathAtomOrdGroup:
+            return [[MTMathGroup alloc] init];
 
         case kMTMathAtomSpace:
             return [[MTMathSpace alloc] initWithSpace:0];
@@ -1071,6 +1076,66 @@ static NSString* fractionCommandForDelimiterPair(NSString* leftDelimiter, NSStri
     MTMathBox *newBox = [super finalized];
     newBox.innerList = newBox.innerList.finalized;
     return newBox;
+}
+
+@end
+
+#pragma mark - MTMathGroup
+
+@implementation MTMathGroup
+
+- (instancetype)init
+{
+    self = [super initWithType:kMTMathAtomOrdGroup value:@""];
+    if (self) {
+        _innerList = [MTMathList new];
+    }
+    return self;
+}
+
+- (instancetype)initWithType:(MTMathAtomType)type value:(NSString *)value
+{
+    if (type == kMTMathAtomOrdGroup) {
+        return [self init];
+    }
+    @throw [NSException exceptionWithName:@"InvalidMethod"
+                                   reason:@"[MTMathGroup initWithType:value:] cannot be called. Use [MTMathGroup init] instead."
+                                 userInfo:nil];
+}
+
+// Standalone string (description / error messages): braces + this atom's scripts.
+- (NSString *)stringValue
+{
+    NSMutableString* str = [NSMutableString stringWithFormat:@"{%@}",
+                            [MTMathListBuilder mathListToString:self.innerList]];
+    if (self.superScript) {
+        [str appendFormat:@"^{%@}", self.superScript.stringValue];
+    }
+    if (self.subScript) {
+        [str appendFormat:@"_{%@}", self.subScript.stringValue];
+    }
+    return str;
+}
+
+// List serializer: emit ONLY {inner}. mathListToString: appends this atom's own
+// ^{…}/_{…} afterwards, so emitting scripts here would double them.
+- (void)appendLaTeXToString:(NSMutableString *)str
+{
+    [str appendFormat:@"{%@}", [MTMathListBuilder mathListToString:self.innerList]];
+}
+
+- (id)copyWithZone:(NSZone *)zone
+{
+    MTMathGroup* group = [super copyWithZone:zone];
+    group.innerList = [self.innerList copyWithZone:zone];
+    return group;
+}
+
+- (instancetype)finalized
+{
+    MTMathGroup* newGroup = [super finalized];
+    newGroup.innerList = newGroup.innerList.finalized;
+    return newGroup;
 }
 
 @end

--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -250,6 +250,11 @@ static const NSInteger kMTMaxRecursionDepth = 150;
                 // \brack, \brace) fired inside this group. The resulting fraction
                 // replaces the group in the parent list (TeX behavior) — do NOT
                 // wrap in MTMathGroup. Fall through to continue after appending.
+                // Update prevAtom to the last appended atom so a following ^ / _ /
+                // prime attaches to the fraction (or field atom), not a spurious
+                // empty Ord — mirrors the pre-grouping behavior and the shared
+                // append path below (prevAtom = atom).
+                prevAtom = [sublist.atoms lastObject];
                 [list append:sublist];
                 if (oneCharOnly) {
                     return list;

--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -51,6 +51,11 @@ static const NSInteger kMTMaxRecursionDepth = 150;
     MTFontStyle _currentFontStyle;
     BOOL _spacesAllowed;
     NSInteger _recursionDepth;
+    // Set to YES by stopCommand when a TeX group-transformation command (\over,
+    // \atop, \choose, \brack, \brace) fires inside a {…} group. Checked in the
+    // {…} branch to decide whether to wrap as MTMathGroup. Cleared at the top of
+    // every buildInternal call so the check is always fresh.
+    BOOL _groupWasTransformedByStopCommand;
 }
 
 - (instancetype)initWithString:(NSString *)str
@@ -171,6 +176,7 @@ static const NSInteger kMTMaxRecursionDepth = 150;
         return nil;
     }
     _recursionDepth++;
+    _groupWasTransformedByStopCommand = NO;
     @try {
     MTMathList* list = [MTMathList new];
     NSAssert(!(oneCharOnly && (stop > 0)), @"Cannot set both oneCharOnly and stopChar.");
@@ -224,12 +230,33 @@ static const NSInteger kMTMaxRecursionDepth = 150;
         } else if (ch == '{') {
             // this puts us in a recursive routine, and sets oneCharOnly to false and no stop character
             MTMathList* sublist = [self buildInternal:false stopChar:'}'];
-            prevAtom = [sublist.atoms lastObject];
-            [list append:sublist];
-            if (oneCharOnly) {
-                return list;
+            if (!sublist) {
+                // inner error already set (e.g. missing closing brace); propagate.
+                return nil;
             }
-            continue;
+            BOOL transformed = _groupWasTransformedByStopCommand;
+            if (oneCharOnly || transformed) {
+                // Field brace (^{…}, _{…}, \frac{…}, command argument): the {…}
+                // *is* the field. Flatten and return it as the field — unchanged.
+                // Also: a group-transforming command (\over, \atop, \choose,
+                // \brack, \brace) fired inside this group. The resulting fraction
+                // replaces the group in the parent list (TeX behavior) — do NOT
+                // wrap in MTMathGroup. Fall through to continue after appending.
+                [list append:sublist];
+                if (oneCharOnly) {
+                    return list;
+                }
+                continue;
+            }
+            // Grouping brace in the main list: wrap as an Ord subformula so style
+            // nodes are scoped, scripts target the whole group, and Bin/Ord
+            // reclassification stops at the brace boundary
+            // (== TeX Ord-noad-with-sub_mlist / KaTeX ordgroup).
+            MTMathGroup* group = [[MTMathGroup alloc] init];
+            group.innerList = sublist;
+            atom = group;
+            // fall through to the shared append path below: it sets prevAtom = group
+            // (so {x}^2 scripts the group) and finalize assigns the indexRange.
         } else if (ch == '}') {
             NSAssert(!oneCharOnly, @"This should have been handled before");
             NSAssert(stop == 0, @"This should have been handled before");
@@ -1178,6 +1205,12 @@ static const NSInteger kMTMaxRecursionDepth = 150;
         }
         MTMathList* fracList = [MTMathList new];
         [fracList addAtom:frac];
+        // Signal to the {…} branch that this group was transformed by a TeX
+        // group-transformation command (\over / \atop / \choose / \brack / \brace).
+        // The fraction should be inserted into the parent list directly (not wrapped
+        // in MTMathGroup), mirroring TeX's behavior where these commands replace the
+        // enclosing group with a generalized fraction.
+        _groupWasTransformedByStopCommand = YES;
         return fracList;
     } else if ([command isEqualToString:@"\\"] || [command isEqualToString:@"cr"]) {
         if (_currentEnv) {

--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -234,7 +234,15 @@ static const NSInteger kMTMaxRecursionDepth = 150;
                 // inner error already set (e.g. missing closing brace); propagate.
                 return nil;
             }
+            // Read-and-clear: a \over/\atop-\class transform fired by an INNER
+            // group must not leak into THIS (enclosing) group's decision. The flag
+            // is set in stopCommand: and reset at the top of each buildInternal:,
+            // but the inner recursion runs between our reset and this read, so
+            // without clearing here a transformed inner group would wrongly
+            // suppress wrapping of the outer group (dropping it + leaking any
+            // \scriptstyle inside it — a #177 regression).
             BOOL transformed = _groupWasTransformedByStopCommand;
+            _groupWasTransformedByStopCommand = NO;
             if (oneCharOnly || transformed) {
                 // Field brace (^{…}, _{…}, \frac{…}, command argument): the {…}
                 // *is* the field. Flatten and return it as the field — unchanged.

--- a/iosMath/render/internal/MTTypesetter.m
+++ b/iosMath/render/internal/MTTypesetter.m
@@ -51,6 +51,7 @@ NSUInteger getInterElementSpaceArrayIndexForType(MTMathAtomType type, BOOL row) 
         case kMTMathAtomColor:
         case kMTMathAtomColorbox:
         case kMTMathAtomOrdinary:
+        case kMTMathAtomOrdGroup:       // Ord group is spaced as Ordinary
         case kMTMathAtomPlaceholder:   // A placeholder is treated as ordinary
         case kMTMathAtomText:          // Text blocks are spaced as Ord
             return 0;
@@ -704,6 +705,31 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
 
                 if (atom.subScript || atom.superScript) {
                     [self makeScripts:atom display:display index:atom.indexRange.location delta:0];
+                }
+                break;
+            }
+
+            case kMTMathAtomOrdGroup: {
+                // A brace group {…}: an Ord subformula. Lay out its sub-mlist with a
+                // fresh typesetter — that recursion scopes any interior style node
+                // (the #177 fix) — then place the child inline like \color and run
+                // scripts on the whole group.
+                if (_currentLine.length > 0) {
+                    [self addDisplayLine];
+                }
+                // Spaced as Ordinary: reclassify before any inter-element lookup
+                // (mirrors the Box case), so it never reaches the default assert.
+                [self addInterElementSpace:prevNode currentType:kMTMathAtomOrdinary];
+                atom.type = kMTMathAtomOrdinary;
+
+                MTMathGroup* groupAtom = (MTMathGroup*) atom;
+                MTMathListDisplay* child = [MTTypesetter createLineForMathList:groupAtom.innerList font:_font style:_style];
+                child.position = _currentPosition;
+                _currentPosition.x += child.width;
+                [_displayAtoms addObject:child];
+
+                if (atom.subScript || atom.superScript) {
+                    [self makeScripts:atom display:child index:atom.indexRange.location delta:0];
                 }
                 break;
             }

--- a/iosMath/render/internal/MTTypesetter.m
+++ b/iosMath/render/internal/MTTypesetter.m
@@ -51,7 +51,6 @@ NSUInteger getInterElementSpaceArrayIndexForType(MTMathAtomType type, BOOL row) 
         case kMTMathAtomColor:
         case kMTMathAtomColorbox:
         case kMTMathAtomOrdinary:
-        case kMTMathAtomOrdGroup:       // Ord group is spaced as Ordinary
         case kMTMathAtomPlaceholder:   // A placeholder is treated as ordinary
         case kMTMathAtomText:          // Text blocks are spaced as Ord
             return 0;

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -3480,4 +3480,24 @@ static NSArray* getTestDataLargeDelimiters() {
                    @"z must be a plain top-level variable, not style-contaminated");
 }
 
+- (void)testScriptAfterOverTransformedGroupAttachesToFraction
+{
+    // {a \over b}^2 — \over transforms the enclosing group into a Fraction at
+    // the parent level (TeX group-transformation). The following ^2 must attach
+    // to THAT fraction, not to a spurious empty Ord. Before the prevAtom fix the
+    // transformed path appended the fraction without updating prevAtom, so the ^
+    // branch allocated an empty Ord and hung the superscript on it instead.
+    NSError* error = nil;
+    MTMathList* list = [MTMathListBuilder buildFromString:@"{a \\over b}^2" error:&error];
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(@(list.atoms.count), @1, @"expected a single fraction atom, not fraction + empty Ord");
+    MTMathAtom* frac = list.atoms[0];
+    XCTAssertEqual(frac.type, kMTMathAtomFraction, @"expected the \\over fraction");
+    XCTAssertNotNil(frac.superScript, @"^2 must attach to the fraction");
+    [self checkAtomTypes:frac.superScript types:@[ @(kMTMathAtomNumber) ] desc:@"{a \\over b}^2 superscript"];
+    // Round-trip: \over normalizes to \frac{}{} on serialization (existing
+    // behavior); the superscript stays on the fraction.
+    XCTAssertEqualObjects([MTMathListBuilder mathListToString:list], @"\\frac{a}{b}^{2}");
+}
+
 @end

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -59,8 +59,8 @@ static NSArray* getTestData() {
              @[ @"x+2", @[ @(kMTMathAtomVariable), @(kMTMathAtomBinaryOperator), @(kMTMathAtomNumber) ], @"x+2"],
              // spaces are ignored
              @[ @"(2.3 * 8)", @[ @(kMTMathAtomOpen), @(kMTMathAtomNumber), @(kMTMathAtomNumber), @(kMTMathAtomNumber), @(kMTMathAtomBinaryOperator), @(kMTMathAtomNumber) , @(kMTMathAtomClose) ], @"(2.3*8)"],
-             // braces are just for grouping
-             @[ @"5{3+4}", @[@(kMTMathAtomNumber), @(kMTMathAtomNumber), @(kMTMathAtomBinaryOperator), @(kMTMathAtomNumber)], @"53+4"],
+             // braces create an Ord group (MTMathGroup)
+             @[ @"5{3+4}", @[@(kMTMathAtomNumber), @(kMTMathAtomOrdGroup)], @"5{3+4}"],
              // commands
              @[ @"\\pi+\\theta\\geq 3",@[ @(kMTMathAtomVariable), @(kMTMathAtomBinaryOperator), @(kMTMathAtomVariable), @(kMTMathAtomRelation), @(kMTMathAtomNumber)], @"\\pi +\\theta \\geq 3"],
              // aliases
@@ -102,9 +102,9 @@ static NSArray* getTestDataSuperScript() {
              @[ @"x^{2^3}", @[ @(kMTMathAtomVariable) ], @[ @(kMTMathAtomNumber)], @[ @(kMTMathAtomNumber),], @"x^{2^{3}}"],
              @[ @"x^{^2*}", @[ @(kMTMathAtomVariable) ], @[ @(kMTMathAtomOrdinary), @(kMTMathAtomBinaryOperator)], @[ @(kMTMathAtomNumber),], @"x^{{}^{2}*}"],
              @[ @"^2", @ [ @(kMTMathAtomOrdinary)], @[ @(kMTMathAtomNumber) ], @"{}^{2}"],
-             @[ @"{}^2", @ [ @(kMTMathAtomOrdinary)], @[ @(kMTMathAtomNumber) ], @"{}^{2}"],
+             @[ @"{}^2", @ [ @(kMTMathAtomOrdGroup)], @[ @(kMTMathAtomNumber) ], @"{}^{2}"],
              @[ @"x^^2", @[ @(kMTMathAtomVariable), @(kMTMathAtomOrdinary) ],  @[ ], @"x^{}{}^{2}"],
-             @[ @"5{x}^2", @ [ @(kMTMathAtomNumber), @(kMTMathAtomVariable)], @[ ], @"5x^{2}"],
+             @[ @"5{x}^2", @ [ @(kMTMathAtomNumber), @(kMTMathAtomOrdGroup)], @[ ], @"5{x}^{2}"],
              ];
 }
 
@@ -152,9 +152,9 @@ static NSArray* getTestDataSubScript() {
              @[ @"x_{2_3}", @[ @(kMTMathAtomVariable) ], @[ @(kMTMathAtomNumber)], @[ @(kMTMathAtomNumber),], @"x_{2_{3}}"],
              @[ @"x_{_2*}", @[ @(kMTMathAtomVariable) ], @[ @(kMTMathAtomOrdinary), @(kMTMathAtomBinaryOperator)], @[ @(kMTMathAtomNumber),], @"x_{{}_{2}*}"],
              @[ @"_2", @ [ @(kMTMathAtomOrdinary)], @[ @(kMTMathAtomNumber) ], @"{}_{2}" ],
-             @[ @"{}_2", @ [ @(kMTMathAtomOrdinary)], @[ @(kMTMathAtomNumber) ], @"{}_{2}" ],
+             @[ @"{}_2", @ [ @(kMTMathAtomOrdGroup)], @[ @(kMTMathAtomNumber) ], @"{}_{2}" ],
              @[ @"x__2", @[ @(kMTMathAtomVariable), @(kMTMathAtomOrdinary) ],  @[ ], @"x_{}{}_{2}"],
-             @[ @"5{x}_2", @ [ @(kMTMathAtomNumber), @(kMTMathAtomVariable)], @[ ], @"5x_{2}"],
+             @[ @"5{x}_2", @ [ @(kMTMathAtomNumber), @(kMTMathAtomOrdGroup)], @[ ], @"5{x}_{2}"],
              ];
 }
 
@@ -407,16 +407,21 @@ static NSArray* getTestDataSuperSubScript() {
 
 - (void) testSqrtInGroup
 {
-    // A \sqrt with no argument inside a group exercises a different path
-    // (empty radicand via the oneCharOnly stop-char guard) than the
-    // end-of-input case, and must also not crash.
+    // A \sqrt with no argument inside a brace group. With MTMathGroup semantics,
+    // the {…} wraps as an Ord subformula — the radical lives inside the group.
+    // This exercises the MTMathGroup path without crashing.
     NSString *str = @"{\\sqrt}";
     MTMathList* list = [MTMathListBuilder buildFromString:str];
     NSString* desc = [NSString stringWithFormat:@"Error for string:%@", str];
 
     XCTAssertNotNil(list, @"%@", desc);
     XCTAssertEqualObjects(@(list.atoms.count), @1, @"%@", desc);
-    MTRadical* rad = list.atoms[0];
+    // The outer atom is an MTMathGroup (Ord subformula wrapping the radical).
+    MTMathGroup* group = list.atoms[0];
+    XCTAssertEqual(group.type, kMTMathAtomOrdGroup, @"%@", desc);
+
+    XCTAssertEqualObjects(@(group.innerList.atoms.count), @1, @"%@", desc);
+    MTRadical* rad = group.innerList.atoms[0];
     XCTAssertEqual(rad.type, kMTMathAtomRadical, @"%@", desc);
 
     MTMathList *subList = rad.radicand;
@@ -424,9 +429,9 @@ static NSArray* getTestDataSuperSubScript() {
     XCTAssertEqualObjects(@(subList.atoms.count), @0, @"%@", desc);
     XCTAssertNil(rad.degree, @"%@", desc);
 
-    // convert it back to latex
+    // convert it back to latex — braces preserved, radical serializes as \sqrt{}
     NSString* latex = [MTMathListBuilder mathListToString:list];
-    XCTAssertEqualObjects(latex, @"\\sqrt{}", @"%@", desc);
+    XCTAssertEqualObjects(latex, @"{\\sqrt{}}", @"%@", desc);
 }
 
 - (void) testSqrtInSqrt
@@ -3382,6 +3387,63 @@ static NSArray* getTestDataLargeDelimiters() {
     // \mathstrut serializes lossily to \vphantom{(}
     XCTAssertEqualObjects([MTMathListBuilder mathListToString:
         [MTMathListBuilder buildFromString:@"\\mathstrut"]], @"\\vphantom{(}");
+}
+
+- (void)testBraceGrouping
+{
+    // x{\scriptstyle y}z — the issue #177 case. The group is a distinct atom;
+    // \scriptstyle lives inside it; round-trips with braces preserved.
+    NSError* error = nil;
+    MTMathList* list = [MTMathListBuilder buildFromString:@"x{\\scriptstyle y}z" error:&error];
+    XCTAssertNil(error);
+    [self checkAtomTypes:list
+                   types:@[ @(kMTMathAtomVariable), @(kMTMathAtomOrdGroup), @(kMTMathAtomVariable) ]
+                    desc:@"x{\\scriptstyle y}z"];
+    MTMathGroup* group = (MTMathGroup*) list.atoms[1];
+    XCTAssertTrue([group isKindOfClass:[MTMathGroup class]]);
+    [self checkAtomTypes:group.innerList
+                   types:@[ @(kMTMathAtomStyle), @(kMTMathAtomVariable) ]
+                    desc:@"group innerList"];
+    XCTAssertEqualObjects([MTMathListBuilder mathListToString:list], @"x{\\scriptstyle y}z");
+
+    // {x}^2 — the script attaches to the whole group.
+    list = [MTMathListBuilder buildFromString:@"{x}^2" error:&error];
+    XCTAssertNil(error);
+    [self checkAtomTypes:list types:@[ @(kMTMathAtomOrdGroup) ] desc:@"{x}^2"];
+    group = (MTMathGroup*) list.atoms[0];
+    XCTAssertNotNil(group.superScript, @"superscript must be on the group");
+    [self checkAtomTypes:group.superScript types:@[ @(kMTMathAtomNumber) ] desc:@"{x}^2 script"];
+    XCTAssertEqualObjects([MTMathListBuilder mathListToString:list], @"{x}^{2}");
+
+    // {a+b} — Bin classification stays inside the group; round-trips with braces.
+    list = [MTMathListBuilder buildFromString:@"{a+b}c" error:&error];
+    XCTAssertNil(error);
+    [self checkAtomTypes:list types:@[ @(kMTMathAtomOrdGroup), @(kMTMathAtomVariable) ] desc:@"{a+b}c"];
+    XCTAssertEqualObjects([MTMathListBuilder mathListToString:list], @"{a+b}c");
+
+    // Nested {{x}} — outer group's innerList holds a single inner group.
+    list = [MTMathListBuilder buildFromString:@"{{x}}" error:&error];
+    XCTAssertNil(error);
+    [self checkAtomTypes:list types:@[ @(kMTMathAtomOrdGroup) ] desc:@"{{x}}"];
+    group = (MTMathGroup*) list.atoms[0];
+    [self checkAtomTypes:group.innerList types:@[ @(kMTMathAtomOrdGroup) ] desc:@"{{x}} inner"];
+    XCTAssertEqualObjects([MTMathListBuilder mathListToString:list], @"{{x}}");
+
+    // Empty {} — a group with an empty innerList; round-trips as {}.
+    list = [MTMathListBuilder buildFromString:@"{}" error:&error];
+    XCTAssertNil(error);
+    [self checkAtomTypes:list types:@[ @(kMTMathAtomOrdGroup) ] desc:@"{}"];
+    group = (MTMathGroup*) list.atoms[0];
+    XCTAssertEqual(group.innerList.atoms.count, 0u);
+    XCTAssertEqualObjects([MTMathListBuilder mathListToString:list], @"{}");
+
+    // Field braces must NOT wrap: ^{\scriptstyle y}z keeps the style scoped to the
+    // superscript field, with no group wrapper and no leak onto z.
+    list = [MTMathListBuilder buildFromString:@"x^{\\scriptstyle y}z" error:&error];
+    XCTAssertNil(error);
+    [self checkAtomTypes:list types:@[ @(kMTMathAtomVariable), @(kMTMathAtomVariable) ] desc:@"x^{...}z"];
+    MTMathList* super0 = ((MTMathAtom*) list.atoms[0]).superScript;
+    [self checkAtomTypes:super0 types:@[ @(kMTMathAtomStyle), @(kMTMathAtomVariable) ] desc:@"super field"];
 }
 
 @end

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -3446,4 +3446,38 @@ static NSArray* getTestDataLargeDelimiters() {
     [self checkAtomTypes:super0 types:@[ @(kMTMathAtomStyle), @(kMTMathAtomVariable) ] desc:@"super field"];
 }
 
+- (void)testBraceGroupingAroundOverTransform
+{
+    // Regression: an inner group transformed by \over must NOT cause the
+    // ENCLOSING group to be dropped. {{a \over b}c} → the outer group survives,
+    // wrapping [Fraction, Variable(c)] (the inner {a \over b} became a Fraction,
+    // but that transform is scoped to the inner group only).
+    NSError* error = nil;
+    MTMathList* list = [MTMathListBuilder buildFromString:@"{{a \\over b}c}" error:&error];
+    XCTAssertNil(error);
+    [self checkAtomTypes:list types:@[ @(kMTMathAtomOrdGroup) ] desc:@"{{a \\over b}c} top"];
+    MTMathGroup* group = (MTMathGroup*) list.atoms[0];
+    XCTAssertTrue([group isKindOfClass:[MTMathGroup class]]);
+    [self checkAtomTypes:group.innerList
+                   types:@[ @(kMTMathAtomFraction), @(kMTMathAtomVariable) ]
+                    desc:@"{{a \\over b}c} inner"];
+
+    // The #177 leak variant: \scriptstyle inside the enclosing group must stay
+    // scoped to that group even when a leading inner group was \over-transformed.
+    // Before the fix the inner group's "transformed" flag leaked upward, the
+    // outer group was dropped, and \scriptstyle escaped onto z.
+    list = [MTMathListBuilder buildFromString:@"{{a \\over b}\\scriptstyle c}z" error:&error];
+    XCTAssertNil(error);
+    [self checkAtomTypes:list
+                   types:@[ @(kMTMathAtomOrdGroup), @(kMTMathAtomVariable) ]
+                    desc:@"{{a \\over b}\\scriptstyle c}z top"];
+    group = (MTMathGroup*) list.atoms[0];
+    [self checkAtomTypes:group.innerList
+                   types:@[ @(kMTMathAtomFraction), @(kMTMathAtomStyle), @(kMTMathAtomVariable) ]
+                    desc:@"group innerList"];
+    // z is a separate top-level atom — \scriptstyle did NOT leak out of the group.
+    XCTAssertEqual(((MTMathAtom*) list.atoms[1]).type, kMTMathAtomVariable,
+                   @"z must be a plain top-level variable, not style-contaminated");
+}
+
 @end

--- a/iosMathTests/MTMathListTest.m
+++ b/iosMathTests/MTMathListTest.m
@@ -951,4 +951,31 @@ _XCTPrimitiveAssertNotEqual(test, expression1, @#expression1, expression2, @#exp
     XCTAssertThrows([[MTMathBox alloc] initWithType:kMTMathAtomOrdinary value:@""]);
 }
 
+- (void)testMathGroupAtom
+{
+    // Factory returns an MTMathGroup for the OrdGroup type.
+    MTMathAtom* atom = [MTMathAtom atomWithType:kMTMathAtomOrdGroup value:@""];
+    XCTAssertTrue([atom isKindOfClass:[MTMathGroup class]]);
+    XCTAssertEqual(atom.type, kMTMathAtomOrdGroup);
+
+    // Scripts are allowed (type < kMTMathAtomBoundary): no "scripts not allowed" throw.
+    XCTAssertTrue(atom.scriptsAllowed);
+    XCTAssertNoThrow(atom.superScript = [MTMathListBuilder buildFromString:@"2"]);
+
+    // stringValue braces the group and preserves an interior \scriptstyle
+    // (uses mathListToString:, not innerList.stringValue).
+    MTMathGroup* group = (MTMathGroup*) [MTMathAtom atomWithType:kMTMathAtomOrdGroup value:@""];
+    group.innerList = [MTMathListBuilder buildFromString:@"\\scriptstyle y"];
+    XCTAssertEqualObjects(group.stringValue, @"{\\scriptstyle y}");
+
+    // copyWithZone: deep-copies innerList (distinct object, equal content).
+    MTMathGroup* copy = [group copy];
+    XCTAssertNotEqual(copy.innerList, group.innerList);
+    XCTAssertEqualObjects([MTMathListBuilder mathListToString:copy.innerList],
+                          [MTMathListBuilder mathListToString:group.innerList]);
+
+    // initWithType: guard — only kMTMathAtomOrdGroup is permitted.
+    XCTAssertThrows([[MTMathGroup alloc] initWithType:kMTMathAtomBox value:@""]);
+}
+
 @end

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -3093,4 +3093,53 @@
     XCTAssertNotNil(d);
 }
 
+- (void)testScriptStyleDoesNotLeakPastBraceGroup {
+    // Issue #177: x{\scriptstyle y}z — \scriptstyle must be scoped to the group;
+    // z must render in the outer (display) style, not scriptstyle.
+    MTMathListDisplay* display = [self displayForLaTeX:@"x{\\scriptstyle y}z"];
+    XCTAssertNotNil(display);
+    XCTAssertEqual(display.subDisplays.count, 3u,
+                   @"Expected [CTLine(x), group MTMathListDisplay, CTLine(z)]");
+
+    MTDisplay* xLine = display.subDisplays[0];
+    MTDisplay* groupSub = display.subDisplays[1];
+    MTDisplay* zLine = display.subDisplays[2];
+    XCTAssertTrue([xLine isKindOfClass:[MTCTLineDisplay class]]);
+    XCTAssertTrue([groupSub isKindOfClass:[MTMathListDisplay class]]);
+    XCTAssertTrue([zLine isKindOfClass:[MTCTLineDisplay class]]);
+
+    // z is full display style (same ascent as x) — the leak is fixed.
+    XCTAssertEqualWithAccuracy(zLine.ascent, xLine.ascent, 0.01,
+                               @"z leaked \\scriptstyle: z ascent %.3f != x ascent %.3f",
+                               zLine.ascent, xLine.ascent);
+    // The group's interior y IS in scriptstyle — smaller than display-style x.
+    XCTAssertLessThan(groupSub.ascent, xLine.ascent,
+                      @"group interior should be scriptstyle (smaller)");
+}
+
+- (void)testBraceGroupRenders {
+    // {x}^2 renders without error and produces a group MTMathListDisplay.
+    MTMathListDisplay* display = [self displayForLaTeX:@"{x}^2"];
+    XCTAssertNotNil(display);
+    BOOL hasGroup = NO;
+    for (MTDisplay* d in display.subDisplays) {
+        if ([d isKindOfClass:[MTMathListDisplay class]]) { hasGroup = YES; break; }
+    }
+    XCTAssertTrue(hasGroup, @"Expected a group MTMathListDisplay for {x}^2");
+}
+
+- (void)testBraceGroupAddsNoSpuriousSpacing {
+    // a{b}c — an Ordinary-class group adds no inter-element space (Ord->Ord = none).
+    MTMathListDisplay* display = [self displayForLaTeX:@"a{b}c"];
+    XCTAssertNotNil(display);
+    XCTAssertEqual(display.subDisplays.count, 3u);
+    MTDisplay* aLine = display.subDisplays[0];
+    MTDisplay* groupSub = display.subDisplays[1];
+    MTDisplay* cLine = display.subDisplays[2];
+    XCTAssertEqualWithAccuracy(groupSub.position.x, aLine.position.x + aLine.width, 0.01,
+                               @"Ord->Ord: no space before the group");
+    XCTAssertEqualWithAccuracy(cLine.position.x, groupSub.position.x + groupSub.width, 0.01,
+                               @"Ord->Ord: no space after the group");
+}
+
 @end


### PR DESCRIPTION
## TeX-faithful brace grouping (`MTMathGroup`)

Fixes #177.

Makes a main-list `{…}` brace group build a nested Ord subformula (`MTMathGroup` / `kMTMathAtomOrdGroup`) instead of flattening, so `\scriptstyle` (and Bin/Ord reclassification) is scoped to the group and scripts target the whole group. This is the honest analog of TeX's Ord-noad-with-`sub_mlist` / KaTeX's `ordgroup`. Field braces (`^{…}`, `_{…}`, `\frac{…}`, command args) keep flattening.

**Goal:** Introduce the `MTMathGroup` atom, wire it into the parser for main-list braces, and render it in the typesetter — fixing the `x{\scriptstyle y}z` style-leak, with the branch buildable and all tests green at each commit.

### Design docs
- Plan: `docs/plans/2026-06-30-tex-faithful-brace-grouping.md`
- LLD: `docs/lld/2026-06-30-tex-faithful-brace-grouping.md`

### Commits
- `[item 1] Add MTMathGroup atom (kMTMathAtomOrdGroup) for brace groups`
- `[item 2] Wrap main-list {…} as MTMathGroup in the parser`
- `[item 3] Render MTMathGroup in the typesetter (fix #177 style leak)`

### Notes / deviations from the plan
Beyond the plan's stated 5 data rows, three additional tests needed handling to keep the suite TeX-faithful and green:
- `testSqrtInGroup` — `{\sqrt}` now correctly wraps the radical in an `MTMathGroup`; expectation updated to `MTMathGroup{Radical}` / `{\sqrt{}}`.
- `testOverInParens` / `testAtopInParens` — `\over`/`\atop`-family commands transform the enclosing group into a parent-level fraction (TeX group-transformation), so these groups must NOT be wrapped. A private `_groupWasTransformedByStopCommand` flag skips wrapping in that case; both tests keep their original bare-fraction expectations.

Full test suite passes (all 7 test classes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
