### PR TITLE
Add LaTeX array environment (PR 3/3): renderer — rules + shared column offsets

### DIFF
--- a/iosMath/render/MTMathListDisplay.m
+++ b/iosMath/render/MTMathListDisplay.m
@@ -832,6 +832,54 @@ static BOOL isIos6Supported(void) {
 
 @end
 
+#pragma mark - MTRuleDisplay
+
+@implementation MTRuleDisplay {
+    CGFloat _length;
+    CGFloat _thickness;
+    BOOL _vertical;
+}
+
+- (instancetype)initWithStart:(CGPoint)start length:(CGFloat)length thickness:(CGFloat)thickness vertical:(BOOL)isVertical range:(NSRange)range
+{
+    self = [super init];
+    if (self) {
+        _length = length;
+        _thickness = thickness;
+        _vertical = isVertical;
+        self.position = start;
+        self.range = range;
+        if (isVertical) {
+            self.width = thickness;
+            self.ascent = length;
+            self.descent = 0;
+        } else {
+            self.width = length;
+            self.ascent = thickness;
+            self.descent = 0;
+        }
+    }
+    return self;
+}
+
+- (void)draw:(CGContextRef)context
+{
+    [super draw:context];
+    CGContextSaveGState(context);
+    [self.textColor setStroke];
+    MTBezierPath* path = [MTBezierPath bezierPath];
+    [path moveToPoint:self.position];
+    CGPoint end = _vertical
+        ? CGPointMake(self.position.x, self.position.y + _length)
+        : CGPointMake(self.position.x + _length, self.position.y);
+    [path addLineToPoint:end];
+    path.lineWidth = _thickness;
+    [path stroke];
+    CGContextRestoreGState(context);
+}
+
+@end
+
 #pragma mark - MTAccentDisplay
 
 @implementation MTAccentDisplay

--- a/iosMath/render/internal/MTMathListDisplayInternal.h
+++ b/iosMath/render/internal/MTMathListDisplayInternal.h
@@ -135,6 +135,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+// A standalone straight rule (horizontal or vertical) used to draw array `|` and \hline.
+// A positioned leaf like MTGlyphDisplay: it carries its own position/width/ascent/descent
+// so -recomputeDimensions folds it into the enclosing table's bounds.
+@interface MTRuleDisplay : MTDisplay
+
+// `start` is in table-local coordinates. For a horizontal rule `length` extends
+// rightward (+x); for a vertical rule it extends upward (+y). Stroke is centred on
+// the path, so callers offset `start` by thickness/2 where edge alignment matters.
+- (instancetype) initWithStart:(CGPoint) start
+                        length:(CGFloat) length
+                     thickness:(CGFloat) thickness
+                      vertical:(BOOL) isVertical
+                         range:(NSRange) range NS_DESIGNATED_INITIALIZER;
+
+@end
+
 @interface MTStackDisplay ()
 
 - (instancetype)initWithBase:(MTMathListDisplay*) base

--- a/iosMath/render/internal/MTTypesetter.m
+++ b/iosMath/render/internal/MTTypesetter.m
@@ -2197,6 +2197,10 @@ static const CGFloat kLineSkipMultiplier = 0.1;  // default is 1pt for 10pt font
 static const CGFloat kLineSkipLimitMultiplier = 0;
 static const CGFloat kJotMultiplier = 0.3; // A jot is 3pt for a 10pt font.
 
+// Array rule geometry. Starting values (font-scaled), tuned by snapshot tests.
+static const CGFloat kArrayRuleGapMultiplier = 0.2;     // ≈ \doublerulesep (2pt at 10pt)
+static const CGFloat kArrayRulePaddingMultiplier = 0.2; // content↔rule clearance
+
 - (MTDisplay*) makeTable:(MTMathTable*) table
 {
     NSUInteger numColumns = table.numColumns;
@@ -2204,7 +2208,7 @@ static const CGFloat kJotMultiplier = 0.3; // A jot is 3pt for a 10pt font.
         // Empty table
         return [[MTMathListDisplay alloc] initWithDisplays:[NSArray array] range:table.indexRange];
     }
-    
+
     CGFloat *columnWidths = calloc(numColumns, sizeof(CGFloat));
     NSAssert(columnWidths != NULL, @"Failed to allocate columnWidths");
     // Wrap in @try/@finally so columnWidths is released on all exit paths.
@@ -2214,10 +2218,22 @@ static const CGFloat kJotMultiplier = 0.3; // A jot is 3pt for a 10pt font.
     @try {
         NSArray<NSArray<MTDisplay*>*>* displays = [self typesetCells:table columnWidths:columnWidths];
 
+        MTLineStyle cellStyle = [self cellStyleForTable:table];
+        CGFloat cellStyleMuUnit = [[self class] getStyleSize:cellStyle font:_font] / 18.0;
+        CGFloat thickness = _styleFont.mathTable.fractionRuleThickness;
+        NSMutableArray<NSArray<NSNumber*>*>* vRuleXs = [NSMutableArray array];
+        CGFloat contentWidth = 0;
+        NSArray<NSNumber*>* columnOffsets = [self columnOffsetsForTable:table
+                                                          columnWidths:columnWidths
+                                                             thickness:thickness
+                                                       cellStyleMuUnit:cellStyleMuUnit
+                                                               vRuleXs:vRuleXs
+                                                          contentWidth:&contentWidth];
+
         // Position all the columns in each row
         NSMutableArray<MTDisplay*>* rowDisplays = [NSMutableArray arrayWithCapacity:table.cells.count];
         for (NSArray<MTDisplay*>* row in displays) {
-            MTMathListDisplay* rowDisplay = [self makeRowWithColumns:row forTable:table columnWidths:columnWidths];
+            MTMathListDisplay* rowDisplay = [self makeRowWithColumns:row forTable:table columnWidths:columnWidths columnOffsets:columnOffsets];
             [rowDisplays addObject:rowDisplay];
         }
 
@@ -2229,6 +2245,49 @@ static const CGFloat kJotMultiplier = 0.3; // A jot is 3pt for a 10pt font.
         free(columnWidths);
     }
     return tableDisplay;
+}
+
+// Compute per-column start x-offsets shared by cells and vertical rules, so they cannot
+// drift. For each vertical boundary i (0..numColumns) with verticalLines[i] > 0, widen the
+// gap by 2·padding + the rule block and record each rule's centre x in vRuleXs[i]. With no
+// rules this reduces to -makeRowWithColumns:'s exact running sum (matrix path unchanged).
+- (NSArray<NSNumber*>*) columnOffsetsForTable:(MTMathTable*) table
+                                 columnWidths:(CGFloat[]) columnWidths
+                                    thickness:(CGFloat) thickness
+                              cellStyleMuUnit:(CGFloat) cellStyleMuUnit
+                                      vRuleXs:(NSMutableArray<NSArray<NSNumber*>*>*) vRuleXs
+                                 contentWidth:(CGFloat*) outWidth
+{
+    NSUInteger numColumns = table.numColumns;
+    NSArray<NSNumber*>* vLines = table.verticalLines;
+    CGFloat padding = kArrayRulePaddingMultiplier * _styleFont.fontSize;
+    CGFloat ruleGap = kArrayRuleGapMultiplier * _styleFont.fontSize;
+    NSMutableArray<NSNumber*>* offsets = [NSMutableArray arrayWithCapacity:numColumns];
+    CGFloat x = 0;
+    for (NSUInteger i = 0; i <= numColumns; i++) {
+        CGFloat base = (i == 0 || i == numColumns)
+            ? 0 : table.interColumnSpacing * cellStyleMuUnit;
+        NSInteger count = (i < vLines.count) ? vLines[i].integerValue : 0;
+        NSMutableArray<NSNumber*>* xs = [NSMutableArray array];
+        if (count > 0) {
+            CGFloat ruleAreaStart = x + padding + base / 2;
+            for (NSInteger k = 0; k < count; k++) {
+                CGFloat cx = ruleAreaStart + k * (thickness + ruleGap) + thickness / 2;
+                [xs addObject:@(cx)];
+            }
+            CGFloat ruleBlock = count * thickness + (count - 1) * ruleGap;
+            x += base + 2 * padding + ruleBlock;
+        } else {
+            x += base;
+        }
+        [vRuleXs addObject:xs];
+        if (i < numColumns) {
+            [offsets addObject:@(x)];
+            x += columnWidths[i];
+        }
+    }
+    *outWidth = x;
+    return offsets;
 }
 
 // Typeset every cell in the table. As a side-effect calculate the max column width of each column.
