### PR TITLE
Docs: fix atom-type table + surface shipped features

### DIFF
--- a/ALGORITHM.md
+++ b/ALGORITHM.md
@@ -84,7 +84,7 @@ Defined in `MTMathList.h` as `MTMathAtomType`.
 | `kMTMathAtomColor` / `kMTMathAtomColorbox` | — | iosMath extension. Renders inner list and applies fg/bg color. |
 | `kMTMathAtomTable` | — | iosMath extension (equivalent to TeX `\halign` for matrices, aligned, cases, etc.). |
 | `kMTMathAtomText` | Ord (with sub-mlist) | iosMath extension for the `\text`/`\textrm`/`\textbf`/… family. Holds a run of text typeset upright; spaced as Ordinary (see `MTTypesetter` case). |
-| `kMTMathAtomBox` | Ord (with sub-mlist) | iosMath extension for the phantom/smash/lap family (`\phantom`, `\hphantom`, `\vphantom`, `\smash`, `\llap`, `\rlap`, `\clap`, `\mathstrut`). Script-capable. Draws (or reserves the metrics of) its inner list per per-command keep-width/height/depth flags. |
+| `kMTMathAtomBox` | Ord (with sub-mlist) | iosMath extension for the phantom/smash/lap family (`\phantom`, `\hphantom`, `\vphantom`, `\smash`, `\llap`, `\rlap`, `\clap`, `\mathstrut`). Script-capable. Draws (or reserves the metrics of) its inner list per its per-command keep-width/height/depth flags. |
 | `kMTMathAtomOrdGroup` | Ord (with sub-mlist) | iosMath extension: a brace group `{…}` in math mode — an Ord subformula whose nucleus is a sub-mlist (== TeX Ord noad with `sub_mlist`, KaTeX "ordgroup"). Script-capable; spaced as Ordinary. |
 
 **Missing noad types** (vs. TeX):

--- a/ALGORITHM.md
+++ b/ALGORITHM.md
@@ -77,12 +77,15 @@ Defined in `MTMathList.h` as `MTMathAtomType`.
 | `kMTMathAtomUnderline` | Under | Rule 10. |
 | `kMTMathAtomOverline` | Over | Rule 9. |
 | `kMTMathAtomAccent` | Acc | Rule 12. |
-| `kMTMathAtomStack` | Acc (over/under extensible) | iosMath extension. Generic over/under atom used for `\overrightarrow`, `\overleftarrow`, `\overleftrightarrow`, `\underrightarrow`, `\underleftarrow`, `\underleftrightarrow`, `\overbrace`, `\underbrace`. Retyped to `displayClass` (default Ord) before Rule 16 spacing lookup. Renders via `MTTypesetter.makeStack:` → `MTStackDisplay`. Extensible over/under rows use OpenType `stretchStackGapAboveMin` / `stretchStackGapBelowMin` for vertical clearance. |
+| `kMTMathAtomStack` | Acc (over/under extensible) | iosMath extension. Generic over/under atom used for `\overrightarrow`, `\overleftarrow`, `\overleftrightarrow`, `\underrightarrow`, `\underleftarrow`, `\underleftrightarrow`, `\overbrace`, `\underbrace`, and the two-argument stack macros `\overset`, `\underset`, `\stackrel`, `\stackbin`. Retyped to `displayClass` before Rule 16 spacing lookup — default Ord, but `\stackrel` forces Relation, `\stackbin` forces Binary, and `\overset`/`\underset` inherit the base list's class. Renders via `MTTypesetter.makeStack:` → `MTStackDisplay`. Extensible over/under rows use OpenType `stretchStackGapAboveMin` / `stretchStackGapBelowMin` for vertical clearance. |
 | `kMTMathAtomBoundary` | (for \left, \right) | Cannot appear in a `MTMathList` directly; only on `MTInner.leftBoundary` / `.rightBoundary`. Rule 19 analogue is in `MTTypesetter.makeInner:atIndex:`. |
 | `kMTMathAtomSpace` | glue/kern | Rule 2. |
 | `kMTMathAtomStyle` | style item | Rule 3. |
 | `kMTMathAtomColor` / `kMTMathAtomColorbox` | — | iosMath extension. Renders inner list and applies fg/bg color. |
 | `kMTMathAtomTable` | — | iosMath extension (equivalent to TeX `\halign` for matrices, aligned, cases, etc.). |
