### PR TITLE
alignedat environment (argument-reading hook)

### DIFF
--- a/iosMath/lib/MTMathAtomFactory.m
+++ b/iosMath/lib/MTMathAtomFactory.m
@@ -498,6 +498,27 @@ static const CGFloat kSmallMatrixInterColumnSpacing = 5;
         table.interColumnSpacing = kSmallMatrixInterColumnSpacing;
         table.cellStyle = kMTLineStyleScript;
         return table;
+    } else if ([env isEqualToString:@"alignedat"]) {
+        // Generalization of the aligned branch to n alignment pairs (2n columns).
+        // The parser has already validated numColumns == 2n.
+        NSInteger cols = table.numColumns;
+        // Relation spacer before each odd column (mirrors aligned's column-1 spacer,
+        // repeated per pair) for correct = / relation spacing.
+        MTMathAtom* spacer = [MTMathAtom atomWithType:kMTMathAtomOrdinary value:@""];
+        for (int i = 0; i < table.cells.count; i++) {
+            NSArray<MTMathList*>* row = table.cells[i];
+            for (int j = 0; j < row.count; j++) {
+                if (j % 2 == 1) {
+                    [row[j] insertAtom:spacer atIndex:0];
+                }
+            }
+        }
+        table.interRowAdditionalSpacing = 1;
+        table.interColumnSpacing = 0;
+        for (int j = 0; j < cols; j++) {
+            [table setAlignment:(j % 2 == 0 ? kMTColumnAlignmentRight : kMTColumnAlignmentLeft) forColumn:j];
+        }
+        return table;
     }
     if (error) {
         NSString* message = [NSString stringWithFormat:@"Unknown environment: %@", env];

--- a/iosMath/lib/MTMathList.m
+++ b/iosMath/lib/MTMathList.m
@@ -1160,6 +1160,12 @@ static NSString* fractionCommandForDelimiterPair(NSString* leftDelimiter, NSStri
             return [MTMathList mathListWithAtomsArray:atoms];
         }
     }
+    if ([self.environment isEqualToString:@"alignedat"]) {
+        if (column % 2 == 1 && cell.atoms.count >= 1 && cell.atoms[0].type == kMTMathAtomOrdinary && cell.atoms[0].nucleus.length == 0) {
+            NSArray* atoms = [cell.atoms subarrayWithRange:NSMakeRange(1, cell.atoms.count - 1)];
+            return [MTMathList mathListWithAtomsArray:atoms];
+        }
+    }
     return cell;
 }
 
