### PR TITLE
Fix array rule corner overhang: outer vertical rules flush with horizontal rules

### DIFF
--- a/iosMath/render/MTMathListDisplay.m
+++ b/iosMath/render/MTMathListDisplay.m
@@ -799,13 +799,19 @@
         _length = length;
         _thickness = thickness;
         _vertical = isVertical;
-        self.position = start;
         self.range = range;
+        // `start` is a point on the stroke's centre-line; a stroked path straddles it by
+        // thickness/2 on each side of the thickness axis. Record `position` as the box's
+        // lower-left origin so the display's bounds exactly cover the drawn stroke (else the
+        // parent over-reports its width/ascent by thickness/2 — see -draw:, which re-derives
+        // the centre-line). The length axis uses a butt cap, so it isn't inset.
         if (isVertical) {
+            self.position = CGPointMake(start.x - thickness / 2, start.y);
             self.width = thickness;
             self.ascent = length;
             self.descent = 0;
         } else {
+            self.position = CGPointMake(start.x, start.y - thickness / 2);
             self.width = length;
             self.ascent = thickness;
             self.descent = 0;
@@ -820,10 +826,15 @@
     CGContextSaveGState(context);
     [self.textColor setStroke];
     MTBezierPath* path = [MTBezierPath bezierPath];
-    [path moveToPoint:self.position];
+    // position is the box origin; the stroke runs along the centre-line, offset thickness/2
+    // from the box edge on the thickness axis (the axis init inset when recording position).
+    CGPoint begin = _vertical
+        ? CGPointMake(self.position.x + _thickness / 2, self.position.y)
+        : CGPointMake(self.position.x, self.position.y + _thickness / 2);
+    [path moveToPoint:begin];
     CGPoint end = _vertical
-        ? CGPointMake(self.position.x, self.position.y + _length)
-        : CGPointMake(self.position.x + _length, self.position.y);
+        ? CGPointMake(begin.x, begin.y + _length)
+        : CGPointMake(begin.x + _length, begin.y);
     [path addLineToPoint:end];
     path.lineWidth = _thickness;
     [path stroke];

--- a/iosMath/render/internal/MTMathListDisplayInternal.h
+++ b/iosMath/render/internal/MTMathListDisplayInternal.h
@@ -140,9 +140,11 @@ NS_ASSUME_NONNULL_BEGIN
 // so -recomputeDimensions folds it into the enclosing table's bounds.
 @interface MTRuleDisplay : MTDisplay
 
-// `start` is in table-local coordinates. For a horizontal rule `length` extends
-// rightward (+x); for a vertical rule it extends upward (+y). Stroke is centred on
-// the path, so callers offset `start` by thickness/2 where edge alignment matters.
+// `start` is a point on the stroke's centre-line, in table-local coordinates. For a
+// horizontal rule `length` extends rightward (+x); for a vertical rule it extends upward
+// (+y). The stroke straddles the centre-line by thickness/2, so the initializer records
+// `position` as the box's lower-left origin (inset by thickness/2 on the thickness axis);
+// callers pass the raw centre-line and must not pre-offset for edge alignment.
 - (instancetype) initWithStart:(CGPoint) start
                         length:(CGFloat) length
                      thickness:(CGFloat) thickness

--- a/iosMath/render/internal/MTTypesetter.m
+++ b/iosMath/render/internal/MTTypesetter.m
@@ -2340,8 +2340,12 @@ static const CGFloat kArrayRulePaddingMultiplier = 0.2; // content↔rule cleara
 
 // Compute per-column start x-offsets shared by cells and vertical rules, so they cannot
 // drift. For each vertical boundary i (0..numColumns) with verticalLines[i] > 0, widen the
-// gap by 2·padding + the rule block and record each rule's centre x in vRuleXs[i]. With no
-// rules this reduces to -makeRowWithColumns:'s exact running sum (matrix path unchanged).
+// gap by the rule block plus padding and record each rule's centre x in vRuleXs[i]. Interior
+// boundaries get padding on both sides; the outer boundaries (i==0, i==numColumns) get padding
+// only on the inside so the outermost rules sit flush at x==0 / x==contentWidth — the same box
+// edges the horizontal rules span, so corners meet instead of the h-rules overhanging (LaTeX
+// behaviour). With no rules this reduces to -makeRowWithColumns:'s exact running sum (matrix
+// path unchanged).
 - (NSArray<NSNumber*>*) columnOffsetsForTable:(MTMathTable*) table
                                  columnWidths:(CGFloat[]) columnWidths
                                     thickness:(CGFloat) thickness
@@ -2361,13 +2365,16 @@ static const CGFloat kArrayRulePaddingMultiplier = 0.2; // content↔rule cleara
         NSInteger count = (i < vLines.count) ? vLines[i].integerValue : 0;
         NSMutableArray<NSNumber*>* xs = [NSMutableArray array];
         if (count > 0) {
-            CGFloat ruleAreaStart = x + padding + base / 2;
+            // No padding outside the outermost rules so they sit flush at the box edges.
+            CGFloat padLeft = (i == 0) ? 0 : padding;
+            CGFloat padRight = (i == numColumns) ? 0 : padding;
+            CGFloat ruleAreaStart = x + padLeft + base / 2;
             for (NSInteger k = 0; k < count; k++) {
                 CGFloat cx = ruleAreaStart + k * (thickness + ruleGap) + thickness / 2;
                 [xs addObject:@(cx)];
             }
             CGFloat ruleBlock = count * thickness + (count - 1) * ruleGap;
-            x += base + 2 * padding + ruleBlock;
+            x += base + padLeft + padRight + ruleBlock;
         } else {
             x += base;
         }

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -3455,10 +3455,24 @@
     XCTAssertEqual(verticals.count, 2u);
     XCTAssertEqual(horizontals.count, 2u);
 
-    // Leftmost vertical (boundary 0, base 0): x == padding + thickness/2 (edge-centred stroke).
+    // Outer vertical rules sit flush with the box edges (no padding *outside* the outer
+    // rules): the leftmost rule's stroke left edge is at x=0. Padding lives only *inside*,
+    // between rule and content. (v.position.x is the stroke centre; the stroke spans
+    // position.x ± thickness/2.)
     CGFloat leftmostX = CGFLOAT_MAX;
-    for (MTRuleDisplay* v in verticals) { leftmostX = MIN(leftmostX, v.position.x); }
-    XCTAssertEqualWithAccuracy(leftmostX, padding + thickness / 2, 0.01);
+    CGFloat rightmostX = -CGFLOAT_MAX;
+    for (MTRuleDisplay* v in verticals) {
+        leftmostX = MIN(leftmostX, v.position.x);
+        rightmostX = MAX(rightmostX, v.position.x);
+    }
+    XCTAssertEqualWithAccuracy(leftmostX - thickness / 2, 0, 0.01);
+
+    // Corners meet flush: each horizontal rule's ends coincide with the outer verticals'
+    // stroke edges rather than overhanging them (the bug: h-rules ran past the box edges).
+    for (MTRuleDisplay* h in horizontals) {
+        XCTAssertEqualWithAccuracy(h.position.x, leftmostX - thickness / 2, 0.01);
+        XCTAssertEqualWithAccuracy(h.position.x + h.width, rightmostX + thickness / 2, 0.01);
+    }
 
     // Top \hline sits padding above the content top; bottom \hline padding below content bottom.
     CGFloat topY = -CGFLOAT_MAX;

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -3328,15 +3328,17 @@
 
 - (void)testRuleDisplayHorizontalAndVerticalMetrics
 {
+    // `start` is a point on the stroke's centre-line. The box straddles it by thickness/2
+    // on the thickness axis, so position (the box origin) is inset by thickness/2 there.
     MTRuleDisplay* h = [[MTRuleDisplay alloc] initWithStart:CGPointMake(2, 5)
                                                      length:10
                                                   thickness:0.6
                                                    vertical:NO
                                                       range:NSMakeRange(0, 1)];
-    XCTAssertEqual(h.position.x, 2);
-    XCTAssertEqual(h.position.y, 5);
+    XCTAssertEqual(h.position.x, 2);          // length axis: start unchanged
+    XCTAssertEqual(h.position.y, 5 - 0.3);    // thickness axis: centre-line 5 → box bottom 4.7
     XCTAssertEqual(h.width, 10);
-    XCTAssertEqual(h.ascent, 0.6);
+    XCTAssertEqual(h.ascent, 0.6);            // box spans y ∈ [4.7, 5.3], centred on 5
     XCTAssertEqual(h.descent, 0);
 
     MTRuleDisplay* v = [[MTRuleDisplay alloc] initWithStart:CGPointMake(3, -4)
@@ -3344,10 +3346,10 @@
                                                   thickness:0.6
                                                    vertical:YES
                                                       range:NSMakeRange(0, 1)];
-    XCTAssertEqual(v.position.x, 3);
-    XCTAssertEqual(v.position.y, -4);
-    XCTAssertEqual(v.width, 0.6);
-    XCTAssertEqual(v.ascent, 12);   // top end = position.y + ascent
+    XCTAssertEqual(v.position.x, 3 - 0.3);    // thickness axis: centre-line 3 → box left 2.7
+    XCTAssertEqual(v.position.y, -4);         // length axis: start unchanged
+    XCTAssertEqual(v.width, 0.6);             // box spans x ∈ [2.7, 3.3], centred on 3
+    XCTAssertEqual(v.ascent, 12);             // top end = position.y + ascent
     XCTAssertEqual(v.descent, 0);
 }
 
@@ -3455,34 +3457,41 @@
     XCTAssertEqual(verticals.count, 2u);
     XCTAssertEqual(horizontals.count, 2u);
 
-    // Outer vertical rules sit flush with the box edges (no padding *outside* the outer
-    // rules): the leftmost rule's stroke left edge is at x=0. Padding lives only *inside*,
-    // between rule and content. (v.position.x is the stroke centre; the stroke spans
-    // position.x ± thickness/2.)
-    CGFloat leftmostX = CGFLOAT_MAX;
-    CGFloat rightmostX = -CGFLOAT_MAX;
+    // A rule's box is [position.x, position.x+width] x [position.y, position.y+ascent] and
+    // exactly covers the drawn stroke (position is the box origin, stroke straddles the
+    // centre-line). Outer vertical rules sit flush with the box edges: no padding *outside*
+    // the outer rules, so the leftmost box-left is at x=0 and the rightmost box-right is at
+    // the content edge. Padding lives only *inside*, between rule and content.
+    CGFloat vLeft = CGFLOAT_MAX;
+    CGFloat vRight = -CGFLOAT_MAX;
     for (MTRuleDisplay* v in verticals) {
-        leftmostX = MIN(leftmostX, v.position.x);
-        rightmostX = MAX(rightmostX, v.position.x);
+        vLeft = MIN(vLeft, v.position.x);
+        vRight = MAX(vRight, v.position.x + v.width);
     }
-    XCTAssertEqualWithAccuracy(leftmostX - thickness / 2, 0, 0.01);
+    XCTAssertEqualWithAccuracy(vLeft, 0, 0.01);
+    // The table's reported width matches the true content edge — no phantom half-thickness
+    // of trailing space (the vertical-rule box straddles its centre-line, so position.x+width
+    // is the real right edge, not centre+thickness).
+    XCTAssertEqualWithAccuracy(vRight, tableDisp.width, 0.01);
 
-    // Corners meet flush: each horizontal rule's ends coincide with the outer verticals'
-    // stroke edges rather than overhanging them (the bug: h-rules ran past the box edges).
+    // Corners meet flush: each horizontal rule spans exactly the box edges [0, width], so its
+    // ends coincide with the outer verticals rather than overhanging them (the overhang bug).
     for (MTRuleDisplay* h in horizontals) {
-        XCTAssertEqualWithAccuracy(h.position.x, leftmostX - thickness / 2, 0.01);
-        XCTAssertEqualWithAccuracy(h.position.x + h.width, rightmostX + thickness / 2, 0.01);
+        XCTAssertEqualWithAccuracy(h.position.x, vLeft, 0.01);
+        XCTAssertEqualWithAccuracy(h.position.x + h.width, vRight, 0.01);
     }
 
-    // Top \hline sits padding above the content top; bottom \hline padding below content bottom.
-    CGFloat topY = -CGFLOAT_MAX;
-    CGFloat botY = CGFLOAT_MAX;
+    // Top \hline sits padding above the content top; bottom \hline padding below content
+    // bottom. The stroke centre-line is position.y + thickness/2 (box straddles the line).
+    CGFloat topLine = -CGFLOAT_MAX;
+    CGFloat botLine = CGFLOAT_MAX;
     for (MTRuleDisplay* h in horizontals) {
-        topY = MAX(topY, h.position.y);
-        botY = MIN(botY, h.position.y);
+        CGFloat line = h.position.y + thickness / 2;
+        topLine = MAX(topLine, line);
+        botLine = MIN(botLine, line);
     }
-    XCTAssertEqualWithAccuracy(topY, contentTop + padding, 0.01);
-    XCTAssertEqualWithAccuracy(botY, contentBot - padding, 0.01);
+    XCTAssertEqualWithAccuracy(topLine, contentTop + padding, 0.01);
+    XCTAssertEqualWithAccuracy(botLine, contentBot - padding, 0.01);
 }
 
 @end