+| `kMTMathAtomText` | Ord (with sub-mlist) | iosMath extension for the `\text`/`\textrm`/`\textbf`/… family. Holds a run of text typeset upright; spaced as Ordinary (see `MTTypesetter` case). |
+| `kMTMathAtomBox` | Ord (with sub-mlist) | iosMath extension for the phantom/smash/lap family (`\phantom`, `\hphantom`, `\vphantom`, `\smash`, `\llap`, `\rlap`, `\clap`, `\mathstrut`). Script-capable. Draws (or reserves the metrics of) its inner list per per-command keep-width/height/depth flags. |
+| `kMTMathAtomOrdGroup` | Ord (with sub-mlist) | iosMath extension: a brace group `{…}` in math mode — an Ord subformula whose nucleus is a sub-mlist (== TeX Ord noad with `sub_mlist`, KaTeX "ordgroup"). Script-capable; spaced as Ordinary. |
 
 **Missing noad types** (vs. TeX):
 - **Vcent atom (Rule 8).** `\vcenter` is not supported. The corresponding atom type does not exist.

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -98,12 +98,13 @@ i\hbar\frac{\partial}{\partial t}\mathbf\Psi(\mathbf{x},t) = -\frac{\hbar}{2m}\n
 
 ## Lorentz Equations
 Use the `gather` or `displaylines` environments to center multiple
-equations.
+equations. `gathered` is the nestable variant, usable inside another
+formula.
 ```LaTeX
 \begin{gather}
 \dot{x} = \sigma(y-x) \\
 \dot{y} = \rho x - y - xz \\
-\dot{z} = -\beta z + xy"
+\dot{z} = -\beta z + xy
 \end{gather}
 ```
 
@@ -136,7 +137,8 @@ multiple equations.
 
 ## Matrix multiplication
 Supported matrix environments: `matrix`, `pmatrix`, `bmatrix`, `Bmatrix`,
-`vmatrix`, `Vmatrix`.
+`vmatrix`, `Vmatrix`, and `smallmatrix` (a compact, script-sized matrix for
+inline use).
 ```LaTeX
 \begin{pmatrix}
 a & b\\ c & d
@@ -171,3 +173,69 @@ f(x) = \begin{cases}
 ```
 
 ![Long equation](img/long.png)
+
+---
+
+# More supported features
+
+The examples below showcase additional supported commands. They mirror the
+runnable gallery in [`MathExamples.h`](./MathExamples.h) (shared by the iOS,
+macOS, and SwiftUI example apps); preview images are not included here.
+
+## AMS fraction and binomial macros
+`\dfrac` / `\tfrac` force display / text style; `\cfrac` builds continued
+fractions; `\dbinom` / `\tbinom` are the display / text binomials.
+```LaTeX
+\tfrac{1}{2} + \dfrac{1}{2} = \cfrac{1}{1+\cfrac{1}{1+\cfrac{1}{1}}}
+\qquad \dbinom{n}{k} \quad \tbinom{n}{k}
+```
+
+## Explicitly sized delimiters
+`\big`, `\Big`, `\bigg`, `\Bigg` (with `l` / `r` / `m` class variants) set a
+fixed delimiter size, independent of the content-driven `\left … \right`.
+```LaTeX
+\bigl( x + y \bigr) \quad \Bigl[ z \Bigr] \quad
+\biggl\langle w \biggr\rangle \quad a \bigm| b
+```
+
+## Stacked and annotated relations
+`\overset`, `\underset`, `\stackrel`, and `\stackbin` place a symbol above or
+below a base while keeping the correct spacing class.
+```LaTeX
+f(x) \stackrel{\text{def}}{=} \sum_{n=0}^{\infty} \frac{f^{(n)}(0)}{n!} x^n
+\qquad \underset{x \in \mathbb{R}}{\sup}\, f(x)
+```
+
+## Over/under braces and arrows
+```LaTeX
+\overbrace{a+b+c}^{n} + \underbrace{d+e+f}_{m}
+\qquad \overrightarrow{AB} \cdot \overleftarrow{CD}
+```
+
+## Multiple integrals
+```LaTeX
+\iint_S f \, dA = \iiint_V g \, dV = \iiiint_{\mathbb{R}^4} h \, dV
+```
+
+## Compact inline matrices
+`smallmatrix` renders script-sized cells for use inside a line of math.
+```LaTeX
+A^{-1} = \frac{1}{ad-bc}\left(\begin{smallmatrix} d & -b \\ -c & a \end{smallmatrix}\right)
+```
+
+## Nestable centered equations
+`gathered` centers a stack of equations and, unlike `gather`, can be nested
+inside another formula.
+```LaTeX
+\begin{gathered}
+(a+b)^2 = a^2 + 2ab + b^2 \\
+(a-b)^2 = a^2 - 2ab + b^2
+\end{gathered}
+```
+
+## Colors
+`\color` recolors an expression; `\colorbox` fills the background behind it.
+```LaTeX
+\color{#ff3399}{(a_1+a_2)^2} = a_1^2 + 2a_1a_2 + a_2^2
+\qquad \colorbox{#f0f0e0}{\sqrt{1+x}}
+```