@@ -2262,29 +2321,25 @@ static const CGFloat kJotMultiplier = 0.3; // A jot is 3pt for a 10pt font.
     return table.cellStyle == kMTLineStyleInherit ? _style : table.cellStyle;
 }
 
-- (MTMathListDisplay*) makeRowWithColumns:(NSArray<MTDisplay*>*) cols forTable:(MTMathTable*) table columnWidths:(CGFloat[]) columnWidths
+- (MTMathListDisplay*) makeRowWithColumns:(NSArray<MTDisplay*>*) cols forTable:(MTMathTable*) table columnWidths:(CGFloat[]) columnWidths columnOffsets:(NSArray<NSNumber*>*) columnOffsets
 {
-    CGFloat columnStart = 0;
-    MTLineStyle cellStyle = [self cellStyleForTable:table];
-    // muUnit == fontSize/18 (see -[MTFontMathTable muUnit]). Don't copy a CTFont just to
-    // read a scalar that is a pure function of _font + cellStyle.
-    CGFloat cellStyleMuUnit = [[self class] getStyleSize:cellStyle font:_font] / 18.0;
     NSRange rowRange = NSMakeRange(NSNotFound, 0);
     for (int i = 0; i < cols.count; i++) {
         MTDisplay* col = cols[i];
         CGFloat colWidth = columnWidths[i];
+        CGFloat columnStart = columnOffsets[i].doubleValue;
         MTColumnAlignment alignment = [table getAlignmentForColumn:i];
-        
+
         CGFloat cellPos = columnStart;
         switch (alignment) {
             case kMTColumnAlignmentRight:
                 cellPos += colWidth - col.width;
                 break;
-                
+
             case kMTColumnAlignmentCenter:
                 cellPos += (colWidth - col.width) / 2;
                 break;
-                
+
             case kMTColumnAlignmentLeft:
                 // No changes if left aligned
                 break;
@@ -2294,9 +2349,8 @@ static const CGFloat kJotMultiplier = 0.3; // A jot is 3pt for a 10pt font.
         } else {
             rowRange = col.range;
         }
-        
+
         col.position = CGPointMake(cellPos, 0);
-        columnStart += colWidth + table.interColumnSpacing * cellStyleMuUnit;
     };
     // Create a display for the row
     MTMathListDisplay* rowDisplay = [[MTMathListDisplay alloc] initWithDisplays:cols range:rowRange];

--- a/iosMath/render/internal/MTTypesetter.m
+++ b/iosMath/render/internal/MTTypesetter.m
@@ -2239,12 +2239,96 @@ static const CGFloat kArrayRulePaddingMultiplier = 0.2; // content↔rule cleara
 
         // Position all the rows
         [self positionRows:rowDisplays forTable:table];
+        NSArray<MTRuleDisplay*>* rules = [self makeRuleDisplaysForTable:table
+                                                                  rows:rowDisplays
+                                                               vRuleXs:vRuleXs
+                                                          contentWidth:contentWidth
+                                                             thickness:thickness];
+        [rowDisplays addObjectsFromArray:rules];
         tableDisplay = [[MTMathListDisplay alloc] initWithDisplays:rowDisplays range:table.indexRange];
         tableDisplay.position = _currentPosition;
     } @finally {
         free(columnWidths);
     }
     return tableDisplay;
