### PR TITLE
Add array environment examples to the example apps

### DIFF
--- a/MacOSMathExample/AppDelegate.m
+++ b/MacOSMathExample/AppDelegate.m
@@ -109,7 +109,7 @@ static const NSUInteger kMacFontCount = 8;
     // --- Demo formulae — LaTeX strings from MathExamples.h ---
     static const CGFloat demoHeights[] = {
         60, 40, 120, 60, 40, 40, 40, 40, 60, 40, 40, 60, 60, 60, 70, 70, 140, 60, 90, 60,
-        60
+        60, 70, 110
     };
     NSArray<NSString*>* demoFormulas = MathDemoFormulas();
     for (NSUInteger i = 0; i < demoFormulas.count; i++) {
@@ -145,7 +145,8 @@ static const NSUInteger kMacFontCount = 8;
         40, 40, 40, 40, 40, 50, 50, 60, 50, 50, 40, 70,
         80, 150, 60, 60, 50, 60, 50,
         40, 60, 60, 70, 60, 60, 70, 60, 60, 60, 60,
-        70, 40, 40, 50, 40, 50
+        70, 40, 40, 50, 40, 50,
+        50, 50, 70, 70
     };
     NSArray<NSString*>* testFormulas = MathTestFormulas();
     for (NSUInteger i = 0; i < testFormulas.count; i++) {

--- a/MathExamples.h
+++ b/MathExamples.h
@@ -86,6 +86,18 @@ static inline NSArray<NSString*>* MathDemoFormulas(void) {
         @"f(x) = \\begin{cases}\\frac{e^x}{2} & x \\geq 0 \\\\1 & x < 0\\end{cases}",
         // 20: Ridge regression — argmin via \underset
         @"\\hat\\theta = \\underset{\\theta}{\\arg\\min}\\, \\|y - X\\theta\\|^2 + \\lambda \\|\\theta\\|^2",
+        // 21: Augmented matrix of a linear system (array with a vertical rule)
+        @"\\left[\\begin{array}{cc|c}"
+         "2 & 1 & 5 \\\\"
+         "1 & 3 & 10"
+         "\\end{array}\\right]",
+        // 22: Ruled multiplication table (array with \hline and vertical rules)
+        @"\\begin{array}{|c|c|c|}"
+         "\\hline \\times & 1 & -1 \\\\"
+         "\\hline 1 & 1 & -1 \\\\"
+         "\\hline -1 & -1 & 1 \\\\"
+         "\\hline"
+         "\\end{array}",
     ];
 }
 
@@ -285,6 +297,14 @@ static inline NSArray<NSString*>* MathTestFormulas(void) {
         @"a \\stackrel{?}{c} b \\quad a \\overset{?}{c} b",
         // 91: Nested stacks — \overset inside the over-arg of \stackrel
         @"a \\stackrel{\\overset{n}{\\to}}{=} b",
+        // 92: Array column alignment — left / centre / right in one table
+        @"\\begin{array}{lcr} a & bb & ccc \\\\ ccc & bb & a \\end{array}",
+        // 93: Array with interior vertical rules only
+        @"\\begin{array}{c|c|c} a & b & c \\\\ d & e & f \\end{array}",
+        // 94: Array full grid — \hline on every boundary plus outer/interior verticals
+        @"\\begin{array}{|c|c|} \\hline a & b \\\\ \\hline c & d \\\\ \\hline \\end{array}",
+        // 95: Partitioned (block) matrix — array with a vertical rule inside \left(...\right)
+        @"\\left(\\begin{array}{cc|cc} 1 & 0 & a & b \\\\ 0 & 1 & c & d \\end{array}\\right)",
     ];
 }
 

