### PR TITLE
Add LaTeX array environment (PR 2/3): parser + serialization

### DIFF
--- a/iosMath/lib/MTMathList.m
+++ b/iosMath/lib/MTMathList.m
@@ -1287,13 +1287,37 @@ static NSString* fractionCommandForDelimiterPair(NSString* leftDelimiter, NSStri
 
 - (void)appendLaTeXToString:(NSMutableString *)str
 {
+    BOOL isArray = [self.environment isEqualToString:@"array"];
     if (self.environment) {
         [str appendFormat:@"\\begin{%@}", self.environment];
         if ([self.environment isEqualToString:@"alignedat"]) {
             [str appendFormat:@"{%ld}", (long) (self.numColumns / 2)];
+        } else if (isArray) {
+            [str appendString:@"{"];
+            NSUInteger cols = self.numColumns;
+            for (NSUInteger i = 0; i <= cols; i++) {
+                NSInteger v = (i < self.verticalLines.count) ? self.verticalLines[i].integerValue : 0;
+                for (NSInteger k = 0; k < v; k++) { [str appendString:@"|"]; }
+                if (i < cols) {
+                    switch ([self getAlignmentForColumn:i]) {
+                        case kMTColumnAlignmentLeft:   [str appendString:@"l"]; break;
+                        case kMTColumnAlignmentCenter: [str appendString:@"c"]; break;
+                        case kMTColumnAlignmentRight:  [str appendString:@"r"]; break;
+                    }
+                }
+            }
+            [str appendString:@"}"];
         }
     }
-    for (NSUInteger i = 0; i < self.numRows; i++) {
+    NSUInteger numRows = self.numRows;
+    NSInteger bottomHLines = (isArray && numRows < self.horizontalLines.count)
+        ? self.horizontalLines[numRows].integerValue : 0;
+    for (NSUInteger i = 0; i < numRows; i++) {
+        if (isArray && i < self.horizontalLines.count) {
+            for (NSInteger k = 0; k < self.horizontalLines[i].integerValue; k++) {
+                [str appendString:@"\\hline "];
+            }
+        }
         NSArray<MTMathList*>* row = self.cells[i];
         for (NSUInteger j = 0; j < row.count; j++) {
             [str appendString:[MTMathListBuilder mathListToString:[self serializedCellAtRow:i column:j]]];
@@ -1301,8 +1325,17 @@ static NSString* fractionCommandForDelimiterPair(NSString* leftDelimiter, NSStri
                 [str appendString:@"&"];
             }
         }
-        if (i < self.numRows - 1) {
+        BOOL lastRow = (i == numRows - 1);
+        if (!lastRow) {
             [str appendString:@"\\\\ "];
+        } else if (bottomHLines > 0) {
+            // A bottom \hline needs a row terminator before it.
+            [str appendString:@"\\\\ "];
+        }
+    }
+    if (isArray) {
+        for (NSInteger k = 0; k < bottomHLines; k++) {
+            [str appendString:@"\\hline "];
         }
     }
     if (self.environment) {

--- a/iosMath/lib/MTMathListBuilder.h
+++ b/iosMath/lib/MTMathListBuilder.h
@@ -93,6 +93,10 @@ typedef NS_ENUM(NSUInteger, MTParseErrors) {
     /// mode (e.g. a non-ASCII literal like π, or a special character such as
     /// %, #, $ that has no meaning here).
     MTParseErrorInvalidCharacter,
+    /// An array environment was declared with no column specification.
+    MTParseErrorMissingColumnSpec,
+    /// An array column specification was empty or used an unsupported specifier.
+    MTParseErrorInvalidColumnSpec,
 };
 
 @end

--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -20,6 +20,7 @@ NSString *const MTParseError = @"ParseError";
 @property (nonatomic) NSString* argument;
 @property (nonatomic) BOOL ended;
 @property (nonatomic) NSInteger numRows;
+@property (nonatomic) NSMutableArray<NSNumber*>* hLines;
 
 @end
 
@@ -33,6 +34,7 @@ NSString *const MTParseError = @"ParseError";
         _argument = nil;
         _numRows = 0;
         _ended = NO;
+        _hLines = [NSMutableArray array];
     }
     return self;
 }
@@ -283,6 +285,13 @@ static const NSInteger kMTMaxRecursionDepth = 150;
         } else if (ch == '\\') {
             // \ means a command
             NSString* command = [self readCommand];
+            if ([command isEqualToString:@"hline"]) {
+                // \hline is a no-op boundary marker: record it and keep reading the same cell.
+                if (![self recordHorizontalLine]) {
+                    return nil;   // error already set
+                }
+                continue;
+            }
             MTMathList* done = [self stopCommand:command list:list stopChar:stop oneChar:oneCharOnly];
             if (done) {
                 return done;
@@ -898,6 +907,35 @@ static const NSInteger kMTMaxRecursionDepth = 150;
     return envs;
 }
 
++ (NSSet<NSString*>*) environmentsAllowingHorizontalLines
+{
+    static NSSet<NSString*>* envs = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        envs = [NSSet setWithObjects:@"array", nil];
+    });
+    return envs;
+}
+
+// Record a \hline at the current row boundary (== _currentEnv.numRows). Allowed only
+// inside an environment that permits horizontal lines (array). \hline emits no atom and
+// consumes no cell content. Returns NO (and sets the error) if not in such an environment.
+- (BOOL) recordHorizontalLine
+{
+    if (_currentEnv && [[MTMathListBuilder environmentsAllowingHorizontalLines]
+                            containsObject:_currentEnv.envName]) {
+        NSUInteger boundary = _currentEnv.numRows;
+        while (_currentEnv.hLines.count <= boundary) {
+            [_currentEnv.hLines addObject:@0];
+        }
+        _currentEnv.hLines[boundary] = @(_currentEnv.hLines[boundary].integerValue + 1);
+        return YES;
+    }
+    [self setError:MTParseErrorInvalidCommand
+           message:@"\\hline is only valid inside an array environment"];
+    return NO;
+}
+
 // Reads the raw {…} argument after \begin{env}: require {, capture raw chars to },
 // require }. Returns the raw inside string (e.g. @"2"); interpretation happens later
 // in -buildTable:argument:firstList:row:. On a malformed argument, sets the error and
@@ -1436,6 +1474,23 @@ static const NSInteger kMTMaxRecursionDepth = 150;
         [self setError:MTParseErrorMissingEnd message:@"Missing \\end"];
         return nil;
     }