+}
+
+// Build vertical + horizontal rule displays for an array table from the positioned rows.
+// Vertical rules span the shared frame (frameBot..frameTop); horizontals span the full
+// content width so outer rules meet at the corners by construction. Returns @[] when the
+// table has no rules (every non-array table, and arrays without rules) — fast path.
+- (NSArray<MTRuleDisplay*>*) makeRuleDisplaysForTable:(MTMathTable*) table
+                                                rows:(NSArray<MTDisplay*>*) rows
+                                             vRuleXs:(NSArray<NSArray<NSNumber*>*>*) vRuleXs
+                                        contentWidth:(CGFloat) contentWidth
+                                           thickness:(CGFloat) thickness
+{
+    NSArray<NSNumber*>* vLines = table.verticalLines;
+    NSArray<NSNumber*>* hLines = table.horizontalLines;
+    BOOL anyV = NO; for (NSNumber* n in vLines) { if (n.integerValue > 0) { anyV = YES; break; } }
+    BOOL anyH = NO; for (NSNumber* n in hLines) { if (n.integerValue > 0) { anyH = YES; break; } }
+    if (!anyV && !anyH) { return @[]; }
+
+    CGFloat padding = kArrayRulePaddingMultiplier * _styleFont.fontSize;
+    CGFloat ruleGap = kArrayRuleGapMultiplier * _styleFont.fontSize;
+    NSMutableArray<MTRuleDisplay*>* rules = [NSMutableArray array];
+
+    // Centred content box from the positioned rows.
+    CGFloat contentTop = -CGFLOAT_MAX;
+    CGFloat contentBot = CGFLOAT_MAX;
+    for (MTDisplay* row in rows) {
+        contentTop = MAX(contentTop, row.position.y + row.ascent);
+        contentBot = MIN(contentBot, row.position.y - row.descent);
+    }
+    CGFloat frameTop = contentTop + padding;
+    CGFloat frameBot = contentBot - padding;
+
+    // Vertical rules — span the whole frame so they meet the top/bottom horizontals.
+    for (NSUInteger i = 0; i < vRuleXs.count; i++) {
+        for (NSNumber* xn in vRuleXs[i]) {
+            [rules addObject:[[MTRuleDisplay alloc] initWithStart:CGPointMake(xn.doubleValue, frameBot)
+                                                          length:(frameTop - frameBot)
+                                                       thickness:thickness
+                                                        vertical:YES
+                                                           range:table.indexRange]];
+        }
+    }
+
+    // Horizontal rules — span full content width so they meet the outer verticals.
+    NSUInteger numRows = table.numRows;
+    for (NSUInteger b = 0; b < hLines.count; b++) {
+        NSInteger count = hLines[b].integerValue;
+        if (count == 0) { continue; }
+        CGFloat y0;
+        if (b == 0) {
+            y0 = frameTop;
+        } else if (b >= numRows) {
+            y0 = frameBot;
+        } else {
+            MTDisplay* above = rows[b - 1];   // upper row (higher y)
+            MTDisplay* below = rows[b];       // lower row
+            CGFloat gapBot = above.position.y - above.descent;
+            CGFloat gapTop = below.position.y + below.ascent;
+            y0 = (gapTop + gapBot) / 2;
+        }
+        for (NSInteger k = 0; k < count; k++) {
+            CGFloat yk;
+            if (b == 0) {
+                yk = y0 - k * (thickness + ruleGap);           // stack downward
+            } else if (b >= numRows) {
+                yk = y0 + k * (thickness + ruleGap);           // stack upward
+            } else {
+                NSInteger step = (k % 2 == 0 ? 1 : -1) * ((k + 1) / 2);
+                yk = y0 + step * (thickness + ruleGap);        // symmetric
+            }
+            [rules addObject:[[MTRuleDisplay alloc] initWithStart:CGPointMake(0, yk)
+                                                          length:contentWidth
+                                                       thickness:thickness
+                                                        vertical:NO
+                                                           range:table.indexRange]];
+        }
+    }
+    return rules;
 }
 
 // Compute per-column start x-offsets shared by cells and vertical rules, so they cannot