@@ -1278,6 +1284,9 @@ static NSString* fractionCommandForDelimiterPair(NSString* leftDelimiter, NSStri
 {
     if (self.environment) {
         [str appendFormat:@"\\begin{%@}", self.environment];
+        if ([self.environment isEqualToString:@"alignedat"]) {
+            [str appendFormat:@"{%ld}", (long) (self.numColumns / 2)];
+        }
     }
     for (NSUInteger i = 0; i < self.numRows; i++) {
         NSArray<MTMathList*>* row = self.cells[i];

--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -17,6 +17,7 @@ NSString *const MTParseError = @"ParseError";
 @interface MTEnvProperties : NSObject
 
 @property (nonatomic, readonly) NSString* envName;
+@property (nonatomic) NSString* argument;
 @property (nonatomic) BOOL ended;
 @property (nonatomic) NSInteger numRows;
 
@@ -29,6 +30,7 @@ NSString *const MTParseError = @"ParseError";
     self = [super init];
     if (self) {
         _envName = name;
+        _argument = nil;
         _numRows = 0;
         _ended = NO;
     }
@@ -344,7 +346,7 @@ static const NSInteger kMTMaxRecursionDepth = 150;
                 return list;
             } else {
                 // Create a new table with the current list and a default env
-                MTMathAtom* table = [self buildTable:nil firstList:list row:NO];
+                MTMathAtom* table = [self buildTable:nil argument:nil firstList:list row:NO];
                 return [MTMathList mathListWithAtoms:table, nil];
             }
         } else if (ch == '\'') {
@@ -883,6 +885,47 @@ static const NSInteger kMTMaxRecursionDepth = 150;
     return env;
 }
 
+// Environments that take a mandatory raw {…} argument after \begin{env}.
+// This is the same generic gate the array LLD calls environmentsRequiringColumnSpec;
+// if both features land they must converge on one mechanism (LLD §5).
++ (NSSet<NSString*>*) environmentsTakingArgument
+{
+    static NSSet<NSString*>* envs = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        envs = [NSSet setWithObjects:@"alignedat", nil];
+    });
+    return envs;
+}
+
+// Reads the raw {…} argument after \begin{env}: require {, capture raw chars to },
+// require }. Returns the raw inside string (e.g. @"2"); interpretation happens later
+// in -buildTable:argument:firstList:row:. On a malformed argument, sets the error and
+// returns nil.
+- (nullable NSString*) readEnvironmentArgument
+{
+    if (![self expectCharacter:'{']) {
+        [self setError:MTParseErrorInvalidCommand
+               message:@"alignedat requires a numeric argument, e.g. \\begin{alignedat}{2}"];
+        return nil;
+    }
+    NSMutableString* arg = [NSMutableString string];
+    while ([self hasCharacters]) {
+        unichar ch = [self getNextCharacter];
+        if (ch == '}') {
+            [self unlookCharacter];
+            break;
+        }
+        [arg appendString:[NSString stringWithCharacters:&ch length:1]];
+    }
+    if (![self expectCharacter:'}']) {
+        [self setError:MTParseErrorInvalidCommand
+               message:@"alignedat requires a numeric argument, e.g. \\begin{alignedat}{2}"];
+        return nil;
+    }
+    return arg;
+}
+
 - (MTMathAtom*) getBoundaryAtom:(NSString*) delimiterType
 {
     NSString* delim = [self readDelimiter];
@@ -1061,7 +1104,15 @@ static const NSInteger kMTMaxRecursionDepth = 150;
         if (!env) {
             return nil;
         }
-        MTMathAtom* table = [self buildTable:env firstList:nil row:NO];
+        NSString* argument = nil;
+        if ([[MTMathListBuilder environmentsTakingArgument] containsObject:env]) {
+            argument = [self readEnvironmentArgument];
+            if (!argument) {
+                // readEnvironmentArgument already set the error.
+                return nil;
+            }
+        }
+        MTMathAtom* table = [self buildTable:env argument:argument firstList:nil row:NO];
         return table;
     } else if ([command isEqualToString:@"color"]) {
         // A color command has 2 arguments
@@ -1232,7 +1283,7 @@ static const NSInteger kMTMaxRecursionDepth = 150;
             return list;
         } else {
             // Create a new table with the current list and a default env
-            MTMathAtom* table = [self buildTable:nil firstList:list row:YES];
+            MTMathAtom* table = [self buildTable:nil argument:nil firstList:list row:YES];
             return [MTMathList mathListWithAtoms:table, nil];
         }
     } else if ([command isEqualToString:@"end"]) {
@@ -1292,11 +1343,12 @@ static const NSInteger kMTMaxRecursionDepth = 150;
     }
 }
 
-- (MTMathAtom*) buildTable:(NSString*) env firstList:(MTMathList*) firstList row:(BOOL) isRow
+- (MTMathAtom*) buildTable:(NSString*) env argument:(NSString*) argument firstList:(MTMathList*) firstList row:(BOOL) isRow
 {
     // Save the current env till an new one gets built.
     MTEnvProperties* oldEnv = _currentEnv;
     _currentEnv = [[MTEnvProperties alloc] initWithName:env];
+    _currentEnv.argument = argument;
     NSInteger currentRow = 0;
     NSInteger currentCol = 0;
     NSMutableArray<NSMutableArray<MTMathList*>*>* rows = [NSMutableArray array];

--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -923,7 +923,10 @@ static const NSInteger kMTMaxRecursionDepth = 150;
                message:@"alignedat requires a numeric argument, e.g. \\begin{alignedat}{2}"];
         return nil;
     }
-    return arg;
+    // Strip surrounding whitespace (TeX's argument scanner ignores it), matching
+    // -readColor's skipSpaces. Interior whitespace is preserved so malformed args
+    // like {2 3} still fail the digit check downstream.
+    return [arg stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
 }
 
 - (MTMathAtom*) getBoundaryAtom:(NSString*) delimiterType