+    if ([_currentEnv.envName isEqualToString:@"array"] && rows.count > 0) {
+        // A trailing "\\" is needed so a bottom \hline is recognized before \end (it
+        // opens a new row boundary). If nothing but \hline/whitespace followed that
+        // trailing "\\", the row it opened has no real content — drop it so it isn't
+        // counted as an extra (blank) array row.
+        NSArray<MTMathList*>* lastRow = rows.lastObject;
+        BOOL lastRowEmpty = YES;
+        for (MTMathList* cell in lastRow) {
+            if (cell.atoms.count > 0) {
+                lastRowEmpty = NO;
+                break;
+            }
+        }
+        if (lastRowEmpty) {
+            [rows removeLastObject];
+        }
+    }
     if ([_currentEnv.envName isEqualToString:@"alignedat"]) {
         // argument is the raw {n}; require a positive integer.
         NSString* arg = _currentEnv.argument;
@@ -1472,7 +1527,7 @@ static const NSInteger kMTMaxRecursionDepth = 150;
                              verticalLines:vLines]) {
             table = [MTMathAtomFactory arrayTableWithAlignments:alignments
                                                   verticalLines:vLines
-                                                horizontalLines:@[]
+                                                horizontalLines:(_currentEnv.hLines ?: @[])
                                                            rows:rows
                                                           error:&error];
         }

--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -940,6 +940,42 @@ static const NSInteger kMTMaxRecursionDepth = 150;
     return [arg stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
 }
 
