### PR TITLE
Ink extent through the display tree (PR 1/2)

### DIFF
--- a/iosMath.xcodeproj/project.pbxproj
+++ b/iosMath.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		490465BF1D23DA8400F82033 /* MTTypesetterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 490465BE1D23DA8400F82033 /* MTTypesetterTest.m */; };
+		49A1B2C41D23DA8400F82033 /* MTInkWidthTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 49A1B2C31D23DA8400F82033 /* MTInkWidthTest.m */; };
 		490465C11D23DA8400F82033 /* MTFontManagerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 490465C01D23DA8400F82033 /* MTFontManagerTest.m */; };
 		492EED0817DAEDD200939107 /* MTFontManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 492EECFA17DAED9000939107 /* MTFontManager.m */; };
 		492EED0917DAEDD200939107 /* MTFontMathTable.m in Sources */ = {isa = PBXBuildFile; fileRef = 492EECF817DAED9000939107 /* MTFontMathTable.m */; };
@@ -74,6 +75,7 @@
 
 /* Begin PBXFileReference section */
 		490465BE1D23DA8400F82033 /* MTTypesetterTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTTypesetterTest.m; sourceTree = "<group>"; };
+		49A1B2C31D23DA8400F82033 /* MTInkWidthTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTInkWidthTest.m; sourceTree = "<group>"; };
 		490465C01D23DA8400F82033 /* MTFontManagerTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTFontManagerTest.m; sourceTree = "<group>"; };
 		492EECF317DAED9000939107 /* MTMathListDisplay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTMathListDisplay.h; sourceTree = "<group>"; };
 		492EECF417DAED9000939107 /* MTMathUILabel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTMathUILabel.h; sourceTree = "<group>"; };
@@ -250,6 +252,7 @@
 				C01DEC0DE20260612000002 /* MTColorDecoderTest.m */,
 				49B83EF517CF046A0014B739 /* MTMathListTest.m */,
 				490465BE1D23DA8400F82033 /* MTTypesetterTest.m */,
+				49A1B2C31D23DA8400F82033 /* MTInkWidthTest.m */,
 				490465C01D23DA8400F82033 /* MTFontManagerTest.m */,
 				49965F2417CBBA2700A555C5 /* Supporting Files */,
 			);
@@ -526,6 +529,7 @@
 				C01DEC0DE20260612000001 /* MTColorDecoderTest.m in Sources */,
 				498730A817D548190041B02B /* MTMathListTest.m in Sources */,
 				490465BF1D23DA8400F82033 /* MTTypesetterTest.m in Sources */,
