### PR TITLE
Add LaTeX array environment (PR 1/3): model fields + factory constructor

### DIFF
--- a/iosMath/lib/MTMathAtomFactory.h
+++ b/iosMath/lib/MTMathAtomFactory.h
@@ -210,6 +210,21 @@ FOUNDATION_EXPORT NSString *const MTSymbolDegree;
  matrix environments are have builtin delimiters added to the table and hence are returned as inner atoms.
  */
 + (nullable MTMathAtom*) tableWithEnvironment:(nullable NSString*) env rows:(NSArray<NSArray<MTMathList*>*>*) rows error:(NSError**) error;
+
+/**
+ Construct a bare `array`-environment table from already-validated structured input.
+ The parser owns all column-spec syntax validation; this method only validates row
+ cell counts against `columnAlignments.count` and assembles the table.
+ @param columnAlignments one MTColumnAlignment per declared column.
+ @param verticalLines `|` counts per column boundary (length columnAlignments.count+1).
+ @param horizontalLines `\hline` counts per row boundary (normalized here to numRows+1).
+ @returns a bare MTMathTable (no delimiters), or nil + error on too-many-cells.
+ */
++ (nullable MTMathAtom*) arrayTableWithAlignments:(NSArray<NSNumber*>*) columnAlignments
+                                    verticalLines:(NSArray<NSNumber*>*) verticalLines
+                                  horizontalLines:(NSArray<NSNumber*>*) horizontalLines
+                                             rows:(NSArray<NSArray<MTMathList*>*>*) rows
+                                            error:(NSError**) error;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/iosMath/lib/MTMathAtomFactory.m
+++ b/iosMath/lib/MTMathAtomFactory.m
@@ -527,6 +527,47 @@ static const CGFloat kSmallMatrixInterColumnSpacing = 5;
     return nil;
 }
 
++ (nullable MTMathAtom*) arrayTableWithAlignments:(NSArray<NSNumber*>*) columnAlignments
+                                    verticalLines:(NSArray<NSNumber*>*) verticalLines
+                                  horizontalLines:(NSArray<NSNumber*>*) horizontalLines
+                                             rows:(NSArray<NSArray<MTMathList*>*>*) rows
+                                            error:(NSError**) error
+{
+    MTMathTable* table = [[MTMathTable alloc] initWithEnvironment:@"array"];
+    NSInteger numCols = columnAlignments.count;
+    for (int i = 0; i < rows.count; i++) {
+        NSArray<MTMathList*>* row = rows[i];
+        if ((NSInteger) row.count > numCols) {
+            if (error) {
+                NSString* message = [NSString stringWithFormat:
+                    @"array row has %ld cells but column specification declares %ld columns",
+                    (long) row.count, (long) numCols];
+                *error = [NSError errorWithDomain:MTParseError
+                                             code:MTParseErrorInvalidNumColumns
+                                         userInfo:@{ NSLocalizedDescriptionKey : message }];
+            }
+            return nil;
+        }
+        for (int j = 0; j < row.count; j++) {
+            [table setCell:row[j] forRow:i column:j];
+        }
+    }
+    for (int j = 0; j < numCols; j++) {
+        [table setAlignment:columnAlignments[j].integerValue forColumn:j];
+    }
+    table.verticalLines = verticalLines;
+    // Normalize horizontalLines to length numRows+1 so the renderer can index boundaries.
+    NSMutableArray<NSNumber*>* hLines = [NSMutableArray arrayWithArray:horizontalLines];
+    while (hLines.count < table.numRows + 1) {
+        [hLines addObject:@0];
+    }
+    table.horizontalLines = hLines;
+    table.interRowAdditionalSpacing = 0;
+    table.interColumnSpacing = 18;   // ≈ 2·\arraycolsep at the default size; matches matrix.
+    table.cellStyle = kMTLineStyleText;   // post-#245: cells render textstyle via the table.
+    return table;
+}
+
 + (NSMutableDictionary<NSString*, MTMathAtom*>*) supportedLatexSymbols
 {
     static NSMutableDictionary<NSString*, MTMathAtom*>* commands = nil;

--- a/iosMath/lib/MTMathAtomFactory.m
+++ b/iosMath/lib/MTMathAtomFactory.m
@@ -551,13 +551,25 @@ static const CGFloat kSmallMatrixInterColumnSpacing = 5;
         for (int j = 0; j < row.count; j++) {
             [table setCell:row[j] forRow:i column:j];
         }
+        // Pad short rows out to numCols. numColumns is derived from the widest row,
+        // so without this a trailing all-empty column (its alignment + vertical rule)
+        // would be silently dropped. setCell backfills the intermediate cells.
+        if ((NSInteger) row.count < numCols) {
+            [table setCell:[MTMathList new] forRow:i column:numCols - 1];
+        }
     }
     for (int j = 0; j < numCols; j++) {
         [table setAlignment:columnAlignments[j].integerValue forColumn:j];
     }