+// Interpret a raw array column-spec string (e.g. "|r|c|l|") into structured
+// alignments + per-boundary vertical-line counts. l/c/r append an alignment and
+// open a new boundary slot; | increments the current (rightmost) boundary slot.
+// Any other char, or zero declared columns, is a loud error. Returns NO on error.
+- (BOOL) interpretArrayColumnSpec:(NSString*) raw
+                   intoAlignments:(NSMutableArray<NSNumber*>*) alignments
+                    verticalLines:(NSMutableArray<NSNumber*>*) vLines
+{
+    [vLines addObject:@0];   // boundary before column 0
+    for (NSUInteger i = 0; i < raw.length; i++) {
+        unichar c = [raw characterAtIndex:i];
+        switch (c) {
+            case 'l': [alignments addObject:@(kMTColumnAlignmentLeft)];   [vLines addObject:@0]; break;
+            case 'c': [alignments addObject:@(kMTColumnAlignmentCenter)]; [vLines addObject:@0]; break;
+            case 'r': [alignments addObject:@(kMTColumnAlignmentRight)];  [vLines addObject:@0]; break;
+            case '|': {
+                NSUInteger idx = vLines.count - 1;
+                vLines[idx] = @(vLines[idx].integerValue + 1);
+                break;
+            }
+            default: {
+                NSString* message = [NSString stringWithFormat:
+                    @"Unsupported array column specifier: %C", c];
+                [self setError:MTParseErrorInvalidColumnSpec message:message];
+                return NO;
+            }
+        }
+    }
+    if (alignments.count == 0) {
+        [self setError:MTParseErrorInvalidColumnSpec
+               message:@"array environment must declare at least one column"];
+        return NO;
+    }
+    return YES;
+}
+
 - (MTMathAtom*) getBoundaryAtom:(NSString*) delimiterType
 {
     NSString* delim = [self readDelimiter];
@@ -1427,7 +1463,23 @@ static const NSInteger kMTMaxRecursionDepth = 150;
         }
     }
     NSError* error;
-    MTMathAtom* table = [MTMathAtomFactory tableWithEnvironment:_currentEnv.envName rows:rows error:&error];
+    MTMathAtom* table;
+    if ([_currentEnv.envName isEqualToString:@"array"]) {
+        NSMutableArray<NSNumber*>* alignments = [NSMutableArray array];
+        NSMutableArray<NSNumber*>* vLines = [NSMutableArray array];
+        if ([self interpretArrayColumnSpec:_currentEnv.argument
+                            intoAlignments:alignments
+                             verticalLines:vLines]) {
+            table = [MTMathAtomFactory arrayTableWithAlignments:alignments
+                                                  verticalLines:vLines
+                                                horizontalLines:@[]
+                                                           rows:rows
+                                                          error:&error];
+        }
+        // else: interpretArrayColumnSpec set _error; table stays nil.
+    } else {
+        table = [MTMathAtomFactory tableWithEnvironment:_currentEnv.envName rows:rows error:&error];
+    }
     if (!table && !_error) {
         _error = error;
         return nil;

--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -893,7 +893,7 @@ static const NSInteger kMTMaxRecursionDepth = 150;
     static NSSet<NSString*>* envs = nil;
     static dispatch_once_t once;
     dispatch_once(&once, ^{
-        envs = [NSSet setWithObjects:@"alignedat", nil];
+        envs = [NSSet setWithObjects:@"alignedat", @"array", nil];
     });
     return envs;
 }
@@ -902,11 +902,17 @@ static const NSInteger kMTMaxRecursionDepth = 150;
 // require }. Returns the raw inside string (e.g. @"2"); interpretation happens later
 // in -buildTable:argument:firstList:row:. On a malformed argument, sets the error and
 // returns nil.