+				49A1B2C41D23DA8400F82033 /* MTInkWidthTest.m in Sources */,
 				490465C11D23DA8400F82033 /* MTFontManagerTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iosMath/render/MTMathListDisplay.m
+++ b/iosMath/render/MTMathListDisplay.m
@@ -770,6 +770,21 @@
     [_nucleus draw:context];
 }
 
+- (CGFloat)inkWidth
+{
+    // Nucleus and limits hold absolute positions (updateNucleus/Upper/LowerLimitPosition,
+    // each including _limitShift). Nucleus is folded in via _nucleus directly.
+    CGFloat result = self.width;
+    result = MAX(result, (_nucleus.position.x - self.position.x) + _nucleus.inkWidth);
+    if (self.upperLimit) {
+        result = MAX(result, (self.upperLimit.position.x - self.position.x) + self.upperLimit.inkWidth);
+    }
+    if (self.lowerLimit) {
+        result = MAX(result, (self.lowerLimit.position.x - self.position.x) + self.lowerLimit.inkWidth);
+    }
+    return result;
+}
+
 @end
 
 #pragma mark - MTLineDisplay

--- a/iosMath/render/MTMathListDisplay.m
+++ b/iosMath/render/MTMathListDisplay.m
@@ -88,8 +88,9 @@
         CGRect bounds = CTLineGetBoundsWithOptions(_line, kCTLineBoundsUseGlyphPathBounds);
         self.ascent = MAX(0, CGRectGetMaxY(bounds) - 0);
         self.descent = MAX(0, 0 - CGRectGetMinY(bounds));
-        // TODO: Should we use this width vs the typographic width? They are slightly different. Don't know why.
-        // _width = CGRectGetMaxX(bounds);
+        // Horizontal twin of ascent/descent: ink max-x from the glyph path. Reported via
+        // inkWidth (MAX with the advance width above); see LLD §3.1. Advance still positions.
+        self.inkMaxX = CGRectGetMaxX(bounds);
     }
     return self;
 }

--- a/iosMath/render/MTMathListDisplay.m
+++ b/iosMath/render/MTMathListDisplay.m
@@ -460,6 +460,17 @@
     [self updateRadicandPosition];
 }
 
+- (CGFloat)inkWidth
+{
+    // The √ glyph is always to the left of the radicand, so only the radicand can
+    // trail. Radicand stores an absolute position (updateRadicandPosition).
+    CGFloat result = self.width;
+    if (self.radicand) {
+        result = MAX(result, (self.radicand.position.x - self.position.x) + self.radicand.inkWidth);
+    }
+    return result;
+}
+
 - (void) setPosition:(CGPoint)position
 {
     super.position = position;

--- a/iosMath/render/MTMathListDisplay.m
+++ b/iosMath/render/MTMathListDisplay.m
@@ -826,6 +826,12 @@
     self.inner.position = CGPointMake(self.position.x, self.position.y);
 }
 
+- (CGFloat)inkWidth
+{
+    // _inner is drawn at its own absolute position (updateInnerPosition).
+    return MAX(self.width, (_inner.position.x - self.position.x) + _inner.inkWidth);
+}
+
 @end
 
 #pragma mark - MTRuleDisplay

--- a/iosMath/render/MTMathListDisplay.m
+++ b/iosMath/render/MTMathListDisplay.m
@@ -1312,6 +1312,20 @@ static CGPoint MTBoxPointFromValue(NSValue* v) {
   return w;
 }
 
+- (CGFloat)inkWidth
+{
+  // Delimiters and inner hold absolute positions after setPosition:.
+  CGFloat result = self.width;
+  if (_leftDelimiter) {
+      result = MAX(result, (_leftDelimiter.position.x - self.position.x) + _leftDelimiter.inkWidth);
+  }
+  result = MAX(result, (_inner.position.x - self.position.x) + _inner.inkWidth);
+  if (_rightDelimiter) {
+      result = MAX(result, (_rightDelimiter.position.x - self.position.x) + _rightDelimiter.inkWidth);
+  }
+  return result;
+}
+
 - (void)setTextColor:(MTColor *)textColor
 {
   [super setTextColor:textColor];

--- a/iosMath/render/MTMathListDisplay.m
+++ b/iosMath/render/MTMathListDisplay.m
@@ -328,6 +328,16 @@
     return MAX(_numerator.width, _denominator.width);
 }
 
+- (CGFloat)inkWidth
+{
+    // Children store absolute positions (updateDenominatorPosition adds self.position.x),
+    // so subtract self.position.x to get the extent from this display's origin.
+    CGFloat result = self.width;
+    result = MAX(result, (_numerator.position.x   - self.position.x) + _numerator.inkWidth);
+    result = MAX(result, (_denominator.position.x - self.position.x) + _denominator.inkWidth);
+    return result;
+}
+
 - (void)setDenominatorDown:(CGFloat)denominatorDown
 {
     _denominatorDown = denominatorDown;

--- a/iosMath/render/MTMathListDisplay.m
+++ b/iosMath/render/MTMathListDisplay.m
@@ -38,6 +38,11 @@
     return CGRectMake(self.position.x, self.position.y - self.descent, self.width, self.ascent + self.descent);
 }
 
+- (CGFloat)inkWidth
+{
+    return MAX(self.width, self.inkMaxX);
+}
+
 // Debug method skipped for MAC.
 #if TARGET_OS_IPHONE
 - (id)debugQuickLookObject

--- a/iosMath/render/MTMathListDisplay.m
+++ b/iosMath/render/MTMathListDisplay.m
@@ -17,6 +17,18 @@
 #import "MTFont+Internal.h"
 #import "MTMathListDisplayInternal.h"
 
+// Ink max-x of a glyph run: the widest per-glyph bbox right edge, each shifted by
+// its own x-offset. Shared by the two glyph-array displays so they can't drift.
+static CGFloat MTInkMaxXForGlyphRun(const CGGlyph* glyphs, const CGPoint* positions, NSInteger count, MTFont* font)
+{
+    CGFloat maxX = 0;
+    for (NSInteger i = 0; i < count; i++) {
+        CGRect bbox = CTFontGetBoundingRectsForGlyphs(font.ctFont, kCTFontOrientationDefault, &glyphs[i], NULL, 1);
+        maxX = MAX(maxX, positions[i].x + CGRectGetMaxX(bbox));
+    }
+    return maxX;
+}
+
 #pragma mark MTDisplay
 
 @implementation MTDisplay
@@ -89,7 +101,7 @@
         self.ascent = MAX(0, CGRectGetMaxY(bounds) - 0);
         self.descent = MAX(0, 0 - CGRectGetMinY(bounds));
         // Horizontal twin of ascent/descent: ink max-x from the glyph path. Reported via
-        // inkWidth (MAX with the advance width above); see LLD §3.1. Advance still positions.
+        // inkWidth (MAX with the advance width above). Advance still positions.
         self.inkMaxX = CGRectGetMaxX(bounds);
     }
     return self;
@@ -161,7 +173,7 @@
         CGRect bounds = CTLineGetBoundsWithOptions(_line, kCTLineBoundsUseGlyphPathBounds);
         self.ascent  = MAX(0, CGRectGetMaxY(bounds));
         self.descent = MAX(0, -CGRectGetMinY(bounds));
-        self.inkMaxX = CGRectGetMaxX(bounds);   // ink extent; see LLD §3.1
+        self.inkMaxX = CGRectGetMaxX(bounds);   // ink extent
     }
     return self;
 }
@@ -462,11 +474,15 @@
 
 - (CGFloat)inkWidth
 {
-    // The √ glyph is always to the left of the radicand, so only the radicand can
-    // trail. Radicand stores an absolute position (updateRadicandPosition).
+    // The √ glyph is left of the radicand and the degree sits upper-left, so the
+    // radicand normally trails; fold in every child anyway for consistency. Both
+    // store absolute positions (updateRadicandPosition / setDegree:).
     CGFloat result = self.width;
     if (self.radicand) {
         result = MAX(result, (self.radicand.position.x - self.position.x) + self.radicand.inkWidth);
+    }
+    if (self.degree) {
+        result = MAX(result, (self.degree.position.x - self.position.x) + self.degree.inkWidth);
     }
     return result;
 }
@@ -609,12 +625,7 @@
         _font = font;
         self.position = CGPointZero;
         // x-offsets are 0 for vertical stacking, so ink max-x is the widest glyph bbox.
-        CGFloat maxX = 0;
-        for (int i = 0; i < _numGlyphs; i++) {
-            CGRect bbox = CTFontGetBoundingRectsForGlyphs(font.ctFont, kCTFontOrientationDefault, &_glyphs[i], NULL, 1);
-            maxX = MAX(maxX, _positions[i].x + CGRectGetMaxX(bbox));
-        }
-        self.inkMaxX = maxX;
+        self.inkMaxX = MTInkMaxXForGlyphRun(_glyphs, _positions, _numGlyphs, font);
     }
     return self;
 }
@@ -944,8 +955,14 @@
 
 - (CGFloat)inkWidth
 {
-    // width is set to accentee.width by the typesetter; accentee holds an absolute position.
-    return MAX(self.width, (self.accentee.position.x - self.position.x) + self.accentee.inkWidth);
+    // width is set to accentee.width by the typesetter. Both children hold absolute
+    // positions; the accent glyph is offset by skew and can overhang the accentee,
+    // so it has to be folded in too.
+    CGFloat result = MAX(self.width, (self.accentee.position.x - self.position.x) + self.accentee.inkWidth);
+    if (self.accent) {
+        result = MAX(result, (self.accent.position.x - self.position.x) + self.accent.inkWidth);
+    }
+    return result;
 }
 
 - (void)draw:(CGContextRef)context
@@ -1053,12 +1070,7 @@
         _font = font;
         self.range = range;
         self.position = CGPointZero;
-        CGFloat maxX = 0;
-        for (int i = 0; i < _numGlyphs; i++) {
-            CGRect bbox = CTFontGetBoundingRectsForGlyphs(font.ctFont, kCTFontOrientationDefault, &_glyphs[i], NULL, 1);
-            maxX = MAX(maxX, _positions[i].x + CGRectGetMaxX(bbox));
-        }
-        self.inkMaxX = maxX;
+        self.inkMaxX = MTInkMaxXForGlyphRun(_glyphs, _positions, _numGlyphs, font);
     }
     return self;
 }

--- a/iosMath/render/MTMathListDisplay.m
+++ b/iosMath/render/MTMathListDisplay.m
@@ -161,6 +161,7 @@
         CGRect bounds = CTLineGetBoundsWithOptions(_line, kCTLineBoundsUseGlyphPathBounds);
         self.ascent  = MAX(0, CGRectGetMaxY(bounds));
         self.descent = MAX(0, -CGRectGetMinY(bounds));
+        self.inkMaxX = CGRectGetMaxX(bounds);   // ink extent; see LLD §3.1
     }
     return self;
 }

--- a/iosMath/render/MTMathListDisplay.m
+++ b/iosMath/render/MTMathListDisplay.m
@@ -267,12 +267,13 @@
     CGFloat max_ascent = 0;
     CGFloat max_descent = 0;
     CGFloat max_width = 0;
+    CGFloat max_inkMaxX = 0;
     for (MTDisplay* atom in self.subDisplays) {
         CGFloat ascent = MAX(0, atom.position.y + atom.ascent);
         if (ascent > max_ascent) {
             max_ascent = ascent;
         }
-        
+
         CGFloat descent = MAX(0, 0 - (atom.position.y - atom.descent));
         if (descent > max_descent) {
             max_descent = descent;
@@ -281,10 +282,15 @@
         if (width > max_width) {
             max_width = width;
         }
+        CGFloat inkRight = atom.position.x + atom.inkWidth;   // ink twin of width
+        if (inkRight > max_inkMaxX) {
+            max_inkMaxX = inkRight;
+        }
     }
     self.ascent = max_ascent;
     self.descent = max_descent;
     self.width = max_width;
+    self.inkMaxX = max_inkMaxX;
 }
 
 

--- a/iosMath/render/MTMathListDisplay.m
+++ b/iosMath/render/MTMathListDisplay.m
@@ -989,6 +989,12 @@
         _font = font;
         self.range = range;
         self.position = CGPointZero;
+        CGFloat maxX = 0;
+        for (int i = 0; i < _numGlyphs; i++) {
+            CGRect bbox = CTFontGetBoundingRectsForGlyphs(font.ctFont, kCTFontOrientationDefault, &_glyphs[i], NULL, 1);
+            maxX = MAX(maxX, _positions[i].x + CGRectGetMaxX(bbox));
+        }
+        self.inkMaxX = maxX;
     }
     return self;
 }

--- a/iosMath/render/MTMathListDisplay.m
+++ b/iosMath/render/MTMathListDisplay.m
@@ -927,6 +927,12 @@
     self.accentee.position = CGPointMake(self.position.x, self.position.y);
 }
 
+- (CGFloat)inkWidth
+{
+    // width is set to accentee.width by the typesetter; accentee holds an absolute position.
+    return MAX(self.width, (self.accentee.position.x - self.position.x) + self.accentee.inkWidth);
+}
+
 - (void)draw:(CGContextRef)context
 {
     [super draw:context];

--- a/iosMath/render/MTMathListDisplay.m
+++ b/iosMath/render/MTMathListDisplay.m
@@ -996,6 +996,16 @@
     }
 }
 
+- (CGFloat)inkWidth
+{
+    // base/over/under carry absolute positions after setPosition: shifts them.
+    CGFloat result = self.width;
+    if (_base)  result = MAX(result, (_base.position.x  - self.position.x) + _base.inkWidth);
+    if (_over)  result = MAX(result, (_over.position.x  - self.position.x) + _over.inkWidth);
+    if (_under) result = MAX(result, (_under.position.x - self.position.x) + _under.inkWidth);
+    return result;
+}
+
 - (void)setTextColor:(MTColor *)textColor
 {
     [super setTextColor:textColor];

--- a/iosMath/render/MTMathListDisplay.m
+++ b/iosMath/render/MTMathListDisplay.m
@@ -518,9 +518,12 @@
     if (self) {
         _font = font;
         _glyph = glyph;
-        
+
         self.position = CGPointZero;
         self.range = range;
+        // Ink extent measured next to draw: so no typesetter call site can forget it.
+        CGRect bbox = CTFontGetBoundingRectsForGlyphs(font.ctFont, kCTFontOrientationDefault, &_glyph, NULL, 1);
+        self.inkMaxX = CGRectGetMaxX(bbox);
     }
     return self;
 }

--- a/iosMath/render/MTMathListDisplay.m
+++ b/iosMath/render/MTMathListDisplay.m
@@ -581,6 +581,13 @@
         }
         _font = font;
         self.position = CGPointZero;
+        // x-offsets are 0 for vertical stacking, so ink max-x is the widest glyph bbox.
+        CGFloat maxX = 0;
+        for (int i = 0; i < _numGlyphs; i++) {
+            CGRect bbox = CTFontGetBoundingRectsForGlyphs(font.ctFont, kCTFontOrientationDefault, &_glyphs[i], NULL, 1);
+            maxX = MAX(maxX, _positions[i].x + CGRectGetMaxX(bbox));
+        }
+        self.inkMaxX = maxX;
     }
     return self;
 }

--- a/iosMath/render/internal/MTMathListDisplayInternal.h
+++ b/iosMath/render/internal/MTMathListDisplayInternal.h
@@ -17,6 +17,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) CGFloat ascent;
 @property (nonatomic) CGFloat descent;
 @property (nonatomic) CGFloat width;
+// Raw glyph-path ink max-x measured from this display's own origin. Default 0.
+// See docs/lld/2026-07-06-ink-aware-width.md §3.1.
+@property (nonatomic) CGFloat inkMaxX;
+// Read-time ink extent: MAX(width, inkMaxX). A getter (not a frozen value) so it
+// tracks post-init width mutations in the typesetter (LLD §2.4).
+@property (nonatomic, readonly) CGFloat inkWidth;
 @property (nonatomic) NSRange range;
 @property (nonatomic) BOOL hasScript;
 

--- a/iosMath/render/internal/MTMathListDisplayInternal.h
+++ b/iosMath/render/internal/MTMathListDisplayInternal.h
@@ -18,10 +18,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) CGFloat descent;
 @property (nonatomic) CGFloat width;
 // Raw glyph-path ink max-x measured from this display's own origin. Default 0.
-// See docs/lld/2026-07-06-ink-aware-width.md §3.1.
 @property (nonatomic) CGFloat inkMaxX;
 // Read-time ink extent: MAX(width, inkMaxX). A getter (not a frozen value) so it
-// tracks post-init width mutations in the typesetter (LLD §2.4).
+// tracks post-init width mutations in the typesetter.
 @property (nonatomic, readonly) CGFloat inkWidth;
 @property (nonatomic) NSRange range;
 @property (nonatomic) BOOL hasScript;

--- a/iosMathTests/MTInkWidthTest.m
+++ b/iosMathTests/MTInkWidthTest.m
@@ -51,4 +51,17 @@
     XCTAssertEqualWithAccuracy(lineX.width, 11.44, 0.01);
 }
 
+// \text{...} produces an MTTextDisplay leaf; its inkMaxX must be populated and
+// the invariant inkWidth >= width must hold.
+- (void)testTextLeafInk {
+    MTMathListDisplay* d = [self displayFor:@"\\text{Wf}"];
+    MTTextDisplay* text = nil;
+    for (MTDisplay* sub in d.subDisplays) {
+        if ([sub isKindOfClass:[MTTextDisplay class]]) { text = (MTTextDisplay*)sub; break; }
+    }
+    XCTAssertNotNil(text, @"expected an MTTextDisplay");
+    XCTAssertGreaterThan(text.inkMaxX, 0);
+    XCTAssertGreaterThanOrEqual(text.inkWidth, text.width - 0.01);
+}
+
 @end

--- a/iosMathTests/MTInkWidthTest.m
+++ b/iosMathTests/MTInkWidthTest.m
@@ -117,6 +117,10 @@
     XCTAssertEqualWithAccuracy(script.position.y, 7.26, 0.01);
 }
 
+- (void)testFractionInk {
+    [self assertComposite:[MTFractionDisplay class] bare:@"\\frac{1}{V}" shifted:@"a\\frac{1}{V}"];
+}
+
 // Depth-first: the first display of the given class, or nil.
 - (MTDisplay*)findDisplayOfClass:(Class)cls in:(MTDisplay*)d {
     if ([d isKindOfClass:cls]) return d;
@@ -169,6 +173,32 @@
         return a;
     }
     return @[];
+}
+
+// True ink-right of a composite, composed from its public children in the
+// composite's own absolute-position basis. This is the guarantee lower bound.
+- (CGFloat)composedInkRightOf:(MTDisplay*)d {
+    CGFloat r = d.width;
+    for (MTDisplay* child in [self childrenOf:d]) {
+        if (!child) continue;
+        r = MAX(r, (child.position.x - d.position.x) + child.inkWidth);
+    }
+    return r;
+}
+
+// Assert (a) the getter covers the composed child ink (guarantee), (b) it strictly
+// exceeds the advance for an overhang child, and (c) the overhang (inkWidth - width)
+// is invariant to the composite's absolute x — catching a wrong coordinate basis.
+- (void)assertComposite:(Class)cls bare:(NSString*)bare shifted:(NSString*)shifted {
+    MTDisplay* b = [self findDisplayOfClass:cls in:[self displayFor:bare]];
+    MTDisplay* s = [self findDisplayOfClass:cls in:[self displayFor:shifted]];
+    XCTAssertNotNil(b, @"no %@ in %@", NSStringFromClass(cls), bare);
+    XCTAssertNotNil(s, @"no %@ in %@", NSStringFromClass(cls), shifted);
+    XCTAssertGreaterThanOrEqual(b.inkWidth, [self composedInkRightOf:b] - 0.01);
+    XCTAssertGreaterThanOrEqual(s.inkWidth, [self composedInkRightOf:s] - 0.01);
+    XCTAssertGreaterThan(b.inkWidth, b.width);            // trailing child overhangs
+    XCTAssertGreaterThan(s.position.x, b.position.x);     // shifted variant is further right
+    XCTAssertEqualWithAccuracy(s.inkWidth - s.width, b.inkWidth - b.width, 0.02);  // basis-invariant
 }
 
 @end

--- a/iosMathTests/MTInkWidthTest.m
+++ b/iosMathTests/MTInkWidthTest.m
@@ -121,6 +121,10 @@
     [self assertComposite:[MTFractionDisplay class] bare:@"\\frac{1}{V}" shifted:@"a\\frac{1}{V}"];
 }
 
+- (void)testRadicalInk {
+    [self assertComposite:[MTRadicalDisplay class] bare:@"\\sqrt{V}" shifted:@"a\\sqrt{V}"];
+}
+
 // Depth-first: the first display of the given class, or nil.
 - (MTDisplay*)findDisplayOfClass:(Class)cls in:(MTDisplay*)d {
     if ([d isKindOfClass:cls]) return d;

--- a/iosMathTests/MTInkWidthTest.m
+++ b/iosMathTests/MTInkWidthTest.m
@@ -129,6 +129,10 @@
     [self assertComposite:[MTLineDisplay class] bare:@"\\overline{V}" shifted:@"a\\overline{V}"];
 }
 
+- (void)testAccentInk {
+    [self assertComposite:[MTAccentDisplay class] bare:@"\\hat{V}" shifted:@"a\\hat{V}"];
+}
+
 // Depth-first: the first display of the given class, or nil.
 - (MTDisplay*)findDisplayOfClass:(Class)cls in:(MTDisplay*)d {
     if ([d isKindOfClass:cls]) return d;

--- a/iosMathTests/MTInkWidthTest.m
+++ b/iosMathTests/MTInkWidthTest.m
@@ -146,6 +146,10 @@
     [self assertComposite:[MTStackDisplay class] bare:@"\\overrightarrow{VV}" shifted:@"a\\overrightarrow{VV}"];
 }
 
+- (void)testInnerInk {
+    [self assertComposite:[MTInnerDisplay class] bare:@"\\left( V \\right." shifted:@"a\\left( V \\right."];
+}
+
 // Depth-first: the first display of the given class, or nil.
 - (MTDisplay*)findDisplayOfClass:(Class)cls in:(MTDisplay*)d {
     if ([d isKindOfClass:cls]) return d;

--- a/iosMathTests/MTInkWidthTest.m
+++ b/iosMathTests/MTInkWidthTest.m
@@ -36,4 +36,19 @@
     XCTAssertEqualWithAccuracy(d.inkWidth, 10, 0.001);   // inkMaxX < width → width
 }
 
+// The MTCTLineDisplay leaf of an overhang glyph reports ink past its advance.
+- (void)testCTLineLeafInk {
+    MTMathListDisplay* dP = [self displayFor:@"P"];
+    MTCTLineDisplay* lineP = (MTCTLineDisplay*)dP.subDisplays.firstObject;
+    XCTAssertTrue([lineP isKindOfClass:[MTCTLineDisplay class]]);
+    XCTAssertGreaterThanOrEqual(lineP.inkWidth, 15.08 - 0.01);   // P ink right = 15.08
+    XCTAssertGreaterThan(lineP.inkWidth, lineP.width);           // 15.08 > advance 12.84
+
+    // Control: x ink (10.54) < advance (11.44) → inkWidth stays the advance.
+    MTMathListDisplay* dx = [self displayFor:@"x"];
+    MTCTLineDisplay* lineX = (MTCTLineDisplay*)dx.subDisplays.firstObject;
+    XCTAssertEqualWithAccuracy(lineX.inkWidth, 11.44, 0.01);
+    XCTAssertEqualWithAccuracy(lineX.width, 11.44, 0.01);
+}
+
 @end

--- a/iosMathTests/MTInkWidthTest.m
+++ b/iosMathTests/MTInkWidthTest.m
@@ -64,4 +64,68 @@
     XCTAssertGreaterThanOrEqual(text.inkWidth, text.width - 0.01);
 }
 
+// A large-op glyph (e.g. \int) renders as an MTGlyphDisplay; its inkMaxX comes
+// from the glyph bounding box, independent of the shiftDown y-adjustment.
+- (void)testGlyphLeafInk {
+    MTMathListDisplay* d = [self displayFor:@"\\int"];
+    MTGlyphDisplay* glyph = (MTGlyphDisplay*)[self findDisplayOfClass:[MTGlyphDisplay class] in:d];
+    XCTAssertNotNil(glyph, @"expected an MTGlyphDisplay");
+    XCTAssertGreaterThan(glyph.inkMaxX, 0);
+    XCTAssertGreaterThanOrEqual(glyph.inkWidth, glyph.width - 0.01);
+}
+
+// Depth-first: the first display of the given class, or nil.
+- (MTDisplay*)findDisplayOfClass:(Class)cls in:(MTDisplay*)d {
+    if ([d isKindOfClass:cls]) return d;
+    if ([d respondsToSelector:@selector(subDisplays)]) {
+        for (MTDisplay* sub in [(id)d subDisplays]) {
+            MTDisplay* hit = [self findDisplayOfClass:cls in:sub];
+            if (hit) return hit;
+        }
+    }
+    // Composites hold children outside subDisplays; probe the public accessors.
+    for (MTDisplay* child in [self childrenOf:d]) {
+        if (!child) continue;
+        MTDisplay* hit = [self findDisplayOfClass:cls in:child];
+        if (hit) return hit;
+    }
+    return nil;
+}
+
+// Public composite children (nucleus of large-op is private and omitted).
+- (NSArray<MTDisplay*>*)childrenOf:(MTDisplay*)d {
+    if ([d isKindOfClass:[MTFractionDisplay class]]) {
+        MTFractionDisplay* f = (MTFractionDisplay*)d;
+        return @[f.numerator, f.denominator];
+    } else if ([d isKindOfClass:[MTRadicalDisplay class]]) {
+        MTRadicalDisplay* r = (MTRadicalDisplay*)d;
+        return r.degree ? @[r.radicand, r.degree] : @[r.radicand];
+    } else if ([d isKindOfClass:[MTLargeOpLimitsDisplay class]]) {
+        MTLargeOpLimitsDisplay* o = (MTLargeOpLimitsDisplay*)d;
+        NSMutableArray* a = [NSMutableArray array];
+        if (o.upperLimit) [a addObject:o.upperLimit];
+        if (o.lowerLimit) [a addObject:o.lowerLimit];
+        return a;
+    } else if ([d isKindOfClass:[MTLineDisplay class]]) {
+        return @[((MTLineDisplay*)d).inner];
+    } else if ([d isKindOfClass:[MTAccentDisplay class]]) {
+        MTAccentDisplay* a = (MTAccentDisplay*)d;
+        return @[a.accentee, a.accent];
+    } else if ([d isKindOfClass:[MTStackDisplay class]]) {
+        MTStackDisplay* s = (MTStackDisplay*)d;
+        NSMutableArray* a = [NSMutableArray arrayWithObject:s.base];
+        if (s.over) [a addObject:s.over];
+        if (s.under) [a addObject:s.under];
+        return a;
+    } else if ([d isKindOfClass:[MTInnerDisplay class]]) {
+        MTInnerDisplay* i = (MTInnerDisplay*)d;
+        NSMutableArray* a = [NSMutableArray array];
+        if (i.leftDelimiter) [a addObject:i.leftDelimiter];
+        [a addObject:i.inner];
+        if (i.rightDelimiter) [a addObject:i.rightDelimiter];
+        return a;
+    }
+    return @[];
+}
+
 @end

--- a/iosMathTests/MTInkWidthTest.m
+++ b/iosMathTests/MTInkWidthTest.m
@@ -230,4 +230,23 @@
     XCTAssertEqualWithAccuracy(s.inkWidth - s.width, b.inkWidth - b.width, 0.02);  // basis-invariant
 }
 
+- (void)testPostInitWidthMutationGuard {
+    MTMathListDisplay* d = [self displayFor:@"\\left( a+b \\right)"];
+    XCTAssertGreaterThanOrEqual(d.inkWidth, d.width - 0.01);
+    // The mutation absorbs into inkWidth via the getter, not a stale frozen value:
+    // walk every sub-display and assert the invariant holds everywhere.
+    [self assertInkInvariant:d];
+}
+
+- (void)assertInkInvariant:(MTDisplay*)d {
+    XCTAssertGreaterThanOrEqual(d.inkWidth, d.width - 0.01,
+        @"%@ inkWidth %.2f < width %.2f", NSStringFromClass([d class]), d.inkWidth, d.width);
+    if ([d respondsToSelector:@selector(subDisplays)]) {
+        for (MTDisplay* sub in [(id)d subDisplays]) { [self assertInkInvariant:sub]; }
+    }
+    for (MTDisplay* child in [self childrenOf:d]) {
+        if (child) [self assertInkInvariant:child];
+    }
+}
+
 @end

--- a/iosMathTests/MTInkWidthTest.m
+++ b/iosMathTests/MTInkWidthTest.m
@@ -86,6 +86,16 @@
     XCTAssertGreaterThanOrEqual(g.inkWidth, g.width - 0.01);
 }
 
+// A wide over-arrow assembles horizontally; ink max-x folds per-part x offsets.
+- (void)testHorizontalAssemblyLeafInk {
+    MTMathListDisplay* d = [self displayFor:@"\\overleftrightarrow{ABCDEFG}"];
+    MTHorizontalGlyphAssemblyDisplay* h =
+        (MTHorizontalGlyphAssemblyDisplay*)[self findDisplayOfClass:[MTHorizontalGlyphAssemblyDisplay class] in:d];
+    XCTAssertNotNil(h, @"expected an MTHorizontalGlyphAssemblyDisplay");
+    XCTAssertGreaterThan(h.inkMaxX, 0);
+    XCTAssertGreaterThanOrEqual(h.inkWidth, h.width - 0.01);
+}
+
 // Depth-first: the first display of the given class, or nil.
 - (MTDisplay*)findDisplayOfClass:(Class)cls in:(MTDisplay*)d {
     if ([d isKindOfClass:cls]) return d;

--- a/iosMathTests/MTInkWidthTest.m
+++ b/iosMathTests/MTInkWidthTest.m
@@ -1,0 +1,39 @@
+#import <XCTest/XCTest.h>
+#import <CoreText/CoreText.h>
+#import "MTTypesetter.h"
+#import "MTFont+Internal.h"
+#import "MTFontManager.h"
+#import "MTMathListDisplay.h"
+#import "MTMathListDisplayInternal.h"
+#import "MTMathAtomFactory.h"
+#import "MTMathListBuilder.h"
+
+@interface MTInkWidthTest : XCTestCase
+@property (nonatomic) MTFont* font;
+@end
+
+@implementation MTInkWidthTest
+
+- (void)setUp {
+    [super setUp];
+    self.font = MTFontManager.fontManager.defaultFont; // Latin Modern Math @ 20pt
+}
+
+- (MTMathListDisplay*)displayFor:(NSString*)latex {
+    MTMathList* list = [MTMathListBuilder buildFromString:latex];
+    return [MTTypesetter createLineForMathList:list font:self.font style:kMTLineStyleDisplay];
+}
+
+// Base getter: inkWidth == MAX(width, inkMaxX); default inkMaxX is 0.
+- (void)testBaseInkWidthGetter {
+    MTDisplay* d = [[MTDisplay alloc] init];
+    d.width = 10;
+    XCTAssertEqual(d.inkMaxX, 0);
+    XCTAssertEqualWithAccuracy(d.inkWidth, 10, 0.001);   // inkMaxX 0 < width → width
+    d.inkMaxX = 15;
+    XCTAssertEqualWithAccuracy(d.inkWidth, 15, 0.001);   // inkMaxX > width → inkMaxX
+    d.inkMaxX = 4;
+    XCTAssertEqualWithAccuracy(d.inkWidth, 10, 0.001);   // inkMaxX < width → width
+}
+
+@end

--- a/iosMathTests/MTInkWidthTest.m
+++ b/iosMathTests/MTInkWidthTest.m
@@ -125,6 +125,10 @@
     [self assertComposite:[MTRadicalDisplay class] bare:@"\\sqrt{V}" shifted:@"a\\sqrt{V}"];
 }
 
+- (void)testOverlineInk {
+    [self assertComposite:[MTLineDisplay class] bare:@"\\overline{V}" shifted:@"a\\overline{V}"];
+}
+
 // Depth-first: the first display of the given class, or nil.
 - (MTDisplay*)findDisplayOfClass:(Class)cls in:(MTDisplay*)d {
     if ([d isKindOfClass:cls]) return d;

--- a/iosMathTests/MTInkWidthTest.m
+++ b/iosMathTests/MTInkWidthTest.m
@@ -137,6 +137,15 @@
     [self assertComposite:[MTLargeOpLimitsDisplay class] bare:@"\\sum^{VVV}" shifted:@"a\\sum^{VVV}"];
 }
 
+- (void)testStackInk {
+    // \overrightarrow{V} alone doesn't overhang: the target width is the base's
+    // *advance* (not ink), so the stretchy-arrow variant step can land wide
+    // enough that centering the base within it absorbs the base's ink overhang.
+    // A two-character base (VV) has enough advance that the same variant step
+    // no longer fully covers the extra ink, restoring a real overhang.
+    [self assertComposite:[MTStackDisplay class] bare:@"\\overrightarrow{VV}" shifted:@"a\\overrightarrow{VV}"];
+}
+
 // Depth-first: the first display of the given class, or nil.
 - (MTDisplay*)findDisplayOfClass:(Class)cls in:(MTDisplay*)d {
     if ([d isKindOfClass:cls]) return d;

--- a/iosMathTests/MTInkWidthTest.m
+++ b/iosMathTests/MTInkWidthTest.m
@@ -74,6 +74,18 @@
     XCTAssertGreaterThanOrEqual(glyph.inkWidth, glyph.width - 0.01);
 }
 
+// Tall delimiters build an MTGlyphConstructionDisplay (vertical stack, x-offsets 0).
+// Deeply nested fractions are needed to exceed the font's largest pre-built
+// paren variant and force the multi-part glyph assembly.
+- (void)testGlyphConstructionLeafInk {
+    MTMathListDisplay* d = [self displayFor:@"\\left(\\frac{1}{\\frac{1}{\\frac{1}{\\frac{1}{2}}}}\\right)"];
+    MTGlyphConstructionDisplay* g =
+        (MTGlyphConstructionDisplay*)[self findDisplayOfClass:[MTGlyphConstructionDisplay class] in:d];
+    XCTAssertNotNil(g, @"expected an MTGlyphConstructionDisplay");
+    XCTAssertGreaterThan(g.inkMaxX, 0);
+    XCTAssertGreaterThanOrEqual(g.inkWidth, g.width - 0.01);
+}
+
 // Depth-first: the first display of the given class, or nil.
 - (MTDisplay*)findDisplayOfClass:(Class)cls in:(MTDisplay*)d {
     if ([d isKindOfClass:cls]) return d;

--- a/iosMathTests/MTInkWidthTest.m
+++ b/iosMathTests/MTInkWidthTest.m
@@ -133,6 +133,25 @@
     [self assertComposite:[MTAccentDisplay class] bare:@"\\hat{V}" shifted:@"a\\hat{V}"];
 }
 
+// \hat{V} above lets the accentee (V) trail, so it passes even if the accent glyph
+// is ignored. \vec{f} is the opposite: the skewed arrow glyph overhangs past the
+// accentee's ink, so the accent glyph itself must drive inkWidth.
+- (void)testAccentGlyphInk {
+    MTAccentDisplay* a = (MTAccentDisplay*)[self findDisplayOfClass:[MTAccentDisplay class]
+                                                                 in:[self displayFor:@"\\vec{f}"]];
+    XCTAssertNotNil(a);
+    // True painted ink-right of the accent glyph in the accent display's basis.
+    // Use the raw bbox max-x (inkMaxX), not accent.inkWidth, since the accent glyph's
+    // advance is ~0 and would otherwise clamp away the real overhang.
+    CGFloat accentInkRight  = (a.accent.position.x   - a.position.x) + a.accent.inkMaxX;
+    CGFloat accenteeInkRight = (a.accentee.position.x - a.position.x) + a.accentee.inkWidth;
+    // The accent glyph is the trailing source: it overhangs the accentee and the advance.
+    XCTAssertGreaterThan(accentInkRight, accenteeInkRight);
+    XCTAssertGreaterThan(accentInkRight, a.width);
+    // The getter must cover the accent glyph's real ink.
+    XCTAssertGreaterThanOrEqual(a.inkWidth, accentInkRight - 0.01);
+}
+
 - (void)testLargeOpLimitsInk {
     [self assertComposite:[MTLargeOpLimitsDisplay class] bare:@"\\sum^{VVV}" shifted:@"a\\sum^{VVV}"];
 }
@@ -232,6 +251,11 @@
 
 - (void)testPostInitWidthMutationGuard {
     MTMathListDisplay* d = [self displayFor:@"\\left( a+b \\right)"];
+    XCTAssertGreaterThanOrEqual(d.inkWidth, d.width - 0.01);
+    // Actually mutate width post-init: because inkWidth is a getter (not a value
+    // frozen at construction), the invariant must still hold after width grows
+    // past the original inkMaxX. A frozen implementation would fail here.
+    d.width = d.width * 2;
     XCTAssertGreaterThanOrEqual(d.inkWidth, d.width - 0.01);
     // The mutation absorbs into inkWidth via the getter, not a stale frozen value:
     // walk every sub-display and assert the invariant holds everywhere.

--- a/iosMathTests/MTInkWidthTest.m
+++ b/iosMathTests/MTInkWidthTest.m
@@ -96,6 +96,27 @@
     XCTAssertGreaterThanOrEqual(h.inkWidth, h.width - 0.01);
 }
 
+// Top-level rollup folds trailing-leaf ink AND trailing-script ink, while the
+// advance width and script positions stay exactly as before (layout invariance).
+- (void)testRollupAndLayoutInvariance {
+    // Trailing overhang leaf rolls up to the top.
+    MTMathListDisplay* dP = [self displayFor:@"P"];
+    XCTAssertGreaterThanOrEqual(dP.inkWidth, 15.08 - 0.01);
+
+    // Control with no overhang: inkWidth stays the advance.
+    MTMathListDisplay* dx = [self displayFor:@"x"];
+    XCTAssertEqualWithAccuracy(dx.inkWidth, 11.44, 0.01);
+
+    // Scripts append to the top-level displays, so they roll up too.
+    MTMathListDisplay* dxsq = [self displayFor:@"x^2"];
+    XCTAssertGreaterThanOrEqual(dxsq.inkWidth, dxsq.width - 0.01);
+    // Layout invariance: advance width and superscript position unchanged.
+    XCTAssertEqualWithAccuracy(dxsq.width, 18.44, 0.01);
+    MTMathListDisplay* script = (MTMathListDisplay*)dxsq.subDisplays.lastObject;
+    XCTAssertEqualWithAccuracy(script.position.x, 11.44, 0.01);
+    XCTAssertEqualWithAccuracy(script.position.y, 7.26, 0.01);
+}
+
 // Depth-first: the first display of the given class, or nil.
 - (MTDisplay*)findDisplayOfClass:(Class)cls in:(MTDisplay*)d {
     if ([d isKindOfClass:cls]) return d;

--- a/iosMathTests/MTInkWidthTest.m
+++ b/iosMathTests/MTInkWidthTest.m
@@ -133,6 +133,10 @@
     [self assertComposite:[MTAccentDisplay class] bare:@"\\hat{V}" shifted:@"a\\hat{V}"];
 }
 
+- (void)testLargeOpLimitsInk {
+    [self assertComposite:[MTLargeOpLimitsDisplay class] bare:@"\\sum^{VVV}" shifted:@"a\\sum^{VVV}"];
+}
+
 // Depth-first: the first display of the given class, or nil.
 - (MTDisplay*)findDisplayOfClass:(Class)cls in:(MTDisplay*)d {
     if ([d isKindOfClass:cls]) return d;


### PR DESCRIPTION
## PR 1 of 2 — Ink extent through the display tree

Part 1 of the ink-aware width + device-pixel size rounding work (issues #213, #98, #57). This PR adds an internal **ink extent** to the display tree; the label-facing sizing/rounding changes land in **PR 2** (which targets this branch).

**Plan:** `docs/plans/2026-07-14-ink-aware-width.md`
**LLD:** `docs/lld/2026-07-06-ink-aware-width.md`

### Goal
Every `MTDisplay` reports an ink extent (`inkWidth`) that covers trailing glyph-path ink for any leaf or composite, while `width`, pen advance, and script positions stay byte-for-byte unchanged. No label/reporting behavior changes in this PR — it is validated entirely at the display-tree level.

### Approach
Keep `width` as the pen advance (layout untouched). Add a stored `inkMaxX` + read-time `inkWidth` getter (`MAX(width, inkMaxX)`) on `MTDisplay` — the horizontal twin of the existing ink-based `ascent`/`descent`. Measure it on leaves, roll it up in `recomputeDimensions`, and compose it recursively in every composite display's `inkWidth` getter. No `MTTypesetter` changes.

### Commits (one per plan item)
1. `[item 1]` Add MTDisplay inkMaxX/inkWidth ink-extent surface
2. `[item 2]` Measure MTCTLineDisplay ink max-x
3. `[item 3]` Measure MTTextDisplay ink max-x
4. `[item 4]` Measure MTGlyphDisplay ink max-x from glyph bbox
5. `[item 5]` Measure MTGlyphConstructionDisplay ink max-x
6. `[item 6]` Measure MTHorizontalGlyphAssemblyDisplay ink max-x
7. `[item 7]` Roll trailing ink up through recomputeDimensions
8. `[item 8]` Compose fraction inkWidth over numerator/denominator
9. `[item 9]` Compose radical inkWidth over radicand
10. `[item 10]` Compose over/underline inkWidth over inner
11. `[item 11]` Compose accent inkWidth over accentee
12. `[item 12]` Compose large-op-limits inkWidth over nucleus/limits
13. `[item 13]` Compose stack inkWidth over base/over/under
14. `[item 14]` Compose inner inkWidth over delimiters/inner
15. `[item 15]` Guard inkWidth >= width through post-init width mutation

### Testing
New `iosMathTests/MTInkWidthTest.m` (15 tests): leaf-ink measurement, top-level rollup, per-composite guarantee + coordinate-basis-invariance, layout-invariance guard, and a post-init width-mutation guard. Existing `MTTypesetterTest` (132 tests) stays green, confirming advance/pen/script layout is unchanged. Full suite: 431/431 passing.

Two test **inputs** (not asserted mechanisms) were adjusted to actually reach the class under test in Latin Modern Math @ 20pt: item 5 deepened the nested fractions to trigger the multi-part `MTGlyphConstructionDisplay`; item 13 used `\overrightarrow{VV}` because the arrow variant width saturated a single `V`'s overhang. Both keep the guarantee and basis-invariance assertions intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added accurate ink-width measurement for rendered mathematical content, accounting for glyph overhangs beyond advance width.
  * Improved ink-width propagation across glyph-based and composite constructs (including text, fractions, radicals, accents, large-operator limits, stacks, and inner/left-right layouts) while preserving existing positioning behavior.
  * Ensured reported bounds remain consistent even when layout widths change after initialization.
* **Tests**
  * Added `MTInkWidthTest` with deterministic LaTeX-based assertions covering leaf and composite ink-width rollup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->