--- a/iosMath/render/internal/MTTypesetter.m
+++ b/iosMath/render/internal/MTTypesetter.m
@@ -2295,7 +2295,14 @@ static const CGFloat kArrayRulePaddingMultiplier = 0.2; // content↔rule cleara
     }
 
     // Horizontal rules — span full content width so they meet the outer verticals.
+    // The +arrayTableWithAlignments: factory normalizes horizontalLines to exactly
+    // numRows+1 boundaries. Boundaries past that are harmless here (the b >= numRows
+    // branch below draws them all at frameBot, no rows access), but they mean redundant
+    // overlapping bottom rules — a silently-malformed model. Fail loud on the invariant.
     NSUInteger numRows = table.numRows;
+    NSAssert(hLines.count <= numRows + 1,
+             @"horizontalLines has %lu boundaries, expected at most numRows+1 (%lu)",
+             (unsigned long) hLines.count, (unsigned long) (numRows + 1));
     for (NSUInteger b = 0; b < hLines.count; b++) {
         NSInteger count = hLines[b].integerValue;
         if (count == 0) { continue; }

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -3326,4 +3326,29 @@
     }
 }
 
+- (void)testRuleDisplayHorizontalAndVerticalMetrics
+{
+    MTRuleDisplay* h = [[MTRuleDisplay alloc] initWithStart:CGPointMake(2, 5)
+                                                     length:10
+                                                  thickness:0.6
+                                                   vertical:NO
+                                                      range:NSMakeRange(0, 1)];
+    XCTAssertEqual(h.position.x, 2);
+    XCTAssertEqual(h.position.y, 5);
+    XCTAssertEqual(h.width, 10);
+    XCTAssertEqual(h.ascent, 0.6);
+    XCTAssertEqual(h.descent, 0);
+
+    MTRuleDisplay* v = [[MTRuleDisplay alloc] initWithStart:CGPointMake(3, -4)
+                                                     length:12
+                                                  thickness:0.6
+                                                   vertical:YES
+                                                      range:NSMakeRange(0, 1)];
+    XCTAssertEqual(v.position.x, 3);
+    XCTAssertEqual(v.position.y, -4);
+    XCTAssertEqual(v.width, 0.6);
+    XCTAssertEqual(v.ascent, 12);   // top end = position.y + ascent
+    XCTAssertEqual(v.descent, 0);
+}
+
 @end

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -3369,4 +3369,31 @@
     XCTAssertGreaterThan(x2, x1);
 }
 
