### PR TITLE
Add \cancel family (PR 1/2): model, parser, and serialization

### DIFF
--- a/iosMath/lib/MTMathList.h
+++ b/iosMath/lib/MTMathList.h
@@ -632,6 +632,16 @@ typedef NS_ENUM(NSUInteger, MTBoxHAlign) {
     kMTBoxHAlignRight,      ///< \llap: child right edge at origin, offset -childWidth
 };
 
+/** Overlay strike drawn across an otherwise-unchanged box: the cancel/sout family.
+ Selects stroke geometry only; kMTStrikeNone leaves phantom/smash/lap behavior intact. */
+typedef NS_ENUM(NSUInteger, MTStrikeStyle) {
+    kMTStrikeNone = 0,      ///< ordinary box (phantom/smash/lap) — no overlay
+    kMTStrikeForward,       ///< \cancel   : '/'  (lower-left → upper-right)
+    kMTStrikeBackward,      ///< \bcancel  : '\'  (upper-left → lower-right)
+    kMTStrikeCross,         ///< \xcancel  : both diagonals
+    kMTStrikeHorizontal,    ///< \sout     : horizontal rule near x-height
+};
+
 /** An atom representing a box element: the phantom/smash/lap family.
  @note As with `MTMathColorbox`, the usual nucleus/script fields are unused;
  the content lives in `innerList` and the flags below select the variant. */
@@ -655,6 +665,8 @@ typedef NS_ENUM(NSUInteger, MTBoxHAlign) {
 @property (nonatomic) BOOL drawChild;
 /// Horizontal draw offset applied when keepWidth == NO (laps).
 @property (nonatomic) MTBoxHAlign hAlign;
+/// Overlay strike drawn across the box; kMTStrikeNone (default) = no strike.
+@property (nonatomic) MTStrikeStyle strikeStyle;
 
 @end
 

--- a/iosMath/lib/MTMathList.m
+++ b/iosMath/lib/MTMathList.m
@@ -1027,48 +1027,57 @@ static NSString* fractionCommandForDelimiterPair(NSString* leftDelimiter, NSStri
                                  userInfo:nil];
 }
 
-// Lossy by design (LLD §3.4): pick the closest LaTeX command from the flag matrix.
-- (NSString *)stringValue
+// Closest LaTeX command for this box variant (cancel / phantom / lap / smash),
+// picked from the flag matrix. Shared by stringValue and appendLaTeXToString:.
+- (NSString *)latexCommand
 {
-    NSString* cmd;
-    NSString* inner = self.innerList.stringValue ?: @"";
     if (self.strikeStyle != kMTStrikeNone) {
-        NSString* c;
         switch (self.strikeStyle) {
-            case kMTStrikeForward:    c = @"\\cancel";  break;
-            case kMTStrikeBackward:   c = @"\\bcancel"; break;
-            case kMTStrikeCross:      c = @"\\xcancel"; break;
-            case kMTStrikeHorizontal: c = @"\\sout";    break;
+            case kMTStrikeForward:    return @"\\cancel";
+            case kMTStrikeBackward:   return @"\\bcancel";
+            case kMTStrikeCross:      return @"\\xcancel";
+            case kMTStrikeHorizontal: return @"\\sout";
             case kMTStrikeNone:       // unreachable (guarded above)
-            default:                  c = @"\\cancel";  break;
+            default:
+                NSAssert(NO, @"Unknown MTStrikeStyle %lu", (unsigned long)self.strikeStyle);
+                return @"\\cancel";
         }
-        return [NSString stringWithFormat:@"%@{%@}", c, inner];
     }
     if (!self.drawChild) {
         // phantom family
-        if (self.keepWidth && self.keepHeight && self.keepDepth)      cmd = @"\\phantom";
-        else if (self.keepWidth)                                       cmd = @"\\hphantom";
-        else                                                          cmd = @"\\vphantom"; // covers \mathstrut -> \vphantom{(}
+        if (self.keepWidth && self.keepHeight && self.keepDepth)      return @"\\phantom";
+        else if (self.keepWidth)                                       return @"\\hphantom";
+        else                                                          return @"\\vphantom"; // covers \mathstrut -> \vphantom{(}
     } else if (!self.keepWidth) {
         // lap family
         switch (self.hAlign) {
-            case kMTBoxHAlignRight:  cmd = @"\\llap"; break;
-            case kMTBoxHAlignCenter: cmd = @"\\clap"; break;
+            case kMTBoxHAlignRight:  return @"\\llap";
+            case kMTBoxHAlignCenter: return @"\\clap";
             case kMTBoxHAlignLeft:
-            default:                 cmd = @"\\rlap"; break;
+            default:                 return @"\\rlap";
         }
     } else {
         // smash family
-        if (!self.keepHeight && !self.keepDepth)      cmd = @"\\smash";
-        else if (self.keepDepth && !self.keepHeight)  cmd = @"\\smash[t]";
-        else                                          cmd = @"\\smash[b]";
+        if (!self.keepHeight && !self.keepDepth)      return @"\\smash";
+        else if (self.keepDepth && !self.keepHeight)  return @"\\smash[t]";
+        else                                          return @"\\smash[b]";
     }
-    return [NSString stringWithFormat:@"%@{%@}", cmd, inner];
 }
 