--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -1385,6 +1385,32 @@ static const NSInteger kMTMaxRecursionDepth = 150;
         [self setError:MTParseErrorMissingEnd message:@"Missing \\end"];
         return nil;
     }
+    if ([_currentEnv.envName isEqualToString:@"alignedat"]) {
+        // argument is the raw {n}; require a positive integer.
+        NSString* arg = _currentEnv.argument;
+        BOOL numeric = arg.length > 0;
+        for (NSUInteger i = 0; i < arg.length; i++) {
+            unichar c = [arg characterAtIndex:i];
+            if (c < '0' || c > '9') { numeric = NO; break; }
+        }
+        NSInteger n = arg.integerValue;
+        if (!numeric || n < 1) {
+            [self setError:MTParseErrorInvalidCommand
+                   message:@"alignedat requires a numeric argument, e.g. \\begin{alignedat}{2}"];
+            return nil;
+        }
+        NSInteger maxCols = 0;
+        for (NSArray<MTMathList*>* r in rows) {
+            if ((NSInteger) r.count > maxCols) { maxCols = r.count; }
+        }
+        if (maxCols != 2 * n) {
+            NSString* message = [NSString stringWithFormat:
+                @"alignedat declares {%ld} (%ld columns) but a row has %ld columns",
+                (long) n, (long) (2 * n), (long) maxCols];
+            [self setError:MTParseErrorInvalidNumColumns message:message];
+            return nil;
+        }
+    }
     NSError* error;
     MTMathAtom* table = [MTMathAtomFactory tableWithEnvironment:_currentEnv.envName rows:rows error:&error];
     if (!table && !_error) {

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -1542,6 +1542,10 @@ static NSArray* getTestDataLeftRight() {
             }
         }
     }
+
+    // round-trip: {n} re-emitted; per-pair spacers stripped by serializedCellAtRow:column:
+    NSString* latex = [MTMathListBuilder mathListToString:list];
+    XCTAssertEqualObjects(latex, @"\\begin{alignedat}{2}10&x+&3&y\\\\ 3&x+&13&y\\end{alignedat}");
 }
 
 static NSArray* getTestDataParseErrors() {

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -1568,6 +1568,7 @@ static NSArray* getTestDataParseErrors() {
               @[@"\\mkern{1em}", @(MTParseErrorInvalidCommand)],    // mu required for \mkern
               @[@"\\kern1pt", @(MTParseErrorInvalidCommand)],      // valid number, unsupported unit
               @[@"\\kern1xx", @(MTParseErrorInvalidCommand)],      // valid number, unknown unit
+              @[@"\\begin{alignedat} x & y \\end{alignedat}", @(MTParseErrorInvalidCommand)],  // missing {n}
               ];
 };
 

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -1506,6 +1506,44 @@ static NSArray* getTestDataLeftRight() {
     XCTAssertEqualObjects(latex, @"\\begin{gathered}x\\\\ y\\end{gathered}");
 }
 