-- (nullable NSString*) readEnvironmentArgument
+- (nullable NSString*) readEnvironmentArgument:(NSString*) env
 {
+    BOOL isArray = [env isEqualToString:@"array"];
     if (![self expectCharacter:'{']) {
-        [self setError:MTParseErrorInvalidCommand
-               message:@"alignedat requires a numeric argument, e.g. \\begin{alignedat}{2}"];
+        if (isArray) {
+            [self setError:MTParseErrorMissingColumnSpec
+                   message:@"array environment requires a column specification"];
+        } else {
+            [self setError:MTParseErrorInvalidCommand
+                   message:@"alignedat requires a numeric argument, e.g. \\begin{alignedat}{2}"];
+        }
         return nil;
     }
     NSMutableString* arg = [NSMutableString string];
@@ -919,8 +925,13 @@ static const NSInteger kMTMaxRecursionDepth = 150;
         [arg appendString:[NSString stringWithCharacters:&ch length:1]];
     }
     if (![self expectCharacter:'}']) {
-        [self setError:MTParseErrorInvalidCommand
-               message:@"alignedat requires a numeric argument, e.g. \\begin{alignedat}{2}"];
+        if (isArray) {
+            [self setError:MTParseErrorInvalidColumnSpec
+                   message:@"array column specification is missing a closing brace"];
+        } else {
+            [self setError:MTParseErrorInvalidCommand
+                   message:@"alignedat requires a numeric argument, e.g. \\begin{alignedat}{2}"];
+        }
         return nil;
     }
     // Strip surrounding whitespace (TeX's argument scanner ignores it), matching