+// Lossy by design (LLD §3.4): the inner list uses the simplified stringValue form
+// (symbols rendered as their Unicode glyph, not their LaTeX command).
+- (NSString *)stringValue
+{
+    return [NSString stringWithFormat:@"%@{%@}", self.latexCommand, self.innerList.stringValue ?: @""];
+}
+
+// Round-trip serializer: unlike stringValue, serialize the inner list via
+// mathListToString: (as every other container atom does) so a symbol atom emits
+// e.g. \alpha rather than the raw glyph α.
 - (void)appendLaTeXToString:(NSMutableString *)str
 {
-    [str appendString:self.stringValue];
+    [str appendFormat:@"%@{%@}", self.latexCommand,
+     [MTMathListBuilder mathListToString:self.innerList]];
 }
 
 - (id)copyWithZone:(NSZone *)zone

--- a/iosMath/lib/MTMathList.m
+++ b/iosMath/lib/MTMathList.m
@@ -1068,6 +1068,7 @@ static NSString* fractionCommandForDelimiterPair(NSString* leftDelimiter, NSStri
     op->_keepDepth = self.keepDepth;
     op->_drawChild = self.drawChild;
     op->_hAlign = self.hAlign;
+    op->_strikeStyle = self.strikeStyle;
     return op;
 }
 

--- a/iosMath/lib/MTMathList.m
+++ b/iosMath/lib/MTMathList.m
@@ -1032,6 +1032,18 @@ static NSString* fractionCommandForDelimiterPair(NSString* leftDelimiter, NSStri
 {
     NSString* cmd;
     NSString* inner = self.innerList.stringValue ?: @"";
+    if (self.strikeStyle != kMTStrikeNone) {
+        NSString* c;
+        switch (self.strikeStyle) {
+            case kMTStrikeForward:    c = @"\\cancel";  break;
+            case kMTStrikeBackward:   c = @"\\bcancel"; break;
+            case kMTStrikeCross:      c = @"\\xcancel"; break;
+            case kMTStrikeHorizontal: c = @"\\sout";    break;
+            case kMTStrikeNone:       // unreachable (guarded above)
+            default:                  c = @"\\cancel";  break;
+        }
+        return [NSString stringWithFormat:@"%@{%@}", c, inner];
+    }
     if (!self.drawChild) {
         // phantom family
         if (self.keepWidth && self.keepHeight && self.keepDepth)      cmd = @"\\phantom";

--- a/iosMath/lib/MTMathListBuilder.m
+++ b/iosMath/lib/MTMathListBuilder.m
@@ -1057,6 +1057,10 @@ static const NSInteger kMTMaxRecursionDepth = 150;
             @"mathllap":  @{@"kW":@NO,  @"kH":@YES, @"kD":@YES, @"draw":@YES, @"hAlign":@(kMTBoxHAlignRight)},
             @"mathrlap":  @{@"kW":@NO,  @"kH":@YES, @"kD":@YES, @"draw":@YES, @"hAlign":@(kMTBoxHAlignLeft)},
             @"mathclap":  @{@"kW":@NO,  @"kH":@YES, @"kD":@YES, @"draw":@YES, @"hAlign":@(kMTBoxHAlignCenter)},
+            @"cancel":    @{@"kW":@YES, @"kH":@YES, @"kD":@YES, @"draw":@YES, @"strike":@(kMTStrikeForward)},
+            @"bcancel":   @{@"kW":@YES, @"kH":@YES, @"kD":@YES, @"draw":@YES, @"strike":@(kMTStrikeBackward)},
+            @"xcancel":   @{@"kW":@YES, @"kH":@YES, @"kD":@YES, @"draw":@YES, @"strike":@(kMTStrikeCross)},
+            @"sout":      @{@"kW":@YES, @"kH":@YES, @"kD":@YES, @"draw":@YES, @"strike":@(kMTStrikeHorizontal)},
         };
     });
     return commands;