--- a/MathExamples.h
+++ b/MathExamples.h
@@ -86,6 +86,13 @@ static inline NSArray<NSString*>* MathDemoFormulas(void) {
         @"f(x) = \\begin{cases}\\frac{e^x}{2} & x \\geq 0 \\\\1 & x < 0\\end{cases}",
         // 20: Ridge regression — argmin via \underset
         @"\\hat\\theta = \\underset{\\theta}{\\arg\\min}\\, \\|y - X\\theta\\|^2 + \\lambda \\|\\theta\\|^2",
+        // 21: Inline 2×2 matrix — smallmatrix keeps cells script-sized
+        @"A^{-1} = \\frac{1}{ad-bc}\\left(\\begin{smallmatrix} d & -b \\\\ -c & a \\end{smallmatrix}\\right)",
+        // 22: Centered stacked identities — gathered environment
+        @"\\begin{gathered}"
+         "(a+b)^2 = a^2 + 2ab + b^2 \\\\"
+         "(a-b)^2 = a^2 - 2ab + b^2"
+         "\\end{gathered}",
     ];
 }
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ equations look exactly as LaTeX would render them — no WebView required.
 
 It is similar to [MathJax](https://www.mathjax.org) or
 [KaTeX](https://github.com/Khan/KaTeX) for the web but for native iOS or
-macOS applications, and significantly faster than a `UIWebView`.
+macOS applications, and significantly faster than a `WKWebView`.
 
 ## Examples
 
@@ -132,8 +132,11 @@ support is available in [`SwiftMathExample/MathLabel.swift`](SwiftMathExample/Ma
 * Math spacing
 * Overline and underline
 * Math accents
-* Matrices
+* Over/under braces and arrows (`\overbrace`, `\overrightarrow`, etc.)
+* Stacked and annotated relations (`\overset`, `\underset`, `\stackrel`)
+* Matrices (including compact `smallmatrix`)
 * Equation alignment
+* Phantoms and spacing boxes (`\phantom`, `\smash`, `\rlap`, etc.)
 * Bold, roman, caligraphic and other font styles (`\bf`, `\text`, etc.)
 * Most commonly used math symbols
 * Colors


### PR DESCRIPTION
Documentation-only follow-up to the iosMath feature review. **No code changes.**

Stacked on `feature/subordinate-envs-pr2` (not `master`) because two of the fixes reference the `smallmatrix` / `gathered` environments, which live on that branch and are not yet on `master`.

## What & why

The feature review surfaced doc drift — shipped features that the docs under-document or describe incorrectly. This PR fixes the four items:

1. **ALGORITHM.md §2 (factual correctness).** The `MTMathAtomType` enum has three atom types the table never listed: `kMTMathAtomText` (`\text` family), `kMTMathAtomBox` (phantom/smash/lap family), and `kMTMathAtomOrdGroup` (`{…}` brace grouping). Added rows for each, and extended the `kMTMathAtomStack` row to cover `\overset`/`\underset`/`\stackrel`/`\stackbin`.

2. **MathExamples.h (feature visibility).** Added `smallmatrix` and `gathered` gallery entries. This one shared file feeds the iOS, macOS, and SwiftUI example apps, so both newly landed environments now appear in all three.

3. **EXAMPLES.md.** Fixed a stray `"` in the Lorentz `gather` example (a real copy error), noted `gathered`/`smallmatrix` in the environment guidance, and added a "More supported features" section (AMS fractions, sized delimiters, stacked relations, over/under braces & arrows, multiple integrals, smallmatrix, gathered, colors) mirroring the maintained gallery.

4. **README.md.** `UIWebView` → `WKWebView` (Apple removed `UIWebView`), plus bullets for over/under braces & arrows, stacked relations, `smallmatrix`, and spacing boxes.

## Notes
- Scope is deliberately limited to *already-shipped* behavior. Missing features identified in the review (`align`, `\operatorname`, `\xrightarrow`, etc.) are intentionally **not** documented here — those docs should change when the code does.
- New gallery/EXAMPLES snippets use only commands verified present in the dispatch tables on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)