+- (void)testArrayRuleDisplayCountAndBounds
+{
+    // {|c|c|} with \hline top+bottom: 2 vertical outer + 1 interior vertical = 3 vertical,
+    // and 2 horizontal rules. Total rule count == sum(verticalLines)+sum(horizontalLines).
+    NSString* str = @"\\begin{array}{|c|c|} \\hline a & b \\\\ \\hline \\end{array}";
+    MTMathList* list = [MTMathListBuilder buildFromString:str];
+    MTMathListDisplay* display = [MTTypesetter createLineForMathList:list font:self.font style:kMTLineStyleDisplay];
+    MTMathListDisplay* tableDisp = display.subDisplays[0];
+
+    NSUInteger ruleCount = 0;
+    NSUInteger rowCount = 0;
+    for (MTDisplay* sub in tableDisp.subDisplays) {
+        if ([sub isKindOfClass:[MTRuleDisplay class]]) { ruleCount++; }
+        else { rowCount++; }
+    }
+    // verticalLines = [1,1,1] (sum 3); horizontalLines = [1,0,1] (sum 2) -> 5 rules.
+    XCTAssertEqual(ruleCount, 5);
+    XCTAssertEqual(rowCount, 1);
+
+    // Rules widen the table beyond a rule-free counterpart.
+    MTMathList* plain = [MTMathListBuilder buildFromString:@"\\begin{array}{cc} a & b \\end{array}"];
+    MTMathListDisplay* plainDisp = [MTTypesetter createLineForMathList:plain font:self.font style:kMTLineStyleDisplay];
+    XCTAssertGreaterThan(tableDisp.width, ((MTMathListDisplay*) plainDisp.subDisplays[0]).width);
+    // \hline extents are included in the table's vertical bounds.
+    XCTAssertGreaterThan(tableDisp.ascent + tableDisp.descent, 0);
+}
+
 @end

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -3351,4 +3351,22 @@
     XCTAssertEqual(v.descent, 0);
 }
 