+- (void) testAlignedat
+{
+    NSString *str = @"\\begin{alignedat}{2} 10&x +& 3&y \\\\ 3&x +& 13&y \\end{alignedat}";
+    MTMathList* list = [MTMathListBuilder buildFromString:str];
+
+    XCTAssertNotNil(list);
+    XCTAssertEqualObjects(@(list.atoms.count), @1);
+    MTMathTable* table = list.atoms[0];
+    XCTAssertEqual(table.type, kMTMathAtomTable);
+    XCTAssertEqualObjects(table.environment, @"alignedat");
+    XCTAssertEqual(table.interRowAdditionalSpacing, 1);
+    XCTAssertEqual(table.interColumnSpacing, 0);
+    XCTAssertEqual(table.numRows, 2);
+    XCTAssertEqual(table.numColumns, 4);
+
+    // alternating Right / Left across the 2 alignment pairs
+    MTColumnAlignment expected[4] = {
+        kMTColumnAlignmentRight, kMTColumnAlignmentLeft,
+        kMTColumnAlignmentRight, kMTColumnAlignmentLeft };
+    for (int j = 0; j < 4; j++) {
+        XCTAssertEqual([table getAlignmentForColumn:j], expected[j]);
+    }
+
+    // a relation spacer (empty ordinary) is injected at index 0 of every odd column
+    for (int row = 0; row < 2; row++) {
+        for (int col = 0; col < 4; col++) {
+            MTMathList* cell = table.cells[row][col];
+            if (col % 2 == 1) {
+                MTMathAtom* spacer = cell.atoms[0];
+                XCTAssertEqual(spacer.type, kMTMathAtomOrdinary);
+                XCTAssertEqual(spacer.nucleus.length, 0u);
+            } else {
+                XCTAssertEqual(cell.atoms[0].type, kMTMathAtomNumber);
+            }
+        }
+    }
+}
+
 static NSArray* getTestDataParseErrors() {
     return @[
               @[@"}a", @(MTParseErrorMismatchBraces)],
@@ -1569,6 +1607,9 @@ static NSArray* getTestDataParseErrors() {
               @[@"\\kern1pt", @(MTParseErrorInvalidCommand)],      // valid number, unsupported unit
               @[@"\\kern1xx", @(MTParseErrorInvalidCommand)],      // valid number, unknown unit
               @[@"\\begin{alignedat} x & y \\end{alignedat}", @(MTParseErrorInvalidCommand)],  // missing {n}
+              @[@"\\begin{alignedat}{x} a&b \\end{alignedat}", @(MTParseErrorInvalidCommand)],      // non-numeric
+              @[@"\\begin{alignedat}{0} a&b \\end{alignedat}", @(MTParseErrorInvalidCommand)],      // n < 1
+              @[@"\\begin{alignedat}{2} a&b&c \\end{alignedat}", @(MTParseErrorInvalidNumColumns)], // 3 cols != 2n
               ];
 };
 

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -1548,6 +1548,93 @@ static NSArray* getTestDataLeftRight() {
     XCTAssertEqualObjects(latex, @"\\begin{alignedat}{2}10&x+&3&y\\\\ 3&x+&13&y\\end{alignedat}");
 }
 
+// n=1: the 2-column minimum (single alignment pair, degenerate case).
+- (void) testAlignedatSinglePair
+{
+    NSString *str = @"\\begin{alignedat}{1} x&y \\end{alignedat}";
+    MTMathList* list = [MTMathListBuilder buildFromString:str];
+
+    XCTAssertNotNil(list);
+    XCTAssertEqualObjects(@(list.atoms.count), @1);
+    MTMathTable* table = list.atoms[0];
+    XCTAssertEqual(table.type, kMTMathAtomTable);
+    XCTAssertEqualObjects(table.environment, @"alignedat");
+    XCTAssertEqual(table.numRows, 1);
+    XCTAssertEqual(table.numColumns, 2);
+    XCTAssertEqual([table getAlignmentForColumn:0], kMTColumnAlignmentRight);
+    XCTAssertEqual([table getAlignmentForColumn:1], kMTColumnAlignmentLeft);
+
+    // spacer injected into the single odd column
+    MTMathAtom* spacer = ((MTMathList*) table.cells[0][1]).atoms[0];
+    XCTAssertEqual(spacer.type, kMTMathAtomOrdinary);
+    XCTAssertEqual(spacer.nucleus.length, 0u);
+
+    NSString* latex = [MTMathListBuilder mathListToString:list];
+    XCTAssertEqualObjects(latex, @"\\begin{alignedat}{1}x&y\\end{alignedat}");
+}
+
+// Empty odd-column cell (x&&z&w, n=2): the spacer is inserted into an empty list,
+// and the strip must round-trip it back to an empty column.
+- (void) testAlignedatEmptyCell
+{
+    NSString *str = @"\\begin{alignedat}{2} x&&z&w \\end{alignedat}";
+    MTMathList* list = [MTMathListBuilder buildFromString:str];
+
+    XCTAssertNotNil(list);
+    MTMathTable* table = list.atoms[0];
+    XCTAssertEqual(table.type, kMTMathAtomTable);
+    XCTAssertEqual(table.numColumns, 4);
+
+    // The empty odd cell (col 1) contains only the injected spacer.
+    MTMathList* emptyCell = table.cells[0][1];
+    XCTAssertEqual(emptyCell.atoms.count, 1u);
+    XCTAssertEqual(((MTMathAtom*) emptyCell.atoms[0]).type, kMTMathAtomOrdinary);
+    XCTAssertEqual(((MTMathAtom*) emptyCell.atoms[0]).nucleus.length, 0u);
+
+    // Round-trip: spacer stripped, empty column preserved as &&.
+    NSString* latex = [MTMathListBuilder mathListToString:list];
+    XCTAssertEqualObjects(latex, @"\\begin{alignedat}{2}x&&z&w\\end{alignedat}");
+}
+
+// alignedat wrapped in delimiters: exercises the MTInner nesting path.
+- (void) testAlignedatInDelimiters
+{
+    NSString *str = @"\\left( \\begin{alignedat}{1} x&y \\end{alignedat} \\right)";
+    MTMathList* list = [MTMathListBuilder buildFromString:str];
+
+    XCTAssertNotNil(list);
+    XCTAssertEqualObjects(@(list.atoms.count), @1);
+    MTInner* inner = list.atoms[0];
+    XCTAssertEqual(inner.type, kMTMathAtomInner);
+    XCTAssertEqualObjects(inner.leftBoundary.nucleus, @"(");
+    XCTAssertEqualObjects(inner.rightBoundary.nucleus, @")");
+    XCTAssertEqualObjects(@(inner.innerList.atoms.count), @1);
+    MTMathTable* table = inner.innerList.atoms[0];
+    XCTAssertEqual(table.type, kMTMathAtomTable);
+    XCTAssertEqualObjects(table.environment, @"alignedat");
+    XCTAssertEqual(table.numColumns, 2);
+
+    NSString* latex = [MTMathListBuilder mathListToString:list];
+    XCTAssertEqualObjects(latex, @"\\left( \\begin{alignedat}{1}x&y\\end{alignedat}\\right) ");
+}
+
+// Whitespace surrounding the {n} argument is stripped (TeX behavior; matches readColor).
+- (void) testAlignedatWhitespaceArgument
+{
+    NSString *str = @"\\begin{alignedat}{ 2 } 10&x +& 3&y \\end{alignedat}";
+    MTMathList* list = [MTMathListBuilder buildFromString:str];
+
+    XCTAssertNotNil(list);
+    MTMathTable* table = list.atoms[0];
+    XCTAssertEqual(table.type, kMTMathAtomTable);
+    XCTAssertEqualObjects(table.environment, @"alignedat");
+    XCTAssertEqual(table.numColumns, 4);
+
+    // The stripped argument re-emits without the surrounding spaces.
+    NSString* latex = [MTMathListBuilder mathListToString:list];
+    XCTAssertEqualObjects(latex, @"\\begin{alignedat}{2}10&x+&3&y\\end{alignedat}");
+}
+
 static NSArray* getTestDataParseErrors() {
     return @[
               @[@"}a", @(MTParseErrorMismatchBraces)],
@@ -1613,6 +1700,8 @@ static NSArray* getTestDataParseErrors() {
               @[@"\\begin{alignedat} x & y \\end{alignedat}", @(MTParseErrorInvalidCommand)],  // missing {n}
               @[@"\\begin{alignedat}{x} a&b \\end{alignedat}", @(MTParseErrorInvalidCommand)],      // non-numeric
               @[@"\\begin{alignedat}{0} a&b \\end{alignedat}", @(MTParseErrorInvalidCommand)],      // n < 1
+              @[@"\\begin{alignedat}{-1} a&b \\end{alignedat}", @(MTParseErrorInvalidCommand)],     // negative (leading '-' fails digit check)
+              @[@"\\begin{alignedat}{} a&b \\end{alignedat}", @(MTParseErrorInvalidCommand)],       // empty braces
               @[@"\\begin{alignedat}{2} a&b&c \\end{alignedat}", @(MTParseErrorInvalidNumColumns)], // 3 cols != 2n
               ];
 };

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -3297,4 +3297,33 @@
     XCTAssertEqualWithAccuracy(gatheredDisp.descent, gatherDisp.descent, 0.01);
 }
 
+- (void) testAlignedatLayout
+{
+    MTMathList* list = [MTMathListBuilder buildFromString:@"\\begin{alignedat}{2} 10&x +& 3&y \\\\ 3&x +& 13&y \\end{alignedat}"];
+    XCTAssertNotNil(list);
+
+    MTMathListDisplay* display = [MTTypesetter createLineForMathList:list font:self.font style:kMTLineStyleDisplay];
+    XCTAssertNotNil(display);
+    XCTAssertEqual(display.type, kMTLinePositionRegular);
+    XCTAssertEqual(display.subDisplays.count, 1);
+
+    MTMathListDisplay* tableDisp = (MTMathListDisplay*) display.subDisplays[0];
+    XCTAssertEqual(tableDisp.subDisplays.count, 2);  // two rows
+
+    for (MTDisplay* rowSub in tableDisp.subDisplays) {
+        XCTAssertTrue([rowSub isKindOfClass:[MTMathListDisplay class]]);
+        MTMathListDisplay* row = (MTMathListDisplay*) rowSub;
+        XCTAssertEqual(row.subDisplays.count, 4);  // four columns (2 pairs)
+
+        // interColumnSpacing == 0 => pairs are butted: each column starts at or after
+        // the previous one across the row.
+        CGFloat prevX = -CGFLOAT_MAX;
+        for (MTDisplay* colSub in row.subDisplays) {
+            MTMathListDisplay* col = (MTMathListDisplay*) colSub;
+            XCTAssertGreaterThanOrEqual(col.position.x, prevX);
+            prevX = col.position.x;
+        }
+    }
+}
+
 @end


### PR DESCRIPTION
## Goal

Add `\begin{alignedat}{n}` — the only environment that reads a mandatory `{n}` argument. Introduces a generic argument-capture hook on the parser (`MTEnvProperties.argument`, `+environmentsTakingArgument`, `-readEnvironmentArgument`), threads it through a renamed `-buildTable:argument:firstList:row:`, validates `numColumns == 2n` in the parser, generalizes the `aligned` factory branch to `2n` columns, and round-trips the `{n}` argument.

## Stack

- PR 1 (base of stack): #245 — Typesetter cell-style gap scaling
- PR 2: #246 — smallmatrix + gathered
- **PR 3 (this):** alignedat (argument-reading hook)

This PR is based on `feature/subordinate-envs-pr2` and will auto-retarget to `master` once PR 1 and PR 2 merge.

## Design docs

- Plan: `docs/plans/2026-06-30-smallmatrix-gathered-alignedat.md` (PR 3 section)
- LLD: `docs/lld/2026-06-30-smallmatrix-gathered-alignedat.md`

## Commits

- `[item 7] Add \begin{env}{arg} reader and thread through buildTable` — `MTEnvProperties.argument` + `+environmentsTakingArgument` + `-readEnvironmentArgument`; renamed `-buildTable:argument:firstList:row:` with all 3 call sites updated in one commit. Missing-`{n}` error → `MTParseErrorInvalidCommand`.
- `[item 8] Add alignedat 2n validation and factory branch` — parser validates `n` (positive int) and `numColumns == 2n`; factory branch with alternating R/L alignment + spacer before odd columns. Test `testAlignedat` + 3 error rows.
- `[item 9] Round-trip alignedat {n} argument and per-pair spacers` — strip per-pair spacer for odd columns in `-serializedCellAtRow:column:`; emit `{n}` in `-appendLaTeXToString:`. Round-trip assertion in `testAlignedat`.
- `[item 10] Add alignedat layout test (4 columns, butted pairs)` — `testAlignedatLayout`.

## Tests

Full suite green: 277 tests across `MTTypesetterTest` / `MTMathListBuilderTest` / `MTMathListTest`, 0 failures.

One test-only deviation from the plan (noted in item 9): the plan's round-trip expected literal asserted `x +` (with a space), but iosMath's serialization joins atom nuclei with no whitespace — consistent with the existing `aligned` round-trip test. The expected literal was corrected to `x+`; no implementation change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)