@@ -1109,7 +1120,7 @@ static const NSInteger kMTMaxRecursionDepth = 150;
         }
         NSString* argument = nil;
         if ([[MTMathListBuilder environmentsTakingArgument] containsObject:env]) {
-            argument = [self readEnvironmentArgument];
+            argument = [self readEnvironmentArgument:env];
             if (!argument) {
                 // readEnvironmentArgument already set the error.
                 return nil;

--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -922,8 +922,9 @@ static const NSInteger kMTMaxRecursionDepth = 150;
 // consumes no cell content. Returns NO (and sets the error) if not in such an environment.
 - (BOOL) recordHorizontalLine
 {
-    if (_currentEnv && [[MTMathListBuilder environmentsAllowingHorizontalLines]
-                            containsObject:_currentEnv.envName]) {
+    if (_currentEnv && _currentEnv.envName
+            && [[MTMathListBuilder environmentsAllowingHorizontalLines]
+                    containsObject:_currentEnv.envName]) {
         NSUInteger boundary = _currentEnv.numRows;
         while (_currentEnv.hLines.count <= boundary) {
             [_currentEnv.hLines addObject:@0];
@@ -990,6 +991,12 @@ static const NSInteger kMTMaxRecursionDepth = 150;
     for (NSUInteger i = 0; i < raw.length; i++) {
         unichar c = [raw characterAtIndex:i];
         switch (c) {
+            // Whitespace inside a column spec is ignored in LaTeX (e.g. {c | c}).
+            case ' ':
+            case '\t':
+            case '\n':
+            case '\r':
+                break;
             case 'l': [alignments addObject:@(kMTColumnAlignmentLeft)];   [vLines addObject:@0]; break;
             case 'c': [alignments addObject:@(kMTColumnAlignmentCenter)]; [vLines addObject:@0]; break;
             case 'r': [alignments addObject:@(kMTColumnAlignmentRight)];  [vLines addObject:@0]; break;

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -3817,4 +3817,15 @@ static NSArray* getTestDataLargeDelimiters() {
     XCTAssertEqualObjects([MTMathListBuilder mathListToString:list], @"\\frac{a}{b}^{2}");
 }
 
+- (void)testArrayMissingColumnSpecIsError
+{
+    NSError* error = nil;
+    MTMathList* list = [MTMathListBuilder buildFromString:@"\\begin{array} a \\end{array}" error:&error];
+    XCTAssertNil(list);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, MTParseErrorMissingColumnSpec);
+    XCTAssertEqualObjects(error.localizedDescription,
+        @"array environment requires a column specification");
+}
+
 @end

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -1703,6 +1703,13 @@ static NSArray* getTestDataParseErrors() {
               @[@"\\begin{alignedat}{-1} a&b \\end{alignedat}", @(MTParseErrorInvalidCommand)],     // negative (leading '-' fails digit check)
               @[@"\\begin{alignedat}{} a&b \\end{alignedat}", @(MTParseErrorInvalidCommand)],       // empty braces
               @[@"\\begin{alignedat}{2} a&b&c \\end{alignedat}", @(MTParseErrorInvalidNumColumns)], // 3 cols != 2n
+              @[@"\\begin{array} a \\end{array}", @(MTParseErrorMissingColumnSpec)],
+              @[@"\\begin{array}{} a \\end{array}", @(MTParseErrorInvalidColumnSpec)],
+              @[@"\\begin{array}{p} a \\end{array}", @(MTParseErrorInvalidColumnSpec)],
+              @[@"\\begin{array}{c} a & b \\end{array}", @(MTParseErrorInvalidNumColumns)],
+              @[@"\\begin{array}{c} a", @(MTParseErrorMissingEnd)],
+              @[@"\\hline a", @(MTParseErrorInvalidCommand)],
+              @[@"\\begin{matrix} \\hline a \\end{matrix}", @(MTParseErrorInvalidCommand)],
               ];
 };
 
@@ -3895,6 +3902,38 @@ static NSArray* getTestDataLargeDelimiters() {
     XCTAssertEqual(e2.code, MTParseErrorInvalidCommand);
     XCTAssertEqualObjects(e2.localizedDescription,
         @"\\hline is only valid inside an array environment");
+}
+
+- (void)testArrayFullSpecParse
+{
+    NSString* str = @"\\begin{array}{|r|c|l|} 10 & = & 7 + 3 \\end{array}";
+    MTMathList* list = [MTMathListBuilder buildFromString:str];
+    XCTAssertNotNil(list);
+    XCTAssertEqual(list.atoms.count, 1);
+    MTMathTable* table = list.atoms[0];
+    XCTAssertEqual(table.type, kMTMathAtomTable);
+    XCTAssertEqualObjects(table.environment, @"array");
+    XCTAssertEqual(table.numRows, 1);
+    XCTAssertEqual(table.numColumns, 3);
+    XCTAssertEqual([table getAlignmentForColumn:0], kMTColumnAlignmentRight);
+    XCTAssertEqual([table getAlignmentForColumn:1], kMTColumnAlignmentCenter);
+    XCTAssertEqual([table getAlignmentForColumn:2], kMTColumnAlignmentLeft);
+    XCTAssertEqualObjects(table.verticalLines, (@[ @1, @1, @1, @1 ]));
+    // No \hline -> horizontalLines all zero (length numRows+1).
+    XCTAssertEqualObjects(table.horizontalLines, (@[ @0, @0 ]));
+    // Bare table, textstyle cells.
+    XCTAssertEqual(table.cellStyle, kMTLineStyleText);
+    XCTAssertEqual(table.interColumnSpacing, 18);
+}
+
+- (void)testArrayTooManyCellsIsError
+{
+    NSError* error = nil;
+    MTMathList* list = [MTMathListBuilder buildFromString:@"\\begin{array}{c} a & b \\end{array}" error:&error];
+    XCTAssertNil(list);
+    XCTAssertEqual(error.code, MTParseErrorInvalidNumColumns);
+    XCTAssertEqualObjects(error.localizedDescription,
+        @"array row has 2 cells but column specification declares 1 columns");
 }
 
 @end

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -3870,4 +3870,31 @@ static NSArray* getTestDataLargeDelimiters() {
         @"Unsupported array column specifier: p");
 }
 
+- (void)testArrayHorizontalLineCounting
+{
+    // \hline at top, middle, and bottom boundaries; bottom needs a trailing \\.
+    NSString* str = @"\\begin{array}{c} \\hline a \\\\ \\hline b \\\\ \\hline \\end{array}";
+    MTMathList* list = [MTMathListBuilder buildFromString:str];
+    XCTAssertNotNil(list);
+    MTMathTable* table = list.atoms[0];
+    XCTAssertEqual(table.numRows, 2);
+    // Boundaries: 0 (top)=1, 1 (middle)=1, 2 (bottom)=1.
+    XCTAssertEqualObjects(table.horizontalLines, (@[ @1, @1, @1 ]));
+}
+
+- (void)testHlineOutsideArrayIsError
+{
+    NSError* e1 = nil;
+    XCTAssertNil([MTMathListBuilder buildFromString:@"\\hline a" error:&e1]);
+    XCTAssertEqual(e1.code, MTParseErrorInvalidCommand);
+    XCTAssertEqualObjects(e1.localizedDescription,
+        @"\\hline is only valid inside an array environment");
+
+    NSError* e2 = nil;
+    XCTAssertNil([MTMathListBuilder buildFromString:@"\\begin{matrix} \\hline a \\end{matrix}" error:&e2]);
+    XCTAssertEqual(e2.code, MTParseErrorInvalidCommand);
+    XCTAssertEqualObjects(e2.localizedDescription,
+        @"\\hline is only valid inside an array environment");
+}
+
 @end

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -3854,6 +3854,15 @@ static NSArray* getTestDataLargeDelimiters() {
     XCTAssertEqualObjects(table2.verticalLines, (@[ @2, @2, @1 ]));
     XCTAssertEqual([table2 getAlignmentForColumn:0], kMTColumnAlignmentCenter);
     XCTAssertEqual([table2 getAlignmentForColumn:1], kMTColumnAlignmentCenter);
+
+    // Whitespace inside the column spec is ignored (LaTeX behavior): {c | c} == {c|c}.
+    MTMathList* list3 = [MTMathListBuilder buildFromString:@"\\begin{array}{c | c} a & b \\end{array}"];
+    XCTAssertNotNil(list3);
+    MTMathTable* table3 = list3.atoms[0];
+    XCTAssertEqual(table3.numColumns, 2);
+    XCTAssertEqual([table3 getAlignmentForColumn:0], kMTColumnAlignmentCenter);
+    XCTAssertEqual([table3 getAlignmentForColumn:1], kMTColumnAlignmentCenter);
+    XCTAssertEqualObjects(table3.verticalLines, (@[ @0, @1, @0 ]));
 }
 
 - (void)testArrayEmptySpecAndBadSpecifierAreErrors

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -3936,4 +3936,22 @@ static NSArray* getTestDataLargeDelimiters() {
         @"array row has 2 cells but column specification declares 1 columns");
 }
 
+- (void)testArrayRoundTrip
+{
+    // \hline at top boundary, two rows, leading+trailing vertical rules.
+    NSString* str = @"\\begin{array}{|c|} \\hline a \\\\ b \\end{array}";
+    MTMathList* list = [MTMathListBuilder buildFromString:str];
+    XCTAssertNotNil(list);
+    NSString* latex = [MTMathListBuilder mathListToString:list];
+    XCTAssertEqualObjects(latex, @"\\begin{array}{|c|}\\hline a\\\\ b\\end{array}");
+}
+
+- (void)testArrayRoundTripMixedAlignmentNoRules
+{
+    NSString* str = @"\\begin{array}{rcl} a & b & c \\end{array}";
+    MTMathList* list = [MTMathListBuilder buildFromString:str];
+    NSString* latex = [MTMathListBuilder mathListToString:list];
+    XCTAssertEqualObjects(latex, @"\\begin{array}{rcl}a&b&c\\end{array}");
+}
+
 @end

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -3828,4 +3828,46 @@ static NSArray* getTestDataLargeDelimiters() {
         @"array environment requires a column specification");
 }
 
+- (void)testArrayColumnSpecInterpretation
+{
+    // {rcl} -> 3 cols R/C/L, no rules.
+    MTMathList* list = [MTMathListBuilder buildFromString:@"\\begin{array}{rcl} a & b & c \\end{array}"];
+    XCTAssertNotNil(list);
+    MTMathTable* table = list.atoms[0];
+    XCTAssertEqualObjects(table.environment, @"array");
+    XCTAssertEqual(table.numColumns, 3);
+    XCTAssertEqual([table getAlignmentForColumn:0], kMTColumnAlignmentRight);
+    XCTAssertEqual([table getAlignmentForColumn:1], kMTColumnAlignmentCenter);
+    XCTAssertEqual([table getAlignmentForColumn:2], kMTColumnAlignmentLeft);
+    XCTAssertEqualObjects(table.verticalLines, (@[ @0, @0, @0, @0 ]));
+
+    // {||c||c|} -> vertical-line counts 2/2/1.
+    MTMathList* list2 = [MTMathListBuilder buildFromString:@"\\begin{array}{||c||c|} a & b \\end{array}"];
+    MTMathTable* table2 = list2.atoms[0];
+    XCTAssertEqualObjects(table2.verticalLines, (@[ @2, @2, @1 ]));
+    XCTAssertEqual([table2 getAlignmentForColumn:0], kMTColumnAlignmentCenter);
+    XCTAssertEqual([table2 getAlignmentForColumn:1], kMTColumnAlignmentCenter);
+}
+
+- (void)testArrayEmptySpecAndBadSpecifierAreErrors
+{
+    NSError* e1 = nil;
+    XCTAssertNil([MTMathListBuilder buildFromString:@"\\begin{array}{} a \\end{array}" error:&e1]);
+    XCTAssertEqual(e1.code, MTParseErrorInvalidColumnSpec);
+    XCTAssertEqualObjects(e1.localizedDescription,
+        @"array environment must declare at least one column");
+
+    NSError* e2 = nil;
+    XCTAssertNil([MTMathListBuilder buildFromString:@"\\begin{array}{||} a \\end{array}" error:&e2]);
+    XCTAssertEqual(e2.code, MTParseErrorInvalidColumnSpec);
+    XCTAssertEqualObjects(e2.localizedDescription,
+        @"array environment must declare at least one column");
+
+    NSError* e3 = nil;
+    XCTAssertNil([MTMathListBuilder buildFromString:@"\\begin{array}{p} a \\end{array}" error:&e3]);
+    XCTAssertEqual(e3.code, MTParseErrorInvalidColumnSpec);
+    XCTAssertEqualObjects(e3.localizedDescription,
+        @"Unsupported array column specifier: p");
+}
+
 @end


### PR DESCRIPTION
## Goal

Parse `\begin{array}{<spec>} … \end{array}` end-to-end: register `array` in the merged `#248` argument hook, interpret the raw column spec into structured `alignments`/`verticalLines`, count `\hline` per boundary (array-only, loud error otherwise), build the table via PR 1's constructor, and round-trip via `appendLaTeXToString:`. No renderer changes yet — the produced atom tree is validated structurally.

## Commits

- `[item 4]` Register array in argument hook + column-spec error codes
- `[item 5]` Interpret array column spec into alignments + verticalLines
- `[item 6]` Count `\hline` per boundary; reject outside array
- `[item 7]` End-to-end array parse + error-table coverage
- `[item 8]` Round-trip array spec + `\hline` in appendLaTeXToString

## Notes

- Per the plan's load-bearing control-flow correction, `\hline` is intercepted at the `buildInternal` `\\`-command dispatch site (via `-recordHorizontalLine` + `continue`), not inside `-stopCommand:`.
- Item 6 added a small `array`-scoped trim in `-buildTable:` that drops a trailing all-empty row (so a bottom `\hline` with a trailing `\\` yields the correct `numRows`). Scoped to `array` only; matrix/eqalign/split/aligned behavior is unchanged. Full suite green (397/397).

## Stack

1. #251 — PR 1/3: model fields + array factory constructor (base: `master`)
2. **This PR** — PR 2/3: parser + serialization (base: `feature/array-environment-pr1`)

## References

- Plan: `docs/plans/2026-07-03-array-environment.md` (PR 2, items 4-8)
- LLD: `docs/lld/2026-06-29-array-environment.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
