### PR TITLE
Add \cancel family (PR 2/2): render the strike overlay

### DIFF
--- a/iosMath/render/MTMathListDisplay.m
+++ b/iosMath/render/MTMathListDisplay.m
@@ -998,6 +998,9 @@
                      keepDepth:(BOOL) keepDepth
                      drawChild:(BOOL) drawChild
                         hAlign:(MTBoxHAlign) hAlign
+                   strikeStyle:(MTStrikeStyle) strikeStyle
+               strikeThickness:(CGFloat) strikeThickness
+          strikeVerticalOffset:(CGFloat) strikeVerticalOffset
                          range:(NSRange) range
 {
     self = [super init];
@@ -1006,6 +1009,9 @@
         _drawChild = drawChild;
         _keepWidth = keepWidth;
         _hAlign = hAlign;
+        _strikeStyle = strikeStyle;
+        _strikeThickness = strikeThickness;
+        _strikeVerticalOffset = strikeVerticalOffset;
         self.width   = keepWidth  ? child.width   : 0;
         self.ascent  = keepHeight ? child.ascent  : 0;
         self.descent = keepDepth  ? child.descent : 0;
@@ -1048,9 +1054,49 @@
     if (!self.drawChild) {
         return;                         // phantom: geometry already flowed up at measure time
     }
-    // Child holds its own absolute position (set in setPosition:); it translates
-    // the CTM by that position itself, so there is nothing to do here but draw it.
-    [self.child draw:context];
+    [self.child draw:context];          // child holds its own absolute position (set in setPosition:)
+
+    if (self.strikeStyle == kMTStrikeNone) {
+        return;                         // smash/lap: no overlay
+    }
+    // Overlay stroke over the box's own reported bounds, in the inherited text color
+    // (mirrors MTLineDisplay -draw:). x=left edge, y=baseline; y grows upward.
+    CGContextSaveGState(context);
+    [self.textColor setStroke];
+    CGFloat x   = self.position.x;
+    CGFloat y   = self.position.y;
+    CGFloat w   = self.width;
+    CGFloat top = y + self.ascent;
+    CGFloat bot = y - self.descent;
+    MTBezierPath* path = [MTBezierPath bezierPath];
+    switch (self.strikeStyle) {
+        case kMTStrikeForward:
+            [path moveToPoint:CGPointMake(x, bot)];
+            [path addLineToPoint:CGPointMake(x + w, top)];
+            break;
+        case kMTStrikeBackward:
+            [path moveToPoint:CGPointMake(x, top)];
+            [path addLineToPoint:CGPointMake(x + w, bot)];
+            break;
+        case kMTStrikeCross:
+            [path moveToPoint:CGPointMake(x, bot)];
+            [path addLineToPoint:CGPointMake(x + w, top)];
+            [path moveToPoint:CGPointMake(x, top)];
+            [path addLineToPoint:CGPointMake(x + w, bot)];
+            break;
+        case kMTStrikeHorizontal: {
+            CGFloat m = y + self.strikeVerticalOffset;
+            [path moveToPoint:CGPointMake(x, m)];
+            [path addLineToPoint:CGPointMake(x + w, m)];
+            break;
+        }
+        case kMTStrikeNone:             // unreachable (guarded above)
+        default:
+            break;
+    }
+    path.lineWidth = self.strikeThickness;
+    [path stroke];
+    CGContextRestoreGState(context);
 }
 
 @end

--- a/iosMath/render/MTMathListDisplay.m
+++ b/iosMath/render/MTMathListDisplay.m
@@ -1048,6 +1048,52 @@
     self.child.position = CGPointMake(self.position.x + offset, self.position.y);
 }
 
