### PR TITLE
Fix designated-initializer warnings on MTMathBoxDisplay and MTRuleDisplay

### DIFF
--- a/iosMath/render/MTMathListDisplay.h
+++ b/iosMath/render/MTMathListDisplay.h
@@ -229,6 +229,9 @@ typedef NS_ENUM(unsigned int, MTLinePosition)  {
 /** Display for the box family (phantom/smash/lap). Reports geometry selected by
  the keep* flags and either draws or suppresses its measured child. */
 @interface MTMathBoxDisplay : MTDisplay
+
+- (instancetype)init NS_UNAVAILABLE;
+
 @end
 
 /// Rendering of an list with delimiters

--- a/iosMath/render/internal/MTMathListDisplayInternal.h
+++ b/iosMath/render/internal/MTMathListDisplayInternal.h
@@ -140,6 +140,8 @@ NS_ASSUME_NONNULL_BEGIN
 // so -recomputeDimensions folds it into the enclosing table's bounds.
 @interface MTRuleDisplay : MTDisplay
 
+- (instancetype)init NS_UNAVAILABLE;
+
 // `start` is in table-local coordinates. For a horizontal rule `length` extends
 // rightward (+x); for a vertical rule it extends upward (+y). Stroke is centred on
 // the path, so callers offset `start` by thickness/2 where edge alignment matters.


### PR DESCRIPTION
## Summary
- Both `MTMathBoxDisplay` and `MTRuleDisplay` declare `NS_DESIGNATED_INITIALIZER` on their init, but neither marks the inherited `-init` as unavailable. Clang warns: *Method override for the designated initializer of the superclass '-init' not found*.
- Add `- (instancetype)init NS_UNAVAILABLE;` to each interface — matches the pattern already used by every other `MTDisplay` subclass in the same file.

## Test plan
- [x] `swift build` — clean, no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)