+- (void)testArrayColumnOffsetsMatchAlignmentNoRules
+{
+    // No vertical rules: array column x-positions must follow the same rule as matrix
+    // (left col at 0, next col at colWidth0 + interColumnSpacing·muUnit).
+    MTMathList* list = [MTMathListBuilder buildFromString:@"\\begin{array}{lll} a & b & c \\end{array}"];
+    MTMathListDisplay* display = [MTTypesetter createLineForMathList:list font:self.font style:kMTLineStyleDisplay];
+    XCTAssertEqual(display.subDisplays.count, 1);
+    MTMathListDisplay* tableDisp = display.subDisplays[0];
+    // One row display; its sub-displays are the three cells, left-aligned at increasing x.
+    MTMathListDisplay* rowDisp = tableDisp.subDisplays[0];
+    CGFloat x0 = ((MTDisplay*) rowDisp.subDisplays[0]).position.x;
+    CGFloat x1 = ((MTDisplay*) rowDisp.subDisplays[1]).position.x;
+    CGFloat x2 = ((MTDisplay*) rowDisp.subDisplays[2]).position.x;
+    XCTAssertEqualWithAccuracy(x0, 0, 0.01);
+    XCTAssertGreaterThan(x1, x0);
+    XCTAssertGreaterThan(x2, x1);
+}
+
 @end

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -3422,4 +3422,53 @@
     XCTAssertEqual(tableDisp.subDisplays.count, 2);   // exactly two row displays
 }
 
+- (void)testArrayRuleGeometryIsDeterministic
+{
+    // Count/ordering tests miss a constant offset applied to every rule. Pin absolute
+    // geometry: a vertical rule's x and the \hline y are deterministic from font metrics.
+    // {|cc|} single row with top+bottom \hline -> 2 outer verticals + 2 horizontals.
+    NSString* str = @"\\begin{array}{|cc|} \\hline a & b \\\\ \\hline \\end{array}";
+    MTMathList* list = [MTMathListBuilder buildFromString:str];
+    MTMathListDisplay* display = [MTTypesetter createLineForMathList:list font:self.font style:kMTLineStyleDisplay];
+    MTMathListDisplay* tableDisp = display.subDisplays[0];
+
+    // Metrics the typesetter uses: padding = kArrayRulePaddingMultiplier (0.2) x fontSize,
+    // pinned here on purpose so a multiplier change must consciously update this test.
+    CGFloat padding = 0.2 * self.font.fontSize;
+    CGFloat thickness = self.font.mathTable.fractionRuleThickness;
+
+    NSMutableArray<MTRuleDisplay*>* verticals = [NSMutableArray array];
+    NSMutableArray<MTRuleDisplay*>* horizontals = [NSMutableArray array];
+    CGFloat contentTop = -CGFLOAT_MAX;
+    CGFloat contentBot = CGFLOAT_MAX;
+    for (MTDisplay* sub in tableDisp.subDisplays) {
+        if ([sub isKindOfClass:[MTRuleDisplay class]]) {
+            MTRuleDisplay* r = (MTRuleDisplay*) sub;
+            // vertical rule: width == thickness; horizontal rule: ascent == thickness.
+            if (r.width == thickness) { [verticals addObject:r]; }
+            else { [horizontals addObject:r]; }
+        } else {
+            contentTop = MAX(contentTop, sub.position.y + sub.ascent);
+            contentBot = MIN(contentBot, sub.position.y - sub.descent);
+        }
+    }
+    XCTAssertEqual(verticals.count, 2u);
+    XCTAssertEqual(horizontals.count, 2u);
+
+    // Leftmost vertical (boundary 0, base 0): x == padding + thickness/2 (edge-centred stroke).
+    CGFloat leftmostX = CGFLOAT_MAX;
+    for (MTRuleDisplay* v in verticals) { leftmostX = MIN(leftmostX, v.position.x); }
+    XCTAssertEqualWithAccuracy(leftmostX, padding + thickness / 2, 0.01);
+
+    // Top \hline sits padding above the content top; bottom \hline padding below content bottom.
+    CGFloat topY = -CGFLOAT_MAX;
+    CGFloat botY = CGFLOAT_MAX;
+    for (MTRuleDisplay* h in horizontals) {
+        topY = MAX(topY, h.position.y);
+        botY = MIN(botY, h.position.y);
+    }
+    XCTAssertEqualWithAccuracy(topY, contentTop + padding, 0.01);
+    XCTAssertEqualWithAccuracy(botY, contentBot - padding, 0.01);
+}
+
 @end

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -3396,4 +3396,30 @@
     XCTAssertGreaterThan(tableDisp.ascent + tableDisp.descent, 0);
 }
 