--- a/SwiftMathExample/ContentView.swift
+++ b/SwiftMathExample/ContentView.swift
@@ -85,6 +85,8 @@ private let namedExampleMeta: [NamedFormulaMeta] = [
     NamedFormulaMeta(title: "EM algorithm Q-function"),
     NamedFormulaMeta(title: "Piecewise function"),
     NamedFormulaMeta(title: "Ridge regression"),
+    NamedFormulaMeta(title: "Augmented matrix"),
+    NamedFormulaMeta(title: "Multiplication table"),
 ]
 
 private let namedExamples: [NamedFormula] = {
@@ -239,7 +241,8 @@ private struct GalleryTab: View {
         40, 40, 40, 40, 40, 50, 50, 60, 50, 50, 40, 70,
         80, 150, 60, 60, 50, 60, 50,
         40, 60, 60, 70, 60, 60, 70, 60, 60, 60, 60,
-        70, 40, 40, 50, 40, 50
+        70, 40, 40, 50, 40, 50,
+        50, 50, 70, 70
     ]
 
     private static let testFormulas: [String] = {

--- a/iosMathExample/example/ViewController.m
+++ b/iosMathExample/example/ViewController.m
@@ -149,7 +149,7 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
     // Demo formulae — LaTeX strings from MathExamples.h
     static const CGFloat demoHeights[] = {
         60, 40, 120, 60, 40, 40, 40, 40, 60, 40, 40, 60, 60, 60, 70, 70, 140, 60, 90, 60,
-        60
+        60, 70, 110
     };
     NSArray<NSString*>* demoFormulas = MathDemoFormulas();
     for (NSUInteger i = 0; i < demoFormulas.count; i++) {
@@ -186,7 +186,8 @@ static CGFloat HeightAtIndex(const CGFloat *heights, NSUInteger count, NSUIntege
         40, 40, 40, 40, 40, 50, 50, 60, 50, 50, 40, 70,
         80, 150, 60, 60, 50, 60, 50,
         40, 60, 60, 70, 60, 60, 70, 60, 60, 60, 60,
-        70, 40, 40, 50, 40, 50
+        70, 40, 40, 50, 40, 50,
+        50, 50, 70, 70
     };
     NSArray<NSString*>* testFormulas = MathTestFormulas();
     for (NSUInteger i = 0; i < testFormulas.count; i++) {


### PR DESCRIPTION
## Goal

Showcase the new `\begin{array}` environment (shipped in #254) in all three example apps, so the array feature is discoverable from the galleries.

All LaTeX strings live in the shared `MathExamples.h`, consumed by `iosMathExample`, `MacOSMathExample`, and `SwiftMathExample`.

## What's added

**Demo gallery (`MathDemoFormulas`) — 2 real-world entries:**
- **Augmented matrix** of a linear system — `\left[\begin{array}{cc|c} … \end{array}\right]`, exercising a vertical partition rule inside delimiters.
- **Multiplication table** — a fully ruled grid using `\hline` on every boundary plus vertical rules.

**Feature gallery (`MathTestFormulas`) — 4 entries, one per array feature:**
- Column alignment (`{lcr}` — left / centre / right in one table)
- Interior vertical rules only (`{c|c|c}`)
- Full grid (`\hline` + `|` on every boundary)
- Partitioned block matrix inside `\left(…\right)`

## Wiring

Per-app height/metadata arrays updated in lockstep so the galleries lay out correctly and the Swift app's `precondition` count checks pass:
- `SwiftMathExample/ContentView.swift` — 2 `namedExampleMeta` titles, 4 `testHeights`
- `iosMathExample/…/ViewController.m` — `demoHeights` +2, `testHeights` +4
- `MacOSMathExample/AppDelegate.m` — `demoHeights` +2, `testHeights` +4

Counts align across all four files: demo **23**, test **96**.

## Verification

- All six candidate strings were rendered through the parser + typesetter before wiring in (non-nil display, positive bounds).
- Builds: **iOS example**, **Swift example (iOS)**, and **macOS example** all `** BUILD SUCCEEDED **`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)