### PR DESCRIPTION
## Summary

Two related fixes to array rule rendering, exposed while wiring up the array-environment examples.

## Bug 1 — corner overhang

`\begin{array}{|c|c|} \hline a & b \\ \hline c & d \\ \hline \end{array}` rendered with the horizontal rules **overhanging** the outer vertical rules — the `\hline`s poked past the box corners instead of meeting them. MathJax/LaTeX draw a clean box.

**Root cause.** `columnOffsetsForTable:` added `2·padding` around *every* vertical rule, including *outside* the outermost ones. Nothing sits outside the outer rules, so that padding just inset them from the box edges the horizontal rules span — instrumenting the example (`padding = 4.0`, `thickness = 0.8`) showed v-rules confined to `[4.0, 63.38]` while h-rules spanned the full content box `[0, 67.38]`.

**Fix.** Drop the outside padding on the outer boundaries (`i == 0`, `i == numColumns`); padding now lives only *between* a rule and cell content. The outermost rules sit flush at `x == 0` / `x == contentWidth` — the same edges the horizontals span — so corners meet. Interior boundaries keep padding on both sides. The matrix / existing-env path is untouched: the new `padLeft`/`padRight` logic only fires when `verticalLines[i] > 0`, which is empty for every non-array table.

## Bug 2 — rule bounds off by half a thickness

A stroked `MTRuleDisplay` path straddles its centre-line by `thickness/2`, but the display recorded `position` *on* that centre-line while reporting `width == thickness` (vertical) / `ascent == thickness` (horizontal). So `recomputeDimensions` (`max(position + extent)`) counted the box as reaching `centre + thickness`, over-reporting the parent `table.width` by `thickness/2` on the right.

This is **not** cosmetic: layout advances the pen by a child's reported width, so every ruled array pushed following content `thickness/2` too far right (and surrounding delimiters `thickness/2` too tall).

**Fix.** Record `position` as the box's lower-left origin (inset by `thickness/2` on the thickness axis) and re-derive the stroke centre-line in `-draw:`. Drawn pixels are byte-identical; only the reported metrics tighten to exactly cover the stroke.

## Tests

- `testArrayRuleGeometryIsDeterministic` — pins the **flush-corner invariant**: leftmost v-rule stroke edge at `x=0`, and each h-rule's ends coincide with the outer v-rules' stroke edges rather than overhanging. Fails against the old code, passes after Bug 1.
- `testRuleDisplayHorizontalAndVerticalMetrics` — updated to the straddling-box semantics (`position` is the box origin, offset by `thickness/2` from the centre-line).
- Full suite green: **407/407**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