+- (void)testArrayInsideDelimitersScalesToRuleBounds
+{
+    // \left[ {cc|c} augmented matrix with rules \right] — delimiters read the bare table's
+    // ascent/descent, which include the rules (folded via -recomputeDimensions).
+    NSString* str = @"\\left[ \\begin{array}{cc|c} 1 & 0 & 5 \\\\ 0 & 1 & 6 \\end{array} \\right]";
+    MTMathList* list = [MTMathListBuilder buildFromString:str];
+    XCTAssertNotNil(list);
+    MTMathListDisplay* display = [MTTypesetter createLineForMathList:list font:self.font style:kMTLineStyleDisplay];
+    XCTAssertNotNil(display);
+    // The full expression renders with positive bounds and does not throw.
+    XCTAssertGreaterThan(display.width, 0);
+    XCTAssertGreaterThan(display.ascent + display.descent, 0);
+}
+
+- (void)testMatrixLayoutUnchangedByArraySupport
+{
+    // Regression: a plain matrix produces exactly one table display with no MTRuleDisplay.
+    MTMathList* list = [MTMathListBuilder buildFromString:@"\\begin{matrix} a & b \\\\ c & d \\end{matrix}"];
+    MTMathListDisplay* display = [MTTypesetter createLineForMathList:list font:self.font style:kMTLineStyleDisplay];
+    MTMathListDisplay* tableDisp = display.subDisplays[0];
+    for (MTDisplay* sub in tableDisp.subDisplays) {
+        XCTAssertFalse([sub isKindOfClass:[MTRuleDisplay class]]);
+    }
+    XCTAssertEqual(tableDisp.subDisplays.count, 2);   // exactly two row displays
+}
+
 @end


### PR DESCRIPTION
## Goal

Render array vertical/horizontal rules. Adds a lightweight `MTRuleDisplay` leaf; factors cell x-advance into one `-columnOffsetsForTable:` helper so cells and vertical rules cannot drift; emits rule displays spanning a shared frame and folds them into table bounds so `\left…\right` sizes correctly around the rule-inclusive table. The matrix / every-existing-env path is byte-for-byte unchanged (empty `verticalLines`/`horizontalLines` ⇒ identical running sum, empty rule set).

## Commits

- `[item 9]` Add MTRuleDisplay leaf for array rules
- `[item 10]` Factor shared column offsets; keep matrix path identical
- `[item 11]` Emit array rule displays; fold into table bounds
- `[item 12]` Integration: array in delimiters + matrix non-regression

## Verification

- Full suite green: `swift test` → 402/402.
- Regression guard: existing matrix/table layout tests (`testMathTable`, `testMatrixColumnGapTracksCellStyle`, `testMatrixRowSpacingTracksCellStyle`, `testSmallMatrixColumnGap`, `testSmallMatrixCompactVsMatrix`, `testGatheredMatchesGather`, `testAlignedatLayout`) unchanged after the item-10 offsets refactor.
- `testMatrixLayoutUnchangedByArraySupport` asserts a plain matrix emits no `MTRuleDisplay` and exactly two row displays.

## Stack

1. #251 — PR 1/3: model fields + array factory constructor (base: `master`)
2. #253 — PR 2/3: parser + serialization (base: `feature/array-environment-pr1`)
3. **This PR** — PR 3/3: renderer — rules + shared column offsets (base: `feature/array-environment-pr2`)

## References

- Plan: `docs/plans/2026-07-03-array-environment.md` (PR 3, items 9-12)
- LLD: `docs/lld/2026-06-29-array-environment.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