+static NSValue* MTBoxPointValue(CGPoint p) {
+    return [NSValue value:&p withObjCType:@encode(CGPoint)];
+}
+
+static CGPoint MTBoxPointFromValue(NSValue* v) {
+    CGPoint p = CGPointZero;
+    [v getValue:&p size:sizeof(p)];
+    return p;
+}
+
+- (NSArray<NSValue*>*) strikeSegmentPoints
+{
+    if (self.strikeStyle == kMTStrikeNone) {
+        return @[];                     // smash/lap: no overlay
+    }
+    // Geometry over the box's own reported bounds. x=left edge, y=baseline; y
+    // grows upward. Endpoints are absolute (self.position based) so a test can
+    // assert the exact stroke direction.
+    CGFloat x   = self.position.x;
+    CGFloat y   = self.position.y;
+    CGFloat w   = self.width;
+    CGFloat top = y + self.ascent;
+    CGFloat bot = y - self.descent;
+    switch (self.strikeStyle) {
+        case kMTStrikeForward:
+            return @[MTBoxPointValue(CGPointMake(x, bot)),
+                     MTBoxPointValue(CGPointMake(x + w, top))];
+        case kMTStrikeBackward:
+            return @[MTBoxPointValue(CGPointMake(x, top)),
+                     MTBoxPointValue(CGPointMake(x + w, bot))];
+        case kMTStrikeCross:
+            return @[MTBoxPointValue(CGPointMake(x, bot)),
+                     MTBoxPointValue(CGPointMake(x + w, top)),
+                     MTBoxPointValue(CGPointMake(x, top)),
+                     MTBoxPointValue(CGPointMake(x + w, bot))];
+        case kMTStrikeHorizontal: {
+            CGFloat m = y + self.strikeVerticalOffset;
+            return @[MTBoxPointValue(CGPointMake(x, m)),
+                     MTBoxPointValue(CGPointMake(x + w, m))];
+        }
+        case kMTStrikeNone:             // unreachable (guarded above)
+        default:
+            return @[];
+    }
+}
+
 - (void)draw:(CGContextRef)context
 {
     [super draw:context];               // base draws only localBackgroundColor (a no-op here)
@@ -1056,43 +1102,18 @@
     }
     [self.child draw:context];          // child holds its own absolute position (set in setPosition:)
 
-    if (self.strikeStyle == kMTStrikeNone) {
-        return;                         // smash/lap: no overlay
+    NSArray<NSValue*>* points = [self strikeSegmentPoints];
+    if (points.count == 0) {
+        return;                         // smash/lap or kMTStrikeNone: no overlay
     }
-    // Overlay stroke over the box's own reported bounds, in the inherited text color
-    // (mirrors MTLineDisplay -draw:). x=left edge, y=baseline; y grows upward.
+    // Overlay stroke in the inherited text color (mirrors MTLineDisplay -draw:).
+    // Points come pairwise from -strikeSegmentPoints; each pair is one segment.
     CGContextSaveGState(context);
     [self.textColor setStroke];
-    CGFloat x   = self.position.x;
-    CGFloat y   = self.position.y;
-    CGFloat w   = self.width;
-    CGFloat top = y + self.ascent;
-    CGFloat bot = y - self.descent;
     MTBezierPath* path = [MTBezierPath bezierPath];
-    switch (self.strikeStyle) {
-        case kMTStrikeForward:
-            [path moveToPoint:CGPointMake(x, bot)];
-            [path addLineToPoint:CGPointMake(x + w, top)];
-            break;
-        case kMTStrikeBackward:
-            [path moveToPoint:CGPointMake(x, top)];
-            [path addLineToPoint:CGPointMake(x + w, bot)];
-            break;
-        case kMTStrikeCross:
-            [path moveToPoint:CGPointMake(x, bot)];
-            [path addLineToPoint:CGPointMake(x + w, top)];
-            [path moveToPoint:CGPointMake(x, top)];
-            [path addLineToPoint:CGPointMake(x + w, bot)];
-            break;
-        case kMTStrikeHorizontal: {
-            CGFloat m = y + self.strikeVerticalOffset;
-            [path moveToPoint:CGPointMake(x, m)];
-            [path addLineToPoint:CGPointMake(x + w, m)];
-            break;
-        }
-        case kMTStrikeNone:             // unreachable (guarded above)
-        default:
-            break;
+    for (NSUInteger i = 0; i + 1 < points.count; i += 2) {
+        [path moveToPoint:MTBoxPointFromValue(points[i])];
+        [path addLineToPoint:MTBoxPointFromValue(points[i + 1])];
     }
     path.lineWidth = self.strikeThickness;
     [path stroke];

--- a/iosMath/render/internal/MTMathListDisplayInternal.h
+++ b/iosMath/render/internal/MTMathListDisplayInternal.h
@@ -202,6 +202,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) CGFloat strikeThickness;
 @property (nonatomic) CGFloat strikeVerticalOffset;   ///< y-offset above baseline for \sout
 
+/// Strike overlay geometry as a flat list of absolute endpoints, consumed
+/// pairwise: each even/odd pair is one stroked segment (moveTo then addLineTo).
+/// Empty when strikeStyle == kMTStrikeNone. -draw: builds its path from this, so
+/// asserting it in a test guards the actual stroke direction without rendering.
+- (NSArray<NSValue*>*) strikeSegmentPoints;
+
 @end
 
 @interface MTInnerDisplay ()

--- a/iosMath/render/internal/MTMathListDisplayInternal.h
+++ b/iosMath/render/internal/MTMathListDisplayInternal.h
@@ -189,12 +189,18 @@ NS_ASSUME_NONNULL_BEGIN
                      keepDepth:(BOOL) keepDepth
                      drawChild:(BOOL) drawChild
                         hAlign:(MTBoxHAlign) hAlign
+                   strikeStyle:(MTStrikeStyle) strikeStyle
+               strikeThickness:(CGFloat) strikeThickness
+          strikeVerticalOffset:(CGFloat) strikeVerticalOffset
                          range:(NSRange) range NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic) MTMathListDisplay* child;
 @property (nonatomic) BOOL drawChild;
 @property (nonatomic) BOOL keepWidth;
 @property (nonatomic) MTBoxHAlign hAlign;
