### PR TITLE
Add missing relation, operator, and ordinary symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### v2.5.0 (2026-07-02)
+* Add missing relation, operator, and ordinary symbols reported across several issues: relations `\lt`, `\gt`, `\frown`, `\smile`, `\bowtie`, `\longmapsto`; binary operators `\bigcirc`, `\bigtriangleup`, `\bigtriangledown`, `\diamond`; and ordinaries `\surd`, `\flat`, `\natural`, `\sharp` (#101, #153, #36, #63, #147). `\bigtriangleup`/`\bigtriangledown` share glyphs with the ordinary `\triangle`/`\triangledown` but carry binary-operator spacing, and `\diamond` is a binary operator distinct from the ordinary `\diamondsuit`. `\Join` (U+2A1D) was deferred: Latin Modern Math lacks that glyph, so it cannot render from the default font.
+
 ### v2.4.0 (2026-06-30)
 * Add **box commands** for spacing and overlap control: `\phantom`, `\vphantom`, `\hphantom` (reserve space without drawing), `\smash` (draw without reserving vertical space), and the lap family `\llap`, `\rlap`, `\clap`, `\mathllap`, `\mathrlap`, `\mathclap` (#244).
 * Add over/under stacking commands: `\overset`, `\underset`, `\stackrel`, and `\stackbin` (#219).

--- a/iosMath/lib/MTMathAtomFactory.m
+++ b/iosMath/lib/MTMathAtomFactory.m
@@ -716,6 +716,15 @@ NSString *const MTSymbolDegree = @"\u00B0"; // \circ
                      @"trianglelefteq" : [MTMathAtom atomWithType:kMTMathAtomRelation value:@"\u22B4"],
                      @"trianglerighteq" : [MTMathAtom atomWithType:kMTMathAtomRelation value:@"\u22B5"],
                      @"triangleq" : [MTMathAtom atomWithType:kMTMathAtomRelation value:@"\u225C"],
+                     // '<' / '>' are literal characters, not commands, so these cannot go
+                     // through the aliases map (command -> command). Map them straight to the
+                     // relation atoms produced by the literal characters.
+                     @"lt" : [MTMathAtom atomWithType:kMTMathAtomRelation value:@"<"],
+                     @"gt" : [MTMathAtom atomWithType:kMTMathAtomRelation value:@">"],
+                     @"frown" : [MTMathAtom atomWithType:kMTMathAtomRelation value:@"\u2322"],
+                     @"smile" : [MTMathAtom atomWithType:kMTMathAtomRelation value:@"\u2323"],
+                     @"bowtie" : [MTMathAtom atomWithType:kMTMathAtomRelation value:@"\u22C8"],
+                     @"longmapsto" : [MTMathAtom atomWithType:kMTMathAtomRelation value:@"\u27FC"],
 
                      // Missing ordinaries (logic / suits / Hebrew letters / amssymb)
                      @"complement" : [MTMathAtom atomWithType:kMTMathAtomOrdinary value:@"\u2201"],
@@ -776,6 +785,12 @@ NSString *const MTSymbolDegree = @"\u00B0"; // \circ
                      @"veebar" : [MTMathAtom atomWithType:kMTMathAtomBinaryOperator value:@"\u22BB"],
                      @"triangleleft" : [MTMathAtom atomWithType:kMTMathAtomBinaryOperator value:@"\u25C1"],
                      @"triangleright" : [MTMathAtom atomWithType:kMTMathAtomBinaryOperator value:@"\u25B7"],
+                     @"diamond" : [MTMathAtom atomWithType:kMTMathAtomBinaryOperator value:@"\u22C4"],
+                     @"bigcirc" : [MTMathAtom atomWithType:kMTMathAtomBinaryOperator value:@"\u25EF"],
+                     // \bigtriangleup / \bigtriangledown share glyphs with the ordinary
+                     // \triangle (U+25B3) / \triangledown (U+25BD) but must have binary-op spacing.
+                     @"bigtriangleup" : [MTMathAtom atomWithType:kMTMathAtomBinaryOperator value:@"\u25B3"],
+                     @"bigtriangledown" : [MTMathAtom atomWithType:kMTMathAtomBinaryOperator value:@"\u25BD"],
 
                      // No limit operators
                      @"log" : [MTMathAtomFactory operatorWithName:@"log" limits:NO],
@@ -880,6 +895,10 @@ NSString *const MTSymbolDegree = @"\u00B0"; // \circ
                      @"cdots" : [MTMathAtom atomWithType:kMTMathAtomOrdinary value:@"\u22EF"],
                      @"ddots" : [MTMathAtom atomWithType:kMTMathAtomOrdinary value:@"\u22F1"],
                      @"triangle" : [MTMathAtom atomWithType:kMTMathAtomOrdinary value:@"\u25B3"],
+                     @"surd" : [MTMathAtom atomWithType:kMTMathAtomOrdinary value:@"\u221A"],
+                     @"flat" : [MTMathAtom atomWithType:kMTMathAtomOrdinary value:@"\u266D"],
+                     @"natural" : [MTMathAtom atomWithType:kMTMathAtomOrdinary value:@"\u266E"],
+                     @"sharp" : [MTMathAtom atomWithType:kMTMathAtomOrdinary value:@"\u266F"],
                      @"imath" : [MTMathAtom atomWithType:kMTMathAtomOrdinary value:@"\U0001D6A4"],
                      @"jmath" : [MTMathAtom atomWithType:kMTMathAtomOrdinary value:@"\U0001D6A5"],
                      @"partial" : [MTMathAtom atomWithType:kMTMathAtomOrdinary value:@"\U0001D715"],

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -2236,6 +2236,81 @@ static NSArray* getTestDataLargeDelimiters() {
     }
 }
 
+- (void) testMissingRelationOperatorAndOrdinarySymbols
+{
+    // command, expected nucleus, expected atom type
+    NSArray* rows = @[
+        @[ @"lt",              @0x003C, @(kMTMathAtomRelation) ],
+        @[ @"gt",              @0x003E, @(kMTMathAtomRelation) ],
+        @[ @"frown",           @0x2322, @(kMTMathAtomRelation) ],
+        @[ @"smile",           @0x2323, @(kMTMathAtomRelation) ],
+        @[ @"bowtie",          @0x22C8, @(kMTMathAtomRelation) ],
+        @[ @"longmapsto",      @0x27FC, @(kMTMathAtomRelation) ],
+        @[ @"bigcirc",         @0x25EF, @(kMTMathAtomBinaryOperator) ],
+        @[ @"bigtriangleup",   @0x25B3, @(kMTMathAtomBinaryOperator) ],
+        @[ @"bigtriangledown", @0x25BD, @(kMTMathAtomBinaryOperator) ],
+        @[ @"diamond",         @0x22C4, @(kMTMathAtomBinaryOperator) ],
+        @[ @"surd",            @0x221A, @(kMTMathAtomOrdinary) ],
+        @[ @"flat",            @0x266D, @(kMTMathAtomOrdinary) ],
+        @[ @"natural",         @0x266E, @(kMTMathAtomOrdinary) ],
+        @[ @"sharp",           @0x266F, @(kMTMathAtomOrdinary) ],
+    ];
+    XCTAssertEqual(rows.count, (NSUInteger)14);
+    for (NSArray* r in rows) {
+        NSString* cmd = r[0];
+        unichar expectedNuc = (unichar)[r[1] unsignedIntegerValue];
+        MTMathAtomType expectedType = (MTMathAtomType)[r[2] unsignedIntegerValue];
+        NSString* input = [@"\\" stringByAppendingString:cmd];
+
+        NSError* error = nil;
+        MTMathList* list = [MTMathListBuilder buildFromString:input error:&error];
+        XCTAssertNil(error, @"%@", input);
+        XCTAssertEqual(list.atoms.count, (NSUInteger)1, @"%@", input);
+        MTMathAtom* atom = list.atoms[0];
+        XCTAssertEqual(atom.type, expectedType, @"%@ type", input);
+        XCTAssertEqual(atom.nucleus.length, (NSUInteger)1, @"%@ nucleus length", input);
+        XCTAssertEqual([atom.nucleus characterAtIndex:0], expectedNuc, @"%@ nucleus", input);
+
+        // Round-trip: surround with variables so finalize keeps the atom class stable.
+        NSString* probe = [NSString stringWithFormat:@"a%@ b", input];
+        MTMathList* probeList = [MTMathListBuilder buildFromString:probe error:&error];
+        XCTAssertNil(error, @"%@", input);
+        XCTAssertEqualObjects([MTMathListBuilder mathListToString:probeList],
+                              ([NSString stringWithFormat:@"a%@ b", input]),
+                              @"round-trip %@", input);
+    }
+}
+
+- (void) testBigtriangleupIsBinaryOpDistinctFromTriangle
+{
+    // Same glyph (U+25B3), different atom class: \triangle is ordinary, \bigtriangleup is a binary op.
+    MTMathAtom* tri = [MTMathListBuilder buildFromString:@"\\triangle"].atoms[0];
+    MTMathAtom* big = [MTMathListBuilder buildFromString:@"\\bigtriangleup"].atoms[0];
+    XCTAssertEqualObjects(tri.nucleus, big.nucleus);
+    XCTAssertEqual(tri.type, kMTMathAtomOrdinary);
+    XCTAssertEqual(big.type, kMTMathAtomBinaryOperator);
+}
+
+- (void) testDiamondIsBinaryOpDistinctFromDiamondsuit
+{
+    MTMathAtom* diamond = [MTMathListBuilder buildFromString:@"\\diamond"].atoms[0];
+    MTMathAtom* suit = [MTMathListBuilder buildFromString:@"\\diamondsuit"].atoms[0];
+    XCTAssertEqual(diamond.type, kMTMathAtomBinaryOperator);
+    XCTAssertEqualObjects(diamond.nucleus, @"⋄");
+    XCTAssertEqual(suit.type, kMTMathAtomOrdinary);
+    XCTAssertEqualObjects(suit.nucleus, @"♢");
+}
+
+- (void) testStackrelFrown
+{
+    // Regression for #63: \stackrel{\frown}{AD}
+    NSError* error = nil;
+    MTMathList* list = [MTMathListBuilder buildFromString:@"\\stackrel{\\frown}{AD}" error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(list);
+    XCTAssertEqual(list.atoms.count, (NSUInteger)1);
+}
+
 - (void) testPrecedesSucceeds
 {
     NSArray* rows = @[

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -1659,6 +1659,35 @@
     }
 }
 
+- (void) testMissingSymbolsHaveGlyphsInDefaultFont
+{
+    // Every command added for the missing-symbols work must resolve to a real glyph
+    // in the default font (Latin Modern Math), never .notdef (glyph 0). \Join
+    // (U+2A1D) was deliberately excluded from this batch because Latin Modern lacks
+    // that glyph in its own table (it would only render via OS font substitution).
+    NSArray<NSString*>* commands = @[
+        @"lt", @"gt", @"frown", @"smile", @"bowtie", @"longmapsto",
+        @"bigcirc", @"bigtriangleup", @"bigtriangledown", @"diamond",
+        @"surd", @"flat", @"natural", @"sharp",
+    ];
+    MTFont* font = [[MTFontManager fontManager] defaultFont];
+    for (NSString* cmd in commands) {
+        MTMathAtom* atom = [MTMathAtomFactory atomForLatexSymbolName:cmd];
+        XCTAssertNotNil(atom, @"%@", cmd);
+        NSString* nucleus = atom.nucleus;
+        NSRange range = [nucleus rangeOfComposedCharacterSequenceAtIndex:0];
+        unichar chars[range.length];
+        [nucleus getCharacters:chars range:range];
+        CGGlyph glyphs[range.length];
+        bool found = CTFontGetGlyphsForCharacters(font.ctFont, chars, glyphs, range.length);
+        XCTAssertTrue(found, @"\\%@ (U+%04X) missing from Latin Modern Math",
+                      cmd, [nucleus characterAtIndex:0]);
+        XCTAssertNotEqual(glyphs[0], (CGGlyph)0,
+                          @"\\%@ (U+%04X) rendered as .notdef in Latin Modern Math",
+                          cmd, [nucleus characterAtIndex:0]);
+    }
+}
+
 - (void) testAllBundledFontsLoad
 {
     // Every bundled font must resolve from its <key>.otf + <key>.plist pair


### PR DESCRIPTION
## Summary

Gap-fills several standard LaTeX symbols reported across issues #101, #153, #36, #63, and #147, whose siblings already exist in `MTMathAtomFactory`. 14 commands added to the `supportedLatexSymbols` table:

| Class | Commands |
|---|---|
| **Relation** | `\lt`, `\gt`, `\frown`, `\smile`, `\bowtie`, `\longmapsto` |
| **Binary operator** | `\bigcirc`, `\bigtriangleup`, `\bigtriangledown`, `\diamond` |
| **Ordinary** | `\surd`, `\flat`, `\natural`, `\sharp` |

Notable details:
- `\lt`/`\gt` map straight to the `<`/`>` relation atoms (they can't go through the command→command aliases map, since `<`/`>` aren't commands).
- `\bigtriangleup`/`\bigtriangledown` reuse the `\triangle`/`\triangledown` glyphs (U+25B3/U+25BD) but carry **binary-operator** spacing.
- `\diamond` (U+22C4, binary op) is distinct from the ordinary `\diamondsuit` (U+2662).

## `\Join` deferred

`\Join` (U+2A1D) from the source PRD is **excluded**: Latin Modern Math (the default font) lacks that glyph in its own table — it would only render via OS-level CoreText font substitution, so it can't meet the "renders in the default font" bar. Deferred to separate work; the other 14 all render natively.

## Behavior note

Adding `\lt`/`\gt` to the symbol table populates the reverse-serialization map, so a **literal `<` now round-trips to `\lt `** (and `>` to `\gt `) instead of the bare character. This is valid LaTeX that renders identically. If literal preservation is preferred, `<`/`>` can be special-cased in `-[MTMathAtom appendLaTeXToString:]` the way `:` and `-` already are.

## Tests

- `testMissingRelationOperatorAndOrdinarySymbols` — parses all 14, asserting atom type + code point + round-trip.
- `testBigtriangleupIsBinaryOpDistinctFromTriangle` / `testDiamondIsBinaryOpDistinctFromDiamondsuit` — same-glyph class distinctions.
- `testStackrelFrown` — regression for `\stackrel{\frown}{AD}` (#63).
- `testMissingSymbolsHaveGlyphsInDefaultFont` — strict per-cmap check that all 14 resolve to real (non-`.notdef`) glyphs in Latin Modern.

Full suite: **363 tests, 0 failures** (`swift test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)