@@ -1267,6 +1271,8 @@ static const NSInteger kMTMaxRecursionDepth = 150;
         box.keepDepth  = [boxSpec[@"kD"] boolValue];
         box.drawChild  = [boxSpec[@"draw"] boolValue];
         box.hAlign     = (MTBoxHAlign)[boxSpec[@"hAlign"] unsignedIntegerValue];
+        // absent "strike" key → 0 → kMTStrikeNone, so phantom/smash/lap are unaffected
+        box.strikeStyle = (MTStrikeStyle)[boxSpec[@"strike"] unsignedIntegerValue];
 
         if ([boxSpec[@"synthParen"] boolValue]) {
             // \mathstrut: no argument; synthetic inner list with a single open paren.

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -3753,6 +3753,32 @@ static NSArray* getTestDataLargeDelimiters() {
         [MTMathListBuilder buildFromString:@"\\mathstrut"]], @"\\vphantom{(}");
 }
 
+- (void) testCancelRoundTrip
+{
+    for (NSString* latex in @[@"\\cancel{x}", @"\\bcancel{x}", @"\\xcancel{x}", @"\\sout{x}"]) {
+        XCTAssertEqualObjects(
+            [MTMathListBuilder mathListToString:[MTMathListBuilder buildFromString:latex]],
+            latex, @"%@", latex);
+    }
+
+    // multi-atom inner round-trips
+    XCTAssertEqualObjects(
+        [MTMathListBuilder mathListToString:[MTMathListBuilder buildFromString:@"\\cancel{x+y}"]],
+        @"\\cancel{x+y}");
+
+    // scripts are appended by the mathListToString: driver after appendLaTeXToString:;
+    // this pins that the strikeStyle branch runs under the scripted case too.
+    XCTAssertEqualObjects(
+        [MTMathListBuilder mathListToString:[MTMathListBuilder buildFromString:@"\\cancel{x}^2"]],
+        @"\\cancel{x}^{2}");
+
+    // unbalanced braces surface a non-nil parse error (fail-loud, LLD §6/§8)
+    NSError* error = nil;
+    MTMathList* bad = [MTMathListBuilder buildFromString:@"\\cancel{x" error:&error];
+    XCTAssertNil(bad);
+    XCTAssertNotNil(error);
+}
+
 - (void)testBraceGrouping
 {
     // x{\scriptstyle y}z — the issue #177 case. The group is a distinct atom;

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -3680,6 +3680,46 @@ static NSArray* getTestDataLargeDelimiters() {
     XCTAssertTrue(!sx.keepHeight && !sx.keepDepth);
 }
 
+- (void) testParseCancelFamily
+{
+    NSDictionary<NSString*, NSNumber*>* cases = @{
+        @"\\cancel{x}":  @(kMTStrikeForward),
+        @"\\bcancel{x}": @(kMTStrikeBackward),
+        @"\\xcancel{x}": @(kMTStrikeCross),
+        @"\\sout{x}":    @(kMTStrikeHorizontal),
+    };
+    for (NSString* latex in cases) {
+        MTMathList* list = [MTMathListBuilder buildFromString:latex];
+        [self checkAtomTypes:list types:@[@(kMTMathAtomBox)] desc:latex];
+        MTMathBox* box = list.atoms[0];
+        XCTAssertTrue(box.keepWidth && box.keepHeight && box.keepDepth && box.drawChild, @"%@", latex);
+        XCTAssertEqual(box.strikeStyle, (MTStrikeStyle)cases[latex].unsignedIntegerValue, @"%@", latex);
+        XCTAssertEqual(box.innerList.atoms.count, 1);
+    }
+
+    // multi-atom inner list
+    MTMathBox* sum = [MTMathListBuilder buildFromString:@"\\cancel{x+y}"].atoms[0];
+    XCTAssertEqual(sum.strikeStyle, kMTStrikeForward);
+    XCTAssertEqual(sum.innerList.atoms.count, 3);
+
+    // nested structure inner list (a fraction)
+    MTMathBox* frac = [MTMathListBuilder buildFromString:@"\\cancel{\\frac{a}{b}}"].atoms[0];
+    XCTAssertEqual(frac.innerList.atoms.count, 1);
+    XCTAssertEqual(((MTMathAtom*)frac.innerList.atoms[0]).type, kMTMathAtomFraction);
+
+    // single-token (no-brace) argument, consistent with \phantom x
+    MTMathBox* tok = [MTMathListBuilder buildFromString:@"\\cancel x"].atoms[0];
+    XCTAssertEqual(tok.strikeStyle, kMTStrikeForward);
+    XCTAssertEqual(tok.innerList.atoms.count, 1);
+
+    // \cancel at EOF: empty inner, no crash (LLD §6)
+    MTMathList* eof = [MTMathListBuilder buildFromString:@"\\cancel"];
+    XCTAssertNotNil(eof);
+    MTMathBox* eofBox = eof.atoms[0];
+    XCTAssertEqual(eofBox.strikeStyle, kMTStrikeForward);
+    XCTAssertEqual(eofBox.innerList.atoms.count, 0);
+}
+
 - (void) testParseLaps
 {
     NSDictionary<NSString*, NSNumber*>* cases = @{

--- a/iosMathTests/MTMathListBuilderTest.m
+++ b/iosMathTests/MTMathListBuilderTest.m
@@ -3748,6 +3748,9 @@ static NSArray* getTestDataLargeDelimiters() {
 {
     XCTAssertEqualObjects([MTMathListBuilder mathListToString:
         [MTMathListBuilder buildFromString:@"\\phantom{x}"]], @"\\phantom{x}");
+    // symbol atoms in a box inner serialize as LaTeX commands, not raw glyphs
+    XCTAssertEqualObjects([MTMathListBuilder mathListToString:
+        [MTMathListBuilder buildFromString:@"\\phantom{\\alpha}"]], @"\\phantom{\\alpha }");
     // \mathstrut serializes lossily to \vphantom{(}
     XCTAssertEqualObjects([MTMathListBuilder mathListToString:
         [MTMathListBuilder buildFromString:@"\\mathstrut"]], @"\\vphantom{(}");
@@ -3765,6 +3768,13 @@ static NSArray* getTestDataLargeDelimiters() {
     XCTAssertEqualObjects(
         [MTMathListBuilder mathListToString:[MTMathListBuilder buildFromString:@"\\cancel{x+y}"]],
         @"\\cancel{x+y}");
+
+    // symbol atoms in the inner list must serialize as LaTeX commands (\alpha),
+    // not their raw Unicode glyph — appendLaTeXToString: routes the inner through
+    // mathListToString: rather than the lossy stringValue form.
+    XCTAssertEqualObjects(
+        [MTMathListBuilder mathListToString:[MTMathListBuilder buildFromString:@"\\cancel{\\alpha}"]],
+        @"\\cancel{\\alpha }");
 
     // scripts are appended by the mathListToString: driver after appendLaTeXToString:;
     // this pins that the strikeStyle branch runs under the scripted case too.

--- a/iosMathTests/MTMathListTest.m
+++ b/iosMathTests/MTMathListTest.m
@@ -1077,6 +1077,22 @@ _XCTPrimitiveAssertNotEqual(test, expression1, @#expression1, expression2, @#exp
     XCTAssertThrows([[MTMathBox alloc] initWithType:kMTMathAtomOrdinary value:@""]);
 }
 
+- (void) testMathBoxStrikeStyleCopy
+{
+    MTMathBox* box = [MTMathBox new];
+    box.keepWidth = YES; box.keepHeight = YES; box.keepDepth = YES; box.drawChild = YES;
+    box.strikeStyle = kMTStrikeCross;
+    MTMathList* inner = [MTMathList new];
+    [inner addAtom:[MTMathAtomFactory atomForCharacter:'x']];
+    box.innerList = inner;
+
+    MTMathBox* copy = [box copy];
+    XCTAssertEqual(copy.strikeStyle, kMTStrikeCross);
+    XCTAssertEqual(copy.innerList.atoms.count, 1);
+    XCTAssertNotEqual(copy, box);          // deep copy
+    XCTAssertNotEqual(copy.innerList, box.innerList);
+}
+
 - (void)testMathGroupAtom
 {
     // Factory returns an MTMathGroup for the OrdGroup type.


### PR DESCRIPTION
## Goal

`\cancel{x}`/`\bcancel{x}`/`\xcancel{x}`/`\sout{x}` parse to an `MTMathBox` carrying the correct `strikeStyle`, round-trip through `mathListToString:`, and copy correctly. No rendering yet — such a box typesets as a plain (unstruck) box via the existing `kMTMathAtomBox` path, so the branch builds and all tests pass.

This is **PR 1 of 2**. PR 2 adds the render overlay.

## Commits

- `[item 1]` Add `MTStrikeStyle` enum and `strikeStyle` field to `MTMathBox`
- `[item 2]` Parse `\cancel`/`\bcancel`/`\xcancel`/`\sout` into `MTMathBox` `strikeStyle`
- `[item 3]` Serialize `MTMathBox` `strikeStyle` to LaTeX before the smash branch

## Design docs

- Plan: `docs/plans/2026-07-12-cancel.md`
- LLD: `docs/lld/2026-07-04-cancel.md`

## Tests

New tests: `testMathBoxStrikeStyleCopy`, `testParseCancelFamily`, `testCancelRoundTrip`. Full suite: 369 tests, 0 failures on iPhone 16 simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)