-    table.verticalLines = verticalLines;
+    // Normalize verticalLines to length numCols+1 so every declared column boundary is
+    // represented (mirrors horizontalLines below). Guard nil for the nonnull property.
+    NSMutableArray<NSNumber*>* vLines = [NSMutableArray arrayWithArray:verticalLines ?: @[]];
+    while ((NSInteger) vLines.count < numCols + 1) {
+        [vLines addObject:@0];
+    }
+    table.verticalLines = vLines;
     // Normalize horizontalLines to length numRows+1 so the renderer can index boundaries.
-    NSMutableArray<NSNumber*>* hLines = [NSMutableArray arrayWithArray:horizontalLines];
+    NSMutableArray<NSNumber*>* hLines = [NSMutableArray arrayWithArray:horizontalLines ?: @[]];
     while (hLines.count < table.numRows + 1) {
         [hLines addObject:@0];
     }

--- a/iosMath/lib/MTMathList.h
+++ b/iosMath/lib/MTMathList.h
@@ -728,6 +728,16 @@ typedef NS_ENUM(NSInteger, MTColumnAlignment) {
 /// measures the inter-column/row glue in this style.
 @property (nonatomic) MTLineStyle cellStyle;
 
+/// The number of `|` vertical rules at each column boundary (array environment).
+/// Length numColumns+1: index 0 = before column 0 … numColumns = after the last column.
+/// Empty for every non-array environment (inert default — no layout effect).
+@property (nonatomic, nonnull) NSArray<NSNumber*>* verticalLines;
+
+/// The number of `\hline` horizontal rules at each row boundary (array environment).
+/// Length numRows+1: index 0 = above row 0 … numRows = below the last row.
+/// Empty for every non-array environment (inert default — no layout effect).
+@property (nonatomic, nonnull) NSArray<NSNumber*>* horizontalLines;
+
 /// Set the value of a given cell. The table is automatically resized to contain this cell.
 - (void) setCell:(MTMathList*) list forRow:(NSInteger) row column:(NSInteger) column;
 

--- a/iosMath/lib/MTMathList.h
+++ b/iosMath/lib/MTMathList.h
@@ -731,12 +731,12 @@ typedef NS_ENUM(NSInteger, MTColumnAlignment) {
 /// The number of `|` vertical rules at each column boundary (array environment).
 /// Length numColumns+1: index 0 = before column 0 … numColumns = after the last column.
 /// Empty for every non-array environment (inert default — no layout effect).
-@property (nonatomic, nonnull) NSArray<NSNumber*>* verticalLines;
+@property (nonatomic, copy, nonnull) NSArray<NSNumber*>* verticalLines;
 
 /// The number of `\hline` horizontal rules at each row boundary (array environment).
 /// Length numRows+1: index 0 = above row 0 … numRows = below the last row.
 /// Empty for every non-array environment (inert default — no layout effect).
-@property (nonatomic, nonnull) NSArray<NSNumber*>* horizontalLines;
+@property (nonatomic, copy, nonnull) NSArray<NSNumber*>* horizontalLines;
 
 /// Set the value of a given cell. The table is automatically resized to contain this cell.
 - (void) setCell:(MTMathList*) list forRow:(NSInteger) row column:(NSInteger) column;

--- a/iosMath/lib/MTMathList.m
+++ b/iosMath/lib/MTMathList.m
@@ -1208,8 +1208,9 @@ static NSString* fractionCommandForDelimiterPair(NSString* leftDelimiter, NSStri
     op.cellStyle = self.cellStyle;
     op->_environment = self.environment;
     op.alignments = [NSMutableArray arrayWithArray:self.alignments];
-    op.verticalLines = [NSArray arrayWithArray:self.verticalLines];
-    op.horizontalLines = [NSArray arrayWithArray:self.horizontalLines];
+    // The copy setters take an immutable snapshot, so a plain assignment suffices.
+    op.verticalLines = self.verticalLines;
+    op.horizontalLines = self.horizontalLines;
     // Perform a deep copy of the cells.
     NSMutableArray* cellCopy = [NSMutableArray arrayWithCapacity:self.cells.count];
     for (NSMutableArray* row in self.cells) {

--- a/iosMath/lib/MTMathList.m
+++ b/iosMath/lib/MTMathList.m
@@ -1178,6 +1178,8 @@ static NSString* fractionCommandForDelimiterPair(NSString* leftDelimiter, NSStri
         self.interRowAdditionalSpacing = 0;
         self.interColumnSpacing = 0;
         self.cellStyle = kMTLineStyleInherit;
+        self.verticalLines = [NSArray array];
+        self.horizontalLines = [NSArray array];
         _environment = env;
     }
     return self;
@@ -1206,6 +1208,8 @@ static NSString* fractionCommandForDelimiterPair(NSString* leftDelimiter, NSStri
     op.cellStyle = self.cellStyle;
     op->_environment = self.environment;
     op.alignments = [NSMutableArray arrayWithArray:self.alignments];
+    op.verticalLines = [NSArray arrayWithArray:self.verticalLines];
+    op.horizontalLines = [NSArray arrayWithArray:self.horizontalLines];
     // Perform a deep copy of the cells.
     NSMutableArray* cellCopy = [NSMutableArray arrayWithCapacity:self.cells.count];
     for (NSMutableArray* row in self.cells) {

--- a/iosMathTests/MTMathListTest.m
+++ b/iosMathTests/MTMathListTest.m
@@ -387,7 +387,8 @@ _XCTPrimitiveAssertNotEqual(test, expression1, @#expression1, expression2, @#exp
 - (void)testArrayTableFactoryAcceptsShortRows
 {
     MTMathList* a = [MTMathListBuilder buildFromString:@"a"];
-    // Spec declares 3 columns; row has 1 cell — allowed, trailing cells absent.
+    // Spec declares 3 columns; row has 1 cell — allowed. The short row is padded out
+    // to 3 cells so the declared trailing columns (alignment + vertical rule) survive.
     NSError* error = nil;
     MTMathAtom* atom = [MTMathAtomFactory
         arrayTableWithAlignments:@[ @(kMTColumnAlignmentCenter),
@@ -400,7 +401,29 @@ _XCTPrimitiveAssertNotEqual(test, expression1, @#expression1, expression2, @#exp
     XCTAssertNil(error);
     XCTAssertNotNil(atom);
     MTMathTable* table = (MTMathTable*) atom;
-    XCTAssertEqual([table.cells[0] count], 1);
+    XCTAssertEqual(table.numColumns, 3);
+    XCTAssertEqual([table.cells[0] count], 3);
+}
+
+- (void)testArrayTableFactoryNormalizesVerticalLines
+{
+    MTMathList* a = [MTMathListBuilder buildFromString:@"a"];
+    MTMathList* b = [MTMathListBuilder buildFromString:@"b"];
+    // Caller passes a too-short verticalLines (and nil horizontalLines); the factory
+    // pads verticalLines to numCols+1 and tolerates nil rather than crashing.
+    NSError* error = nil;
+    MTMathAtom* atom = [MTMathAtomFactory
+        arrayTableWithAlignments:@[ @(kMTColumnAlignmentCenter),
+                                    @(kMTColumnAlignmentCenter) ]
+                   verticalLines:@[ @1 ]
+                 horizontalLines:nil
+                            rows:@[ @[ a, b ] ]
+                           error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(atom);
+    MTMathTable* table = (MTMathTable*) atom;
+    XCTAssertEqual(table.verticalLines.count, 3);   // numCols(2) + 1
+    XCTAssertEqualObjects(table.verticalLines, (@[ @1, @0, @0 ]));
 }
 
 @end

--- a/iosMathTests/MTMathListTest.m
+++ b/iosMathTests/MTMathListTest.m
@@ -319,6 +319,17 @@ _XCTPrimitiveAssertNotEqual(test, expression1, @#expression1, expression2, @#exp
     // Mutating the original's field must not affect the copy.
     table.verticalLines = @[ @9 ];
     XCTAssertEqualObjects(copy.verticalLines, (@[ @1, @0, @2 ]));
+
+    // The properties take an immutable snapshot: mutating a mutable array
+    // *after* assigning it must not change the stored value (copy semantics).
+    NSMutableArray<NSNumber*>* mutV = [@[ @1, @2 ] mutableCopy];
+    NSMutableArray<NSNumber*>* mutH = [@[ @3 ] mutableCopy];
+    table.verticalLines = mutV;
+    table.horizontalLines = mutH;
+    [mutV addObject:@99];
+    [mutH addObject:@99];
+    XCTAssertEqualObjects(table.verticalLines, (@[ @1, @2 ]));
+    XCTAssertEqualObjects(table.horizontalLines, (@[ @3 ]));
 }
 
 - (void)testArrayTableFactoryBuildsBareTextstyleTable

--- a/iosMathTests/MTMathListTest.m
+++ b/iosMathTests/MTMathListTest.m
@@ -302,6 +302,25 @@ _XCTPrimitiveAssertNotEqual(test, expression1, @#expression1, expression2, @#exp
     [MTMathListTest checkListCopy:list2 original:list forTest:self];
 }
 
+- (void)testMathTableVerticalHorizontalLinesDefaultAndCopy
+{
+    MTMathTable* table = [[MTMathTable alloc] init];
+    // Default: both empty (inert — existing envs unaffected).
+    XCTAssertNotNil(table.verticalLines);
+    XCTAssertNotNil(table.horizontalLines);
+    XCTAssertEqual(table.verticalLines.count, 0);
+    XCTAssertEqual(table.horizontalLines.count, 0);
+
+    table.verticalLines = @[ @1, @0, @2 ];
+    table.horizontalLines = @[ @1, @0 ];
+    MTMathTable* copy = [table copy];
+    XCTAssertEqualObjects(copy.verticalLines, (@[ @1, @0, @2 ]));
+    XCTAssertEqualObjects(copy.horizontalLines, (@[ @1, @0 ]));
+    // Mutating the original's field must not affect the copy.
+    table.verticalLines = @[ @9 ];
+    XCTAssertEqualObjects(copy.verticalLines, (@[ @1, @0, @2 ]));
+}
+
 @end
 
 @interface MTMathAtomTest : XCTestCase

--- a/iosMathTests/MTMathListTest.m
+++ b/iosMathTests/MTMathListTest.m
@@ -354,6 +354,44 @@ _XCTPrimitiveAssertNotEqual(test, expression1, @#expression1, expression2, @#exp
     XCTAssertEqual(table.cellStyle, kMTLineStyleText);
 }
 
+- (void)testArrayTableFactoryRejectsTooManyCells
+{
+    MTMathList* a = [MTMathListBuilder buildFromString:@"a"];
+    MTMathList* b = [MTMathListBuilder buildFromString:@"b"];
+    // Spec declares 1 column but the row has 2 cells.
+    NSError* error = nil;
+    MTMathAtom* atom = [MTMathAtomFactory
+        arrayTableWithAlignments:@[ @(kMTColumnAlignmentCenter) ]
+                   verticalLines:@[ @0, @0 ]
+                 horizontalLines:@[]
+                            rows:@[ @[ a, b ] ]
+                           error:&error];
+    XCTAssertNil(atom);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, MTParseErrorInvalidNumColumns);
+    XCTAssertEqualObjects(error.localizedDescription,
+        @"array row has 2 cells but column specification declares 1 columns");
+}
+
+- (void)testArrayTableFactoryAcceptsShortRows
+{
+    MTMathList* a = [MTMathListBuilder buildFromString:@"a"];
+    // Spec declares 3 columns; row has 1 cell — allowed, trailing cells absent.
+    NSError* error = nil;
+    MTMathAtom* atom = [MTMathAtomFactory
+        arrayTableWithAlignments:@[ @(kMTColumnAlignmentCenter),
+                                    @(kMTColumnAlignmentCenter),
+                                    @(kMTColumnAlignmentCenter) ]
+                   verticalLines:@[ @0, @0, @0, @0 ]
+                 horizontalLines:@[]
+                            rows:@[ @[ a ] ]
+                           error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(atom);
+    MTMathTable* table = (MTMathTable*) atom;
+    XCTAssertEqual([table.cells[0] count], 1);
+}
+
 @end
 
 @interface MTMathAtomTest : XCTestCase

--- a/iosMathTests/MTMathListTest.m
+++ b/iosMathTests/MTMathListTest.m
@@ -321,6 +321,39 @@ _XCTPrimitiveAssertNotEqual(test, expression1, @#expression1, expression2, @#exp
     XCTAssertEqualObjects(copy.verticalLines, (@[ @1, @0, @2 ]));
 }
 
+- (void)testArrayTableFactoryBuildsBareTextstyleTable
+{
+    MTMathList* a = [MTMathListBuilder buildFromString:@"a"];
+    MTMathList* b = [MTMathListBuilder buildFromString:@"b"];
+    MTMathList* c = [MTMathListBuilder buildFromString:@"c"];
+    MTMathList* d = [MTMathListBuilder buildFromString:@"d"];
+    NSArray* rows = @[ @[ a, b ], @[ c, d ] ];
+
+    NSError* error = nil;
+    MTMathAtom* atom = [MTMathAtomFactory
+        arrayTableWithAlignments:@[ @(kMTColumnAlignmentRight), @(kMTColumnAlignmentLeft) ]
+                   verticalLines:@[ @1, @0, @1 ]
+                 horizontalLines:@[ @1 ]
+                            rows:rows
+                           error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(atom);
+    // Bare table — no MTInner / delimiters wrapping.
+    XCTAssertEqual(atom.type, kMTMathAtomTable);
+    MTMathTable* table = (MTMathTable*) atom;
+    XCTAssertEqualObjects(table.environment, @"array");
+    XCTAssertEqual(table.numRows, 2);
+    XCTAssertEqual(table.numColumns, 2);
+    XCTAssertEqual([table getAlignmentForColumn:0], kMTColumnAlignmentRight);
+    XCTAssertEqual([table getAlignmentForColumn:1], kMTColumnAlignmentLeft);
+    XCTAssertEqualObjects(table.verticalLines, (@[ @1, @0, @1 ]));
+    // horizontalLines normalized to numRows+1 == 3.
+    XCTAssertEqualObjects(table.horizontalLines, (@[ @1, @0, @0 ]));
+    XCTAssertEqual(table.interColumnSpacing, 18);
+    XCTAssertEqual(table.interRowAdditionalSpacing, 0);
+    XCTAssertEqual(table.cellStyle, kMTLineStyleText);
+}
+
 @end
 
 @interface MTMathAtomTest : XCTestCase


### PR DESCRIPTION
## Goal

Add the inert `verticalLines`/`horizontalLines` fields to `MTMathTable` and a dedicated `+arrayTableWithAlignments:verticalLines:horizontalLines:rows:error:` factory constructor that builds a bare textstyle `array` table from already-validated structured input. No parser or renderer changes yet — the constructor is public API and is exercised directly. Existing environments are provably unaffected (new fields default empty; `+tableWithEnvironment:rows:error:` untouched).

## Commits

- `[item 1]` Add verticalLines/horizontalLines fields to MTMathTable
- `[item 2]` Add +arrayTableWithAlignments factory constructor
- `[item 3]` Validate array row cell counts (too-many-cells / short-row)

## References

- Plan: `docs/plans/2026-07-03-array-environment.md` (PR 1, items 1-3)
- LLD: `docs/lld/2026-06-29-array-environment.md`

This is PR 1 of a 3-PR stack implementing the LaTeX `array` environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
