### PR TITLE
Add \textcolor as a 2-argument alias of \color

### DIFF
--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -1023,8 +1023,9 @@ static const NSInteger kMTMaxRecursionDepth = 150;
         }
         MTMathAtom* table = [self buildTable:env firstList:nil row:NO];
         return table;
-    } else if ([command isEqualToString:@"color"]) {
-        // A color command has 2 arguments
+    } else if ([command isEqualToString:@"color"] || [command isEqualToString:@"textcolor"]) {
+        // \color and its alias \textcolor are 2-argument commands: a color
+        // followed by the content group that the color applies to.
         NSString* colorStr = [self readColor];
         if (!colorStr) {
             // readColor already set the error.

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -2967,6 +2967,59 @@ static NSArray* getTestDataLargeDelimiters() {
     XCTAssertEqualObjects(colorAtom.colorString, @"#f00");
 }
 
+- (void)testTextcolorValidHexSix
+{
+    // \textcolor is an alias of \color: same 2-argument parse path, same MTMathColor node.
+    NSError* error = nil;
+    MTMathList* list = [MTMathListBuilder buildFromString:@"\\textcolor{#FF0000}{x}" error:&error];
+    XCTAssertNil(error, @"Unexpected error: %@", error);
+    XCTAssertNotNil(list);
+    XCTAssertEqual(list.atoms.count, (NSUInteger)1);
+    MTMathColor* colorAtom = (MTMathColor*)list.atoms[0];
+    XCTAssertEqual(colorAtom.type, kMTMathAtomColor);
+    XCTAssertEqualObjects(colorAtom.colorString, @"#FF0000");
+    XCTAssertNotNil(colorAtom.innerList);
+    XCTAssertEqual(colorAtom.innerList.atoms.count, (NSUInteger)1);
+    // \textcolor round-trips through the same MTMathColor serialization as \color.
+    XCTAssertEqualObjects(colorAtom.stringValue, @"\\color{#FF0000}{x}");
+}
+
+- (void)testTextcolorEquivalentToColor
+{
+    // \textcolor{c}{content} must produce a structurally equivalent MTMathList
+    // to \color{c}{content}: same MTMathColor node, colorString, and inner list.
+    NSError* textcolorError = nil;
+    MTMathList* textcolorList = [MTMathListBuilder buildFromString:@"\\textcolor{#FF0000}{x}" error:&textcolorError];
+    XCTAssertNil(textcolorError, @"Unexpected error: %@", textcolorError);
+    XCTAssertNotNil(textcolorList);
+
+    NSError* colorError = nil;
+    MTMathList* colorList = [MTMathListBuilder buildFromString:@"\\color{#FF0000}{x}" error:&colorError];
+    XCTAssertNil(colorError, @"Unexpected error: %@", colorError);
+    XCTAssertNotNil(colorList);
+
+    XCTAssertEqual(textcolorList.atoms.count, colorList.atoms.count);
+    MTMathColor* textcolorAtom = (MTMathColor*)textcolorList.atoms[0];
+    MTMathColor* colorAtom = (MTMathColor*)colorList.atoms[0];
+    XCTAssertEqual(textcolorAtom.type, colorAtom.type);
+    XCTAssertEqualObjects(textcolorAtom.colorString, colorAtom.colorString);
+    XCTAssertEqual(textcolorAtom.innerList.atoms.count, colorAtom.innerList.atoms.count);
+    // stringValue serializes color + inner content, so equal stringValue implies
+    // structurally equivalent color nodes.
+    XCTAssertEqualObjects(textcolorAtom.stringValue, colorAtom.stringValue);
+}
+
+- (void)testTextcolorInvalidNamedColorIsParseError
+{
+    // \textcolor shares \color's readColor grammar: named colors fail loud.
+    NSError* error = nil;
+    MTMathList* list = [MTMathListBuilder buildFromString:@"\\textcolor{red}{x}" error:&error];
+    XCTAssertNil(list, @"Expected nil list for invalid textcolor color");
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.domain, MTParseError);
+    XCTAssertEqual(error.code, MTParseErrorInvalidCommand);
+}
+
 - (void)testColorboxValidHexSix
 {
     NSError* error = nil;


### PR DESCRIPTION
## Summary

Adds support for the standard LaTeX `\textcolor{color}{content}` command, closing #157.

iosMath's existing `\color` is already implemented as a **two-argument** command (`\color{#RRGGBB}{content}` — colors just the content), which is exactly the semantics of standard LaTeX/xcolor `\textcolor`. So `\textcolor` is a true alias of the existing path — no new parsing logic or display type.

## Change

- `iosMath/lib/MTMathListBuilder.m` — widened the `atomForCommand:` dispatch from `[command isEqualToString:@"color"]` to also match `@"textcolor"`, so both share the identical `readColor` + `buildInternal:true` + `MTMathColor` path. `\colorbox` untouched.
- `iosMathTests/MTMathListBuilderTest.m` — three new tests mirroring the existing `\color` tests: valid hex → `MTMathColor`; structural equivalence to `\color`; malformed named color fails loud with `MTParseErrorInvalidCommand`.

## Verification

- `swift build` → Build complete.
- `swift test --filter MTMathListBuilderTest` → 157 tests, 0 failures. Existing color/colorbox tests unchanged and passing.

## Scope note

This is the minimal alias only. Aligning `\color` itself to LaTeX's *switch* semantics (a separate, breaking change) was considered and deliberately deferred — see `docs/reqs/2026-07-03-color-textcolor.md`.

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)