+@property (nonatomic) MTStrikeStyle strikeStyle;
+@property (nonatomic) CGFloat strikeThickness;
+@property (nonatomic) CGFloat strikeVerticalOffset;   ///< y-offset above baseline for \sout
 
 @end
 

--- a/iosMath/render/internal/MTTypesetter.m
+++ b/iosMath/render/internal/MTTypesetter.m
@@ -701,6 +701,9 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
                                                                          keepDepth:boxAtom.keepDepth
                                                                          drawChild:boxAtom.drawChild
                                                                             hAlign:boxAtom.hAlign
+                                                                       strikeStyle:boxAtom.strikeStyle
+                                                                   strikeThickness:_styleFont.mathTable.fractionRuleThickness
+                                                              strikeVerticalOffset:0.55 * _styleFont.mathTable.accentBaseHeight
                                                                              range:atom.indexRange];
                 display.position = _currentPosition;
                 _currentPosition.x += display.width;   // 0 for vphantom/laps

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -3061,6 +3061,39 @@
     XCTAssertEqual(line.subDisplays.count, 2);   // box + superscript sub-display
 }
 
+- (void) testCancelEdgeCases
+{
+    // empty content: zero-size box, strokes degenerate harmlessly
+    MTMathBoxDisplay* empty = (MTMathBoxDisplay*)[self singleDisplayForLaTeX:@"\\cancel{}"];
+    XCTAssertEqual(empty.strikeStyle, kMTStrikeForward);
+    XCTAssertEqualWithAccuracy(empty.width, 0, 0.01);
+
+    // \cancel at EOF: empty inner list, still an MTMathBoxDisplay
+    MTMathBoxDisplay* eof = (MTMathBoxDisplay*)[self singleDisplayForLaTeX:@"\\cancel"];
+    XCTAssertEqual(eof.strikeStyle, kMTStrikeForward);
+
+    // nested cancels: outer box whose child line contains an inner box display
+    MTMathBoxDisplay* outer = (MTMathBoxDisplay*)[self singleDisplayForLaTeX:@"\\cancel{\\bcancel{x}}"];
+    XCTAssertEqual(outer.strikeStyle, kMTStrikeForward);
+    MTMathListDisplay* childLine = (MTMathListDisplay*)outer.child;
+    MTMathBoxDisplay* inner = childLine.subDisplays.firstObject;
+    XCTAssertTrue([inner isKindOfClass:[MTMathBoxDisplay class]]);
+    XCTAssertEqual(inner.strikeStyle, kMTStrikeBackward);
+}
+
+- (void) testCancelDrawDoesNotCrash
+{
+    CGColorSpaceRef cs = CGColorSpaceCreateDeviceRGB();
+    CGContextRef ctx = CGBitmapContextCreate(NULL, 100, 50, 8, 0, cs, kCGImageAlphaPremultipliedLast);
+    for (NSString* latex in @[@"\\cancel{x}", @"\\bcancel{x}", @"\\xcancel{x+y}",
+                              @"\\sout{x}", @"\\cancel{}", @"\\cancel{\\bcancel{x}}"]) {
+        MTMathListDisplay* line = [self displayForLaTeX:latex];
+        XCTAssertNoThrow([line draw:ctx], @"%@", latex);
+    }
+    CGContextRelease(ctx);
+    CGColorSpaceRelease(cs);
+}
+
 - (void) testHPhantomMetrics
 {
     MTDisplay* box = [self singleDisplayForLaTeX:@"\\hphantom{x}"];

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -3036,6 +3036,31 @@
     XCTAssertEqualWithAccuracy(box.descent, x.descent, 0.01);
 }
 
+- (void) testCancelStrikeDisplay
+{
+    MTMathBoxDisplay* box = (MTMathBoxDisplay*)[self singleDisplayForLaTeX:@"\\xcancel{x}"];
+    XCTAssertTrue([box isKindOfClass:[MTMathBoxDisplay class]]);
+    XCTAssertEqual(box.strikeStyle, kMTStrikeCross);
+    XCTAssertGreaterThan(box.strikeThickness, 0);
+}
+
+- (void) testCancelMetricsMatchArgument
+{
+    MTDisplay* x = [self singleDisplayForLaTeX:@"x"];
+    for (NSString* latex in @[@"\\cancel{x}", @"\\bcancel{x}", @"\\xcancel{x}", @"\\sout{x}"]) {
+        MTDisplay* box = [self singleDisplayForLaTeX:latex];
+        XCTAssertEqualWithAccuracy(box.width,   x.width,   0.01, @"%@", latex);
+        XCTAssertEqualWithAccuracy(box.ascent,  x.ascent,  0.01, @"%@", latex);
+        XCTAssertEqualWithAccuracy(box.descent, x.descent, 0.01, @"%@", latex);
+    }
+}
+
+- (void) testCancelScriptsCompose
+{
+    MTMathListDisplay* line = [self displayForLaTeX:@"\\cancel{x}^2"];
+    XCTAssertEqual(line.subDisplays.count, 2);   // box + superscript sub-display
+}
+
 - (void) testHPhantomMetrics
 {
     MTDisplay* box = [self singleDisplayForLaTeX:@"\\hphantom{x}"];

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -3094,6 +3094,61 @@
     CGColorSpaceRelease(cs);
 }
 
+- (void) testCancelStrokeDirection
+{
+    // Pin the exact stroke geometry so a swapped forward/backward diagonal (which
+    // -draw: and testCancelDrawDoesNotCrash would both accept) fails the suite.
+    // -draw: builds its path from -strikeSegmentPoints, so this guards what draws.
+    MTMathBoxDisplay* fwd = (MTMathBoxDisplay*)[self singleDisplayForLaTeX:@"\\cancel{x}"];
+    CGFloat x = fwd.position.x, w = fwd.width;
+    CGFloat top = fwd.position.y + fwd.ascent;
+    CGFloat bot = fwd.position.y - fwd.descent;
+    XCTAssertGreaterThan(w, 0);          // otherwise the direction check is vacuous
+    XCTAssertGreaterThan(top, bot);
+
+    // forward "/" : bottom-left up to top-right
+    NSArray<NSValue*>* f = [fwd strikeSegmentPoints];
+    XCTAssertEqual(f.count, 2u);
+    [self assertSegmentFrom:f start:0 to:1 x0:x y0:bot x1:x + w y1:top];
+
+    // backward "\" : top-left down to bottom-right
+    MTMathBoxDisplay* bwd = (MTMathBoxDisplay*)[self singleDisplayForLaTeX:@"\\bcancel{x}"];
+    NSArray<NSValue*>* b = [bwd strikeSegmentPoints];
+    XCTAssertEqual(b.count, 2u);
+    [self assertSegmentFrom:b start:0 to:1
+                          x0:bwd.position.x y0:bwd.position.y + bwd.ascent
+                          x1:bwd.position.x + bwd.width y1:bwd.position.y - bwd.descent];
+
+    // cross "X" : forward diagonal followed by backward diagonal
+    MTMathBoxDisplay* crs = (MTMathBoxDisplay*)[self singleDisplayForLaTeX:@"\\xcancel{x}"];
+    NSArray<NSValue*>* c = [crs strikeSegmentPoints];
+    XCTAssertEqual(c.count, 4u);
+    CGFloat cx = crs.position.x, cw = crs.width;
+    CGFloat ctop = crs.position.y + crs.ascent, cbot = crs.position.y - crs.descent;
+    [self assertSegmentFrom:c start:0 to:1 x0:cx y0:cbot x1:cx + cw y1:ctop];
+    [self assertSegmentFrom:c start:2 to:3 x0:cx y0:ctop x1:cx + cw y1:cbot];
+
+    // horizontal "-" : flat strike, both endpoints at the same y
+    MTMathBoxDisplay* hor = (MTMathBoxDisplay*)[self singleDisplayForLaTeX:@"\\sout{x}"];
+    NSArray<NSValue*>* h = [hor strikeSegmentPoints];
+    XCTAssertEqual(h.count, 2u);
+    CGFloat m = hor.position.y + hor.strikeVerticalOffset;
+    [self assertSegmentFrom:h start:0 to:1
+                          x0:hor.position.x y0:m x1:hor.position.x + hor.width y1:m];
+}
+
+- (void) assertSegmentFrom:(NSArray<NSValue*>*)pts start:(NSUInteger)s to:(NSUInteger)e
+                        x0:(CGFloat)x0 y0:(CGFloat)y0 x1:(CGFloat)x1 y1:(CGFloat)y1
+{
+    CGPoint start = CGPointZero, end = CGPointZero;
+    [pts[s] getValue:&start size:sizeof(start)];
+    [pts[e] getValue:&end   size:sizeof(end)];
+    XCTAssertEqualWithAccuracy(start.x, x0, 0.01);
+    XCTAssertEqualWithAccuracy(start.y, y0, 0.01);
+    XCTAssertEqualWithAccuracy(end.x,   x1, 0.01);
+    XCTAssertEqualWithAccuracy(end.y,   y1, 0.01);
+}
+
 - (void) testHPhantomMetrics
 {
     MTDisplay* box = [self singleDisplayForLaTeX:@"\\hphantom{x}"];


### PR DESCRIPTION
## Goal

`MTMathBoxDisplay` draws the selected stroke(s) over the child in the current text color at the fraction-bar thickness, adding no width/ascent/descent. The typesetter passes the two font-derived scalars (`strikeThickness = fractionRuleThickness`, `strikeVerticalOffset = 0.55·accentBaseHeight`). Metrics of a cancel equal its bare argument.

This is **PR 2 of 2**, stacked on **PR 1** (#259).

## Commits

- `[item 4]` Draw cancel-family strike overlay in `MTMathBoxDisplay` (initializer params + stores, `-draw:` overlay for all four strike styles, typesetter call site)
- `[item 5]` Add cancel-family edge-case and draw-path tests

## Stack

- PR 1/2: #259 — model, parser, serialization (base of this PR)
- PR 2/2: this PR

## Design docs

- Plan: `docs/plans/2026-07-12-cancel.md`
- LLD: `docs/lld/2026-07-04-cancel.md`

## ⚠️ Verification status — please confirm before merge

The implementation matches the plan exactly and builds on PR 1's model/parse layer (which passed the full 369-test suite). **However, the PR 2 test suite could not be run locally**: four verification subagents failed on environment issues (xcodebuild's silent build phase repeatedly tripped a 600s no-progress watchdog; SPM/connection also dropped). The two commits were finalized by the orchestrator from plan-exact work-in-progress, but the five new tests (`testCancelStrikeDisplay`, `testCancelMetricsMatchArgument`, `testCancelScriptsCompose`, `testCancelEdgeCases`, `testCancelDrawDoesNotCrash`) have **not** been executed green. Please verify via CI or a local `xcodebuild test`/`swift test` run before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)