### PR TITLE
Remove dead iOS 6 / legacy-macOS version code

### DIFF
--- a/iosMath/render/MTConfig.h
+++ b/iosMath/render/MTConfig.h
@@ -42,8 +42,7 @@ typedef NSBezierPath    MTBezierPath;
 typedef NSEdgeInsets    MTEdgeInsets;
 typedef NSRect          MTRect;
 
-// For backward compatibility, DO NOT use NSEdgeInsetsZero (Available from OS X 10.10).
-#define MTEdgeInsetsZero (NSEdgeInsetsMake(0.0f, 0.0f, 0.0f, 0.0f));
+#define MTEdgeInsetsZero NSEdgeInsetsZero
 #define MTGraphicsGetCurrentContext() ([[NSGraphicsContext currentContext] CGContext])
 #define MTLineCapStyleRound NSLineCapStyleRound
 

--- a/iosMath/render/MTMathListDisplay.m
+++ b/iosMath/render/MTMathListDisplay.m
@@ -10,34 +10,12 @@
 //
 
 #import <CoreText/CoreText.h>
-#include <sys/param.h>
-#include <sys/sysctl.h>
 
 #import "MTMathListDisplay.h"
 #import "MTFontMathTable.h"
 #import "MTFontManager.h"
 #import "MTFont+Internal.h"
 #import "MTMathListDisplayInternal.h"
-
-static BOOL isIos6Supported(void) {
-    static BOOL initialized = false;
-    static BOOL supported = false;
-    if (!initialized) {
-#if TARGET_OS_IPHONE
-        NSString *reqSysVer = @"6.0";
-        NSString *currSysVer = [UIDevice currentDevice].systemVersion;
-        
-        if ([currSysVer compare:reqSysVer options:NSNumericSearch] != NSOrderedAscending) {
-            supported = true;
-        }
-#else
-        supported = true;
-#endif
-        
-        initialized = true;
-    }
-    return supported;
-}
 
 #pragma mark MTDisplay
 
@@ -102,16 +80,11 @@ static BOOL isIos6Supported(void) {
         _atoms = atoms;
         // We can't use typographic bounds here as the ascent and descent returned are for the font and not for the line.
         self.width = CTLineGetTypographicBounds(_line, NULL, NULL, NULL);
-        if (isIos6Supported()) {
-            CGRect bounds = CTLineGetBoundsWithOptions(_line, kCTLineBoundsUseGlyphPathBounds);
-            self.ascent = MAX(0, CGRectGetMaxY(bounds) - 0);
-            self.descent = MAX(0, 0 - CGRectGetMinY(bounds));
-            // TODO: Should we use this width vs the typographic width? They are slightly different. Don't know why.
-            // _width = CGRectGetMaxX(bounds);
-        } else {
-            // Our own implementation of the ios6 function to get glyph path bounds.
-            [self computeDimensions:font];
-        }
+        CGRect bounds = CTLineGetBoundsWithOptions(_line, kCTLineBoundsUseGlyphPathBounds);
+        self.ascent = MAX(0, CGRectGetMaxY(bounds) - 0);
+        self.descent = MAX(0, 0 - CGRectGetMinY(bounds));
+        // TODO: Should we use this width vs the typographic width? They are slightly different. Don't know why.
+        // _width = CGRectGetMaxX(bounds);
     }
     return self;
 }
@@ -132,27 +105,6 @@ static BOOL isIos6Supported(void) {
     [attrStr addAttribute:(NSString*)kCTForegroundColorAttributeName value:(id)self.textColor.CGColor
                     range:NSMakeRange(0, attrStr.length)];
     self.attributedString = attrStr;
-}
-
-- (void) computeDimensions:(MTFont*) font
-{
-    NSArray* runs = (__bridge NSArray *)(CTLineGetGlyphRuns(_line));
-    for (id obj in runs) {
-        CTRunRef run = (__bridge CTRunRef)(obj);
-        CFIndex numGlyphs = CTRunGetGlyphCount(run);
-        CGGlyph glyphs[numGlyphs];
-        CTRunGetGlyphs(run, CFRangeMake(0, numGlyphs), glyphs);
-        CGRect bounds = CTFontGetBoundingRectsForGlyphs(font.ctFont, kCTFontOrientationDefault, glyphs, NULL, numGlyphs);
-        CGFloat ascent = MAX(0, CGRectGetMaxY(bounds) - 0);
-        // Descent is how much the line goes below the origin. However if the line is all above the origin, then descent can't be negative.
-        CGFloat descent = MAX(0, 0 - CGRectGetMinY(bounds));
-        if (ascent > self.ascent) {
-            self.ascent = ascent;
-        }
-        if (descent > self.descent) {
-            self.descent = descent;
-        }
-    }
 }
 
 - (void)dealloc

--- a/iosMath/render/NSColor+HexString.m
+++ b/iosMath/render/NSColor+HexString.m
@@ -34,9 +34,7 @@
     unsigned rgbValue = 0;
     NSScanner *scanner = [NSScanner scannerWithString:hex];
     [scanner scanHexInt:&rgbValue];
-    // NOTE: red:green:blue:alpha: in AppKit/NSColor.h is NS_AVAILABLE_MAC(10_9), unavailable for macOS 10.8 .
-    // Older method name colorWithSRGBRed::green:blue:alpha: works.
-    return [NSColor colorWithSRGBRed:((rgbValue & 0xFF0000) >> 16)/255.0 green:((rgbValue & 0xFF00) >> 8)/255.0 blue:(rgbValue & 0xFF)/255.0 alpha:1.0];
+    return [NSColor colorWithRed:((rgbValue & 0xFF0000) >> 16)/255.0 green:((rgbValue & 0xFF00) >> 8)/255.0 blue:(rgbValue & 0xFF)/255.0 alpha:1.0];
 }
 
 @end


### PR DESCRIPTION
## Summary

The library's deployment floor is **iOS 13 / macOS 10.15**, so several version guards for iOS 6 and macOS 10.8–10.10 were permanently dead code. This removes them.

## Changes

- **`MTMathListDisplay.m`** — delete `isIos6Supported()` (always `true` on any supported OS) and its unreachable `else` branch in `MTCTLineDisplay`; `CTLineGetBoundsWithOptions` is iOS 6+/macOS 10.8+. Remove the now-orphaned private `computeDimensions:` fallback and the unused `<sys/param.h>`/`<sys/sysctl.h>` includes.
- **`MTConfig.h`** — use `NSEdgeInsetsZero` directly (available since OS X 10.10) instead of the `NSEdgeInsetsMake(...)` workaround; now mirrors the iOS branch.
- **`NSColor+HexString.m`** — use `colorWithRed:green:blue:alpha:` (sRGB, available since 10.9) instead of the `colorWithSRGBRed:` workaround. Equivalent output.

## Testing

Behavior-preserving. `swift build` clean; `swift test` → 392 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)