### PR TITLE
Label ink-aware sizing + device-pixel rounding

### DIFF
--- a/iosMath.xcodeproj/project.pbxproj
+++ b/iosMath.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		498730A417D547450041B02B /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 49965F2617CBBA2700A555C5 /* InfoPlist.strings */; };
 		498730A717D548190041B02B /* MTMathListBuilderTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 49B83EEF17CE71AC0014B739 /* MTMathListBuilderTest.m */; };
 		C01DEC0DE20260612000001 /* MTColorDecoderTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C01DEC0DE20260612000002 /* MTColorDecoderTest.m */; };
+		C01DEC0DE20260722000101 /* MTInkClippingRenderTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C01DEC0DE20260722000102 /* MTInkClippingRenderTest.m */; };
+		C01DEC0DE20260722000103 /* MTMathUILabelSizingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C01DEC0DE20260722000104 /* MTMathUILabelSizingTest.m */; };
 		498730A817D548190041B02B /* MTMathListTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 49B83EF517CF046A0014B739 /* MTMathListTest.m */; };
 		498730A917D548CA0041B02B /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49965EFF17CBBA2700A555C5 /* UIKit.framework */; };
 		498730AA17D548D40041B02B /* CoreText.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49B83EF217CE74620014B739 /* CoreText.framework */; };
@@ -104,6 +106,8 @@
 		49A27B0218EBF5B30030B7EF /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
 		49B83EEF17CE71AC0014B739 /* MTMathListBuilderTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTMathListBuilderTest.m; sourceTree = "<group>"; };
 		C01DEC0DE20260612000002 /* MTColorDecoderTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTColorDecoderTest.m; sourceTree = "<group>"; };
+		C01DEC0DE20260722000102 /* MTInkClippingRenderTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTInkClippingRenderTest.m; sourceTree = "<group>"; };
+		C01DEC0DE20260722000104 /* MTMathUILabelSizingTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTMathUILabelSizingTest.m; sourceTree = "<group>"; };
 		49B83EF217CE74620014B739 /* CoreText.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreText.framework; path = System/Library/Frameworks/CoreText.framework; sourceTree = SDKROOT; };
 		49B83EF517CF046A0014B739 /* MTMathListTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTMathListTest.m; sourceTree = "<group>"; };
 		49B83EF817CF2AE90014B739 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = example/AppDelegate.h; sourceTree = "<group>"; };
@@ -250,6 +254,8 @@
 			children = (
 				49B83EEF17CE71AC0014B739 /* MTMathListBuilderTest.m */,
 				C01DEC0DE20260612000002 /* MTColorDecoderTest.m */,
+				C01DEC0DE20260722000102 /* MTInkClippingRenderTest.m */,
+				C01DEC0DE20260722000104 /* MTMathUILabelSizingTest.m */,
 				49B83EF517CF046A0014B739 /* MTMathListTest.m */,
 				490465BE1D23DA8400F82033 /* MTTypesetterTest.m */,
 				49A1B2C31D23DA8400F82033 /* MTInkWidthTest.m */,
@@ -527,6 +533,8 @@
 			files = (
 				498730A717D548190041B02B /* MTMathListBuilderTest.m in Sources */,
 				C01DEC0DE20260612000001 /* MTColorDecoderTest.m in Sources */,
+				C01DEC0DE20260722000101 /* MTInkClippingRenderTest.m in Sources */,
+				C01DEC0DE20260722000103 /* MTMathUILabelSizingTest.m in Sources */,
 				498730A817D548190041B02B /* MTMathListTest.m in Sources */,
 				490465BF1D23DA8400F82033 /* MTTypesetterTest.m in Sources */,
 				49A1B2C41D23DA8400F82033 /* MTInkWidthTest.m in Sources */,

--- a/iosMath/render/MTMathUILabel.m
+++ b/iosMath/render/MTMathUILabel.m
@@ -214,10 +214,10 @@ static CGFloat ceilToPixel(CGFloat value, CGFloat scale) {
                 textX = self.contentInsets.left;
                 break;
             case kMTTextAlignmentCenter:
-                textX = (self.bounds.size.width - self.contentInsets.left - self.contentInsets.right - _displayList.width) / 2 + self.contentInsets.left;
+                textX = (self.bounds.size.width - self.contentInsets.left - self.contentInsets.right - _displayList.inkWidth) / 2 + self.contentInsets.left;
                 break;
             case kMTTextAlignmentRight:
-                textX = (self.bounds.size.width - _displayList.width - self.contentInsets.right);
+                textX = (self.bounds.size.width - _displayList.inkWidth - self.contentInsets.right);
                 break;
         }
         

--- a/iosMath/render/MTMathUILabel.m
+++ b/iosMath/render/MTMathUILabel.m
@@ -10,10 +10,18 @@
 //
 
 #import "MTMathUILabel.h"
+#import "MTMathUILabelInternal.h"
 #import "MTMathListDisplay.h"
+#import "MTFont+Internal.h"
+#import "MTMathListDisplayInternal.h"
 #import "MTFontManager.h"
 #import "MTMathListBuilder.h"
 #import "MTTypesetter.h"
+
+static CGFloat ceilToPixel(CGFloat value, CGFloat scale) {
+    if (scale <= 0) { scale = 1; }
+    return ceil(value * scale) / scale;
+}
 
 @implementation MTMathUILabel {
     MTLabel* _errorLabel;
@@ -158,6 +166,22 @@
     }
 }
 
+- (CGFloat)screenScale
+{
+#if TARGET_OS_IPHONE
+    CGFloat scale = self.contentScaleFactor;
+    return scale > 0 ? scale : 1;
+#else
+    if (self.window && self.window.backingScaleFactor > 0) {
+        return self.window.backingScaleFactor;
+    }
+    if (self.layer && self.layer.contentsScale > 0) {
+        return self.layer.contentsScale;
+    }
+    return 1;
+#endif
+}
+
 // Only override drawRect: if you perform custom drawing.
 // An empty implementation adversely affects performance during animation.
 - (void)drawRect:(MTRect)rect
@@ -227,9 +251,12 @@
     if (_mathList) {
         displayList = [MTTypesetter createLineForMathList:_mathList font:_font style:self.currentStyle];
     }
-    
-    size.width = displayList.width + self.contentInsets.left + self.contentInsets.right;
-    size.height = displayList.ascent + displayList.descent + self.contentInsets.top + self.contentInsets.bottom;
+
+    CGFloat scale = [self screenScale];
+    CGFloat rawWidth  = displayList.inkWidth + self.contentInsets.left + self.contentInsets.right;
+    CGFloat rawHeight = displayList.ascent + displayList.descent + self.contentInsets.top + self.contentInsets.bottom;
+    size.width  = ceilToPixel(rawWidth,  scale);
+    size.height = ceilToPixel(rawHeight, scale);
     return size;
 }
 

--- a/iosMath/render/MTMathUILabel.m
+++ b/iosMath/render/MTMathUILabel.m
@@ -265,4 +265,26 @@ static CGFloat ceilToPixel(CGFloat value, CGFloat scale) {
     return [self sizeThatFits:CGSizeZero];
 }
 
+#if TARGET_OS_IPHONE
+- (void)didMoveToWindow
+{
+    [super didMoveToWindow];
+    // Backing scale may have changed; re-query so the pixel-rounded size is right.
+    [self invalidateIntrinsicContentSize];
+}
+#else
+- (void)viewDidMoveToWindow
+{
+    [super viewDidMoveToWindow];
+    [self invalidateIntrinsicContentSize];
+}
+
+- (void)viewDidChangeBackingProperties
+{
+    [super viewDidChangeBackingProperties];
+    // window.backingScaleFactor is now known; the earlier fallback answer is stale.
+    [self invalidateIntrinsicContentSize];
+}
+#endif
+
 @end

--- a/iosMath/render/internal/MTMathUILabelInternal.h
+++ b/iosMath/render/internal/MTMathUILabelInternal.h
@@ -1,0 +1,30 @@
+//  MTMathUILabelInternal.h
+//  Internal test/compose surface for MTMathUILabel. Not part of the public API.
+#import "MTMathUILabel.h"
+#import "MTMathListDisplay.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+// NOTE: `displayList` is already declared `readonly` on the public
+// `MTMathUILabel` interface (MTMathUILabel.h); redeclaring it here would be
+// an illegal class-extension redeclaration (Clang requires `readwrite` for a
+// class-extension override of a `readonly` property). This header exists to
+// expose `screenScale`, the other internal test/compose surface item 16/17
+// need.
+@interface MTMathUILabel ()
+
+// Device-pixel scale used for rounding the reported size:
+//  iOS  : contentScaleFactor
+//  macOS: window.backingScaleFactor → layer.contentsScale → 1
+- (CGFloat)screenScale;
+
+// `sizeThatFits:` is implemented in MTMathUILabel.m and is public UIView API
+// on iOS, but NSView has no such method on macOS, so it is otherwise
+// invisible to callers outside the implementation file on that platform.
+// Redeclared here (harmless on iOS, load-bearing on macOS) so tests can call
+// it cross-platform without changing the public API surface.
+- (CGSize)sizeThatFits:(CGSize)size;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/iosMath/render/internal/MTMathUILabelInternal.h
+++ b/iosMath/render/internal/MTMathUILabelInternal.h
@@ -25,6 +25,12 @@ NS_ASSUME_NONNULL_BEGIN
 // it cross-platform without changing the public API surface.
 - (CGSize)sizeThatFits:(CGSize)size;
 
+// Same story as sizeThatFits: above — public UIView API on iOS, but
+// implemented (not declared) on MTMathUILabel for macOS, where NSView uses
+// layout/layoutSubtreeIfNeeded instead. Redeclared here so tests can drive
+// layout directly and cross-platform.
+- (void)layoutSubviews;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/iosMathTests/MTInkClippingRenderTest.m
+++ b/iosMathTests/MTInkClippingRenderTest.m
@@ -18,16 +18,24 @@
 
 @implementation MTInkClippingRenderTest
 
-// Render the laid-out label's display tree into a white RGBA bitmap sized to the
-// reported frame. Returns a malloc'd coverage buffer (0=white .. 255=full ink coverage
-// on any channel below white). DeviceGray was tried first, but the display tree sets
-// its foreground color via a DeviceRGB CGColor (MTColor/NSColor blackColor.CGColor);
-// drawing that into a DeviceGray bitmap context mismatches color spaces and produces
-// garbage coverage, so the harness uses DeviceRGB to match what the tree actually paints.
-- (uint8_t*)renderLabel:(MTMathUILabel*)label width:(size_t*)outW height:(size_t*)outH {
+// Render the laid-out label's display tree into a white RGBA bitmap. The bitmap is
+// `rightPad` pixels WIDER than the reported frame so that any trailing ink which
+// escapes the frame's right edge is captured in the padding instead of being clipped
+// away by the bitmap bounds — that is what lets the tests distinguish "contained"
+// from "clipped". Returns a malloc'd coverage buffer (0=white .. 255=full ink coverage
+// on any channel below white), the frame width (column index of the frame's right
+// edge) in *outFrameW, and the full bitmap width in *outW.
+//
+// DeviceGray was tried first, but the display tree sets its foreground color via a
+// DeviceRGB CGColor (MTColor/NSColor blackColor.CGColor); drawing that into a
+// DeviceGray bitmap context mismatches color spaces and produces garbage coverage, so
+// the harness uses DeviceRGB to match what the tree actually paints.
+- (uint8_t*)renderLabel:(MTMathUILabel*)label rightPad:(size_t)rightPad
+             frameWidth:(size_t*)outFrameW width:(size_t*)outW height:(size_t*)outH {
     CGSize s = label.bounds.size;
-    size_t W = (size_t)ceil(s.width), H = (size_t)ceil(s.height);
-    if (W == 0 || H == 0) { *outW = W; *outH = H; return NULL; }
+    size_t FW = (size_t)ceil(s.width), H = (size_t)ceil(s.height);
+    if (FW == 0 || H == 0) { *outFrameW = FW; *outW = FW; *outH = H; return NULL; }
+    size_t W = FW + rightPad;
     size_t bytesPerRow = W * 4;
     uint8_t* buf = calloc(bytesPerRow * H, 1);
     CGColorSpaceRef cs = CGColorSpaceCreateDeviceRGB();
@@ -41,7 +49,7 @@
     CGContextScaleCTM(ctx, 1, -1);
     [label.displayList draw:ctx];
     CGContextRelease(ctx);
-    *outW = W; *outH = H;
+    *outFrameW = FW; *outW = W; *outH = H;
     return buf;
 }
 
@@ -58,6 +66,13 @@ static int inkInColumn(uint8_t* buf, size_t W, size_t H, size_t col) {
     return n;
 }
 
+// Total ink in columns [fromCol, W) — used to assert nothing escapes past a boundary.
+static int inkAtOrAfterColumn(uint8_t* buf, size_t W, size_t H, size_t fromCol) {
+    int n = 0;
+    for (size_t col = fromCol; col < W; col++) n += inkInColumn(buf, W, H, col);
+    return n;
+}
+
 - (MTMathUILabel*)laidOutLabel:(NSString*)latex alignment:(MTTextAlignment)align {
     return [self laidOutLabel:latex alignment:align label:[[MTMathUILabel alloc] init]];
 }
@@ -71,15 +86,31 @@ static int inkInColumn(uint8_t* buf, size_t W, size_t H, size_t col) {
     return label;
 }
 
-// Cluster A: trailing overhang glyph must not clip the right border, any alignment.
+// Cluster A: trailing overhang glyphs must stay INSIDE the reported frame — no ink
+// may escape past the frame's right edge — at any alignment. This is the exact
+// pre-fix bug: with an advance-based width, a glyph whose ink is wider than its
+// advance (e.g. V: advance 11.66 vs ink 15.38) spills past the frame.
+//
+// The label is rendered into a right-padded bitmap and we assert the beyond-frame
+// region is empty. Asserting containment this way is robust to the antialiasing
+// fringe that a flush-right ink edge (right alignment, zero right inset) legitimately
+// paints into the last IN-frame column — that fringe is contained, not clipped, so it
+// must not fail the test. (An earlier "zero ink in the last frame column" form failed
+// on rasterizers where screenScale resolves to 1 for an unparented label, because the
+// flush edge then lands exactly on a whole-pixel boundary.) screenScale is forced to 1
+// so the frame edge lands on a whole bitmap column deterministically across environments.
 - (void)testNoRightEdgeClip {
+    const size_t kRightPad = 8;
     for (NSString* latex in @[@"P", @"V", @"f"]) {
         for (NSNumber* a in @[@(kMTTextAlignmentLeft), @(kMTTextAlignmentCenter), @(kMTTextAlignmentRight)]) {
-            MTMathUILabel* label = [self laidOutLabel:latex alignment:(MTTextAlignment)a.integerValue];
-            size_t W, H; uint8_t* buf = [self renderLabel:label width:&W height:&H];
-            XCTAssertTrue(buf != NULL);
-            XCTAssertEqual(inkInColumn(buf, W, H, W - 1), 0,
-                @"%@ align %@ clips right border", latex, a);
+            MTScaledInkLabel* scaled = [[MTScaledInkLabel alloc] init];
+            scaled.forcedScale = 1;
+            MTMathUILabel* label = [self laidOutLabel:latex alignment:(MTTextAlignment)a.integerValue label:scaled];
+            size_t FW, W, H; uint8_t* buf = [self renderLabel:label rightPad:kRightPad frameWidth:&FW width:&W height:&H];
+            XCTAssertTrue(buf != NULL, @"%@ align %@ did not render into a bitmap", latex, a);
+            if (!buf) continue;
+            XCTAssertEqual(inkAtOrAfterColumn(buf, W, H, FW), 0,
+                @"%@ align %@ ink escapes past the frame right edge", latex, a);
             free(buf);
         }
     }
@@ -111,10 +142,10 @@ static int inkInColumn(uint8_t* buf, size_t W, size_t H, size_t col) {
             CGFloat hPixels = size.height * scale;
             XCTAssertEqualWithAccuracy(wPixels, round(wPixels), 1e-6, @"%@ @%.0fx width not pixel-aligned", latex, scale);
             XCTAssertEqualWithAccuracy(hPixels, round(hPixels), 1e-6, @"%@ @%.0fx height not pixel-aligned", latex, scale);
-            size_t W, H; uint8_t* buf = [self renderLabel:label width:&W height:&H];
+            size_t FW, W, H; uint8_t* buf = [self renderLabel:label rightPad:8 frameWidth:&FW width:&W height:&H];
             XCTAssertTrue(buf != NULL, @"%@ did not render into a bitmap", latex);
             if (!buf) continue;
-            XCTAssertEqual(inkInColumn(buf, W, H, W - 1), 0, @"%@ @%.0fx right edge clipped", latex, scale);
+            XCTAssertEqual(inkAtOrAfterColumn(buf, W, H, FW), 0, @"%@ @%.0fx ink escapes past the frame right edge", latex, scale);
             free(buf);
         }
     }

--- a/iosMathTests/MTInkClippingRenderTest.m
+++ b/iosMathTests/MTInkClippingRenderTest.m
@@ -1,0 +1,106 @@
+#import <XCTest/XCTest.h>
+#import <CoreGraphics/CoreGraphics.h>
+#import "MTMathUILabel.h"
+#import "MTMathUILabelInternal.h"
+#import "MTMathListDisplay.h"
+
+@interface MTInkClippingRenderTest : XCTestCase
+@end
+
+@implementation MTInkClippingRenderTest
+
+// Render the laid-out label's display tree into a white RGBA bitmap sized to the
+// reported frame. Returns a malloc'd coverage buffer (0=white .. 255=full ink coverage
+// on any channel below white). DeviceGray was tried first, but the display tree sets
+// its foreground color via a DeviceRGB CGColor (MTColor/NSColor blackColor.CGColor);
+// drawing that into a DeviceGray bitmap context mismatches color spaces and produces
+// garbage coverage, so the harness uses DeviceRGB to match what the tree actually paints.
+- (uint8_t*)renderLabel:(MTMathUILabel*)label width:(size_t*)outW height:(size_t*)outH {
+    CGSize s = label.bounds.size;
+    size_t W = (size_t)ceil(s.width), H = (size_t)ceil(s.height);
+    if (W == 0 || H == 0) { *outW = W; *outH = H; return NULL; }
+    size_t bytesPerRow = W * 4;
+    uint8_t* buf = calloc(bytesPerRow * H, 1);
+    CGColorSpaceRef cs = CGColorSpaceCreateDeviceRGB();
+    CGContextRef ctx = CGBitmapContextCreate(buf, W, H, 8, bytesPerRow, cs, (CGBitmapInfo)kCGImageAlphaPremultipliedLast);
+    CGColorSpaceRelease(cs);
+    CGContextSetRGBFillColor(ctx, 1.0, 1.0, 1.0, 1.0);   // white background
+    CGContextFillRect(ctx, CGRectMake(0, 0, W, H));
+    // Flip into the label's top-left frame coordinate space, then draw the tree
+    // at its laid-out position (draw: paints black glyphs).
+    CGContextTranslateCTM(ctx, 0, H);
+    CGContextScaleCTM(ctx, 1, -1);
+    [label.displayList draw:ctx];
+    CGContextRelease(ctx);
+    *outW = W; *outH = H;
+    return buf;
+}
+
+// A pixel counts as "ink" if any RGB channel is meaningfully darker than white.
+static BOOL isInk(uint8_t* buf, size_t bytesPerRow, size_t x, size_t y) {
+    size_t idx = y * bytesPerRow + x * 4;
+    return buf[idx] < 155 || buf[idx + 1] < 155 || buf[idx + 2] < 155;
+}
+
+static int inkInColumn(uint8_t* buf, size_t W, size_t H, size_t col) {
+    size_t bytesPerRow = W * 4;
+    int n = 0;
+    for (size_t y = 0; y < H; y++) if (isInk(buf, bytesPerRow, col, y)) n++;
+    return n;
+}
+
+- (MTMathUILabel*)laidOutLabel:(NSString*)latex alignment:(MTTextAlignment)align {
+    MTMathUILabel* label = [[MTMathUILabel alloc] init];
+    label.latex = latex;
+    label.textAlignment = align;
+    CGSize size = [label sizeThatFits:CGSizeZero];
+    label.frame = CGRectMake(0, 0, size.width, size.height);
+    [label layoutSubviews];
+    return label;
+}
+
+// Cluster A: trailing overhang glyph must not clip the right border, any alignment.
+- (void)testNoRightEdgeClip {
+    for (NSString* latex in @[@"P", @"V", @"f"]) {
+        for (NSNumber* a in @[@(kMTTextAlignmentLeft), @(kMTTextAlignmentCenter), @(kMTTextAlignmentRight)]) {
+            MTMathUILabel* label = [self laidOutLabel:latex alignment:(MTTextAlignment)a.integerValue];
+            size_t W, H; uint8_t* buf = [self renderLabel:label width:&W height:&H];
+            XCTAssertTrue(buf != NULL);
+            XCTAssertEqual(inkInColumn(buf, W, H, W - 1), 0,
+                @"%@ align %@ clips right border", latex, a);
+            free(buf);
+        }
+    }
+}
+
+// Cluster B: device-pixel rounding + trailing-ink containment for tall constructs.
+//
+// The reported size is ceil'd to the device-pixel grid (ceilToPixel in
+// MTMathUILabel.m), so the frame edges land on whole device pixels and there is no
+// fractional-SIZE resample. We assert that grid property directly, plus that trailing
+// ink stays inside the right border.
+//
+// We deliberately do NOT assert "zero ink in the top/right border pixel row". Tall,
+// ink-tight constructs (\int_0^1, \frac{1}{2}) legitimately place ink flush against
+// their ink-tight vertical boundary, so the boundary pixel row contains genuine ink
+// even though nothing is clipped. The true hairline artifact this feature is concerned
+// with is a fractional-ORIGIN compositing resample, addressed by snapping the draw
+// origin; that is deferred (LLD §2.8) and is not exercised by this integer-origin
+// render harness.
+- (void)testTallConstructsPixelAlignedAndContained {
+    for (NSString* latex in @[@"\\quad", @"\\frac{1}{2}", @"\\int_0^1", @"P"]) {
+        MTMathUILabel* label = [self laidOutLabel:latex alignment:kMTTextAlignmentLeft];
+        CGSize size = label.bounds.size;
+        CGFloat scale = [label screenScale];
+        CGFloat wPixels = size.width * scale;
+        CGFloat hPixels = size.height * scale;
+        XCTAssertEqualWithAccuracy(wPixels, round(wPixels), 1e-6, @"%@ width not pixel-aligned", latex);
+        XCTAssertEqualWithAccuracy(hPixels, round(hPixels), 1e-6, @"%@ height not pixel-aligned", latex);
+        size_t W, H; uint8_t* buf = [self renderLabel:label width:&W height:&H];
+        if (!buf) continue;
+        XCTAssertEqual(inkInColumn(buf, W, H, W - 1), 0, @"%@ right edge clipped", latex);
+        free(buf);
+    }
+}
+
+@end

--- a/iosMathTests/MTInkClippingRenderTest.m
+++ b/iosMathTests/MTInkClippingRenderTest.m
@@ -4,6 +4,15 @@
 #import "MTMathUILabelInternal.h"
 #import "MTMathListDisplay.h"
 
+// Forces a known device-pixel scale so the pixel-grid assertions exercise 2x/3x
+// rounding rather than the tautological scale==1 case.
+@interface MTScaledInkLabel : MTMathUILabel
+@property (nonatomic) CGFloat forcedScale;
+@end
+@implementation MTScaledInkLabel
+- (CGFloat)screenScale { return self.forcedScale; }
+@end
+
 @interface MTInkClippingRenderTest : XCTestCase
 @end
 
@@ -50,7 +59,10 @@ static int inkInColumn(uint8_t* buf, size_t W, size_t H, size_t col) {
 }
 
 - (MTMathUILabel*)laidOutLabel:(NSString*)latex alignment:(MTTextAlignment)align {
-    MTMathUILabel* label = [[MTMathUILabel alloc] init];
+    return [self laidOutLabel:latex alignment:align label:[[MTMathUILabel alloc] init]];
+}
+
+- (MTMathUILabel*)laidOutLabel:(NSString*)latex alignment:(MTTextAlignment)align label:(MTMathUILabel*)label {
     label.latex = latex;
     label.textAlignment = align;
     CGSize size = [label sizeThatFits:CGSizeZero];
@@ -88,18 +100,23 @@ static int inkInColumn(uint8_t* buf, size_t W, size_t H, size_t col) {
 // origin; that is deferred (LLD §2.8) and is not exercised by this integer-origin
 // render harness.
 - (void)testTallConstructsPixelAlignedAndContained {
-    for (NSString* latex in @[@"\\quad", @"\\frac{1}{2}", @"\\int_0^1", @"P"]) {
-        MTMathUILabel* label = [self laidOutLabel:latex alignment:kMTTextAlignmentLeft];
-        CGSize size = label.bounds.size;
-        CGFloat scale = [label screenScale];
-        CGFloat wPixels = size.width * scale;
-        CGFloat hPixels = size.height * scale;
-        XCTAssertEqualWithAccuracy(wPixels, round(wPixels), 1e-6, @"%@ width not pixel-aligned", latex);
-        XCTAssertEqualWithAccuracy(hPixels, round(hPixels), 1e-6, @"%@ height not pixel-aligned", latex);
-        size_t W, H; uint8_t* buf = [self renderLabel:label width:&W height:&H];
-        if (!buf) continue;
-        XCTAssertEqual(inkInColumn(buf, W, H, W - 1), 0, @"%@ right edge clipped", latex);
-        free(buf);
+    for (NSNumber* scaleN in @[@2.0, @3.0]) {
+        CGFloat scale = scaleN.doubleValue;
+        for (NSString* latex in @[@"\\sqrt{2}", @"\\frac{1}{2}", @"\\int_0^1", @"P"]) {
+            MTScaledInkLabel* scaled = [[MTScaledInkLabel alloc] init];
+            scaled.forcedScale = scale;
+            MTMathUILabel* label = [self laidOutLabel:latex alignment:kMTTextAlignmentLeft label:scaled];
+            CGSize size = label.bounds.size;
+            CGFloat wPixels = size.width * scale;
+            CGFloat hPixels = size.height * scale;
+            XCTAssertEqualWithAccuracy(wPixels, round(wPixels), 1e-6, @"%@ @%.0fx width not pixel-aligned", latex, scale);
+            XCTAssertEqualWithAccuracy(hPixels, round(hPixels), 1e-6, @"%@ @%.0fx height not pixel-aligned", latex, scale);
+            size_t W, H; uint8_t* buf = [self renderLabel:label width:&W height:&H];
+            XCTAssertTrue(buf != NULL, @"%@ did not render into a bitmap", latex);
+            if (!buf) continue;
+            XCTAssertEqual(inkInColumn(buf, W, H, W - 1), 0, @"%@ @%.0fx right edge clipped", latex, scale);
+            free(buf);
+        }
     }
 }
 

--- a/iosMathTests/MTMathUILabelSizingTest.m
+++ b/iosMathTests/MTMathUILabelSizingTest.m
@@ -53,4 +53,23 @@
     XCTAssertEqualWithAccuracy(size.height, ceil(tb * scale) / scale, 0.001);
 }
 
+- (void)testAlignmentUsesInkWidth {
+    NSString* latex = @"V";   // heavy right overhang (advance 11.66, ink 15.38)
+    for (NSNumber* alignN in @[@(kMTTextAlignmentLeft), @(kMTTextAlignmentCenter), @(kMTTextAlignmentRight)]) {
+        MTMathUILabel* label = [[MTMathUILabel alloc] init];
+        label.latex = latex;
+        label.textAlignment = (MTTextAlignment)alignN.integerValue;
+        CGSize size = [label sizeThatFits:CGSizeZero];
+        label.frame = CGRectMake(0, 0, size.width, size.height);
+        [label layoutSubviews];
+
+        MTMathListDisplay* d = label.displayList;
+        CGFloat inkRight = d.position.x + d.inkWidth;
+        CGFloat frameRight = size.width - label.contentInsets.right;
+        // Ink right edge must sit within the (inset) frame for every alignment.
+        XCTAssertLessThanOrEqual(inkRight, frameRight + 0.01,
+            @"alignment %@ clips ink: inkRight %.2f > frameRight %.2f", alignN, inkRight, frameRight);
+    }
+}
+
 @end

--- a/iosMathTests/MTMathUILabelSizingTest.m
+++ b/iosMathTests/MTMathUILabelSizingTest.m
@@ -15,6 +15,15 @@
 - (void)invalidateIntrinsicContentSize { self.invalidateCount++; [super invalidateIntrinsicContentSize]; }
 @end
 
+// Forces a known device-pixel scale so the grid-rounding assertions exercise
+// 2x/3x rounding rather than the tautological scale==1 case.
+@interface MTScaledLabel : MTMathUILabel
+@property (nonatomic) CGFloat forcedScale;
+@end
+@implementation MTScaledLabel
+- (CGFloat)screenScale { return self.forcedScale; }
+@end
+
 @interface MTMathUILabelSizingTest : XCTestCase
 @end
 
@@ -27,19 +36,25 @@
 }
 
 // Reported width covers the ink extent and lands on the device-pixel grid.
+// Run at 1x/2x/3x so the grid-rounding assertions are exercised where they can
+// actually fail, not just the tautological scale==1 case.
 - (void)testSizeThatFitsInkAndGrid {
-    for (NSString* latex in @[@"P", @"V", @"\\frac{1}{2}", @"\\int_0^1", @"x"]) {
-        MTMathUILabel* label = [self labelFor:latex];
-        CGFloat scale = [label screenScale];
-        MTMathListDisplay* d =
-            [MTTypesetter createLineForMathList:[MTMathListBuilder buildFromString:latex]
-                                           font:label.font style:label.labelMode == kMTMathUILabelModeDisplay ? kMTLineStyleDisplay : kMTLineStyleText];
-        CGSize size = [label sizeThatFits:CGSizeZero];
-        // (a) covers the ink (insets are >= 0, so >= inkWidth alone).
-        XCTAssertGreaterThanOrEqual(size.width, d.inkWidth - 0.001, @"%@", latex);
-        // (b) both axes are whole device pixels.
-        XCTAssertEqualWithAccuracy(size.width * scale,  round(size.width * scale),  0.001, @"%@", latex);
-        XCTAssertEqualWithAccuracy(size.height * scale, round(size.height * scale), 0.001, @"%@", latex);
+    for (NSNumber* scaleN in @[@1.0, @2.0, @3.0]) {
+        CGFloat scale = scaleN.doubleValue;
+        for (NSString* latex in @[@"P", @"V", @"\\frac{1}{2}", @"\\int_0^1", @"x"]) {
+            MTScaledLabel* label = [[MTScaledLabel alloc] init];
+            label.forcedScale = scale;
+            label.latex = latex;
+            MTMathListDisplay* d =
+                [MTTypesetter createLineForMathList:[MTMathListBuilder buildFromString:latex]
+                                               font:label.font style:label.labelMode == kMTMathUILabelModeDisplay ? kMTLineStyleDisplay : kMTLineStyleText];
+            CGSize size = [label sizeThatFits:CGSizeZero];
+            // (a) covers the ink (insets are >= 0, so >= inkWidth alone).
+            XCTAssertGreaterThanOrEqual(size.width, d.inkWidth - 0.001, @"%@ @%.0fx", latex, scale);
+            // (b) both axes are whole device pixels.
+            XCTAssertEqualWithAccuracy(size.width * scale,  round(size.width * scale),  0.001, @"%@ @%.0fx", latex, scale);
+            XCTAssertEqualWithAccuracy(size.height * scale, round(size.height * scale), 0.001, @"%@ @%.0fx", latex, scale);
+        }
     }
 }
 

--- a/iosMathTests/MTMathUILabelSizingTest.m
+++ b/iosMathTests/MTMathUILabelSizingTest.m
@@ -10,8 +10,10 @@
 
 @interface MTSpyLabel : MTMathUILabel
 @property (nonatomic) NSInteger invalidateCount;
+@property (nonatomic) CGFloat forcedScale;   // simulate a known backing scale
 @end
 @implementation MTSpyLabel
+- (CGFloat)screenScale { return self.forcedScale; }
 - (void)invalidateIntrinsicContentSize { self.invalidateCount++; [super invalidateIntrinsicContentSize]; }
 @end
 
@@ -94,9 +96,21 @@
     }
 }
 
+// An actual backing-scale change re-queries the intrinsic size end to end: the
+// platform lifecycle hook fires invalidateIntrinsicContentSize, and because
+// intrinsicContentSize is uncached (recomputed per query) the next read reflects the
+// new scale's device-pixel grid. The hook invalidates unconditionally — it does not
+// diff scales (see MTMathUILabel didMoveToWindow / viewDidChangeBackingProperties) —
+// so this drives the whole path: 1x size → scale becomes 3x → hook → 3x-grid re-query.
 - (void)testScaleLifecycleInvalidates {
     MTSpyLabel* label = [[MTSpyLabel alloc] init];
-    label.latex = @"P";
+    label.forcedScale = 1;
+    label.latex = @"V";   // ink overhang; its 1x and 3x rounded widths differ
+    CGSize sizeAt1x = label.intrinsicContentSize;
+    XCTAssertEqualWithAccuracy(sizeAt1x.width, round(sizeAt1x.width), 0.001, @"1x width off grid");
+
+    // Backing scale becomes 3x, then fire the platform lifecycle hook.
+    label.forcedScale = 3;
     label.invalidateCount = 0;
 #if TARGET_OS_IPHONE
     [label didMoveToWindow];
@@ -104,7 +118,12 @@
     [label viewDidChangeBackingProperties];
     [label viewDidMoveToWindow];
 #endif
-    XCTAssertGreaterThan(label.invalidateCount, 0);
+    XCTAssertGreaterThan(label.invalidateCount, 0, @"scale-change lifecycle hook must invalidate intrinsic size");
+
+    // Re-query now lands on the 3x grid and differs from the 1x answer.
+    CGSize sizeAt3x = label.intrinsicContentSize;
+    XCTAssertEqualWithAccuracy(sizeAt3x.width * 3, round(sizeAt3x.width * 3), 0.001, @"3x width off grid");
+    XCTAssertNotEqualWithAccuracy(sizeAt3x.width, sizeAt1x.width, 0.001, @"re-query did not adopt the new scale");
 }
 
 @end

--- a/iosMathTests/MTMathUILabelSizingTest.m
+++ b/iosMathTests/MTMathUILabelSizingTest.m
@@ -1,0 +1,56 @@
+#import <XCTest/XCTest.h>
+#import "MTMathUILabel.h"
+#import "MTMathUILabelInternal.h"
+#import "MTMathListDisplay.h"
+#import "MTFont+Internal.h"
+#import "MTMathListDisplayInternal.h"
+#import "MTTypesetter.h"
+#import "MTFontManager.h"
+#import "MTMathListBuilder.h"
+
+@interface MTMathUILabelSizingTest : XCTestCase
+@end
+
+@implementation MTMathUILabelSizingTest
+
+- (MTMathUILabel*)labelFor:(NSString*)latex {
+    MTMathUILabel* label = [[MTMathUILabel alloc] init];
+    label.latex = latex;
+    return label;
+}
+
+// Reported width covers the ink extent and lands on the device-pixel grid.
+- (void)testSizeThatFitsInkAndGrid {
+    for (NSString* latex in @[@"P", @"V", @"\\frac{1}{2}", @"\\int_0^1", @"x"]) {
+        MTMathUILabel* label = [self labelFor:latex];
+        CGFloat scale = [label screenScale];
+        MTMathListDisplay* d =
+            [MTTypesetter createLineForMathList:[MTMathListBuilder buildFromString:latex]
+                                           font:label.font style:label.labelMode == kMTMathUILabelModeDisplay ? kMTLineStyleDisplay : kMTLineStyleText];
+        CGSize size = [label sizeThatFits:CGSizeZero];
+        // (a) covers the ink (insets are >= 0, so >= inkWidth alone).
+        XCTAssertGreaterThanOrEqual(size.width, d.inkWidth - 0.001, @"%@", latex);
+        // (b) both axes are whole device pixels.
+        XCTAssertEqualWithAccuracy(size.width * scale,  round(size.width * scale),  0.001, @"%@", latex);
+        XCTAssertEqualWithAccuracy(size.height * scale, round(size.height * scale), 0.001, @"%@", latex);
+    }
+}
+
+- (void)testIntrinsicMatchesSizeThatFits {
+    MTMathUILabel* label = [self labelFor:@"\\frac{1}{2}"];
+    XCTAssertTrue(CGSizeEqualToSize(label.intrinsicContentSize, [label sizeThatFits:CGSizeZero]));
+}
+
+// Nil latex → insets only, still pixel-rounded.
+- (void)testNilLatexReportsRoundedInsets {
+    MTMathUILabel* label = [[MTMathUILabel alloc] init];
+    label.latex = nil;
+    CGFloat scale = [label screenScale];
+    CGSize size = [label sizeThatFits:CGSizeZero];
+    CGFloat lr = label.contentInsets.left + label.contentInsets.right;
+    CGFloat tb = label.contentInsets.top + label.contentInsets.bottom;
+    XCTAssertEqualWithAccuracy(size.width,  ceil(lr * scale) / scale, 0.001);
+    XCTAssertEqualWithAccuracy(size.height, ceil(tb * scale) / scale, 0.001);
+}
+
+@end

--- a/iosMathTests/MTMathUILabelSizingTest.m
+++ b/iosMathTests/MTMathUILabelSizingTest.m
@@ -8,6 +8,13 @@
 #import "MTFontManager.h"
 #import "MTMathListBuilder.h"
 
+@interface MTSpyLabel : MTMathUILabel
+@property (nonatomic) NSInteger invalidateCount;
+@end
+@implementation MTSpyLabel
+- (void)invalidateIntrinsicContentSize { self.invalidateCount++; [super invalidateIntrinsicContentSize]; }
+@end
+
 @interface MTMathUILabelSizingTest : XCTestCase
 @end
 
@@ -70,6 +77,19 @@
         XCTAssertLessThanOrEqual(inkRight, frameRight + 0.01,
             @"alignment %@ clips ink: inkRight %.2f > frameRight %.2f", alignN, inkRight, frameRight);
     }
+}
+
+- (void)testScaleLifecycleInvalidates {
+    MTSpyLabel* label = [[MTSpyLabel alloc] init];
+    label.latex = @"P";
+    label.invalidateCount = 0;
+#if TARGET_OS_IPHONE
+    [label didMoveToWindow];
+#else
+    [label viewDidChangeBackingProperties];
+    [label viewDidMoveToWindow];
+#endif
+    XCTAssertGreaterThan(label.invalidateCount, 0);
 }
 
 @end


### PR DESCRIPTION
## PR 2 of 2 — Label ink-aware sizing + device-pixel rounding

Part 2 of the ink-aware width + device-pixel size rounding work (issues #213, #98, #57). This PR routes `MTMathUILabel`'s reporting/positioning surface through the ink extent added in PR 1, rounds the reported size up to the device-pixel grid, and re-queries when the backing scale becomes known.

**Plan:** `docs/plans/2026-07-14-ink-aware-width.md`
**LLD:** `docs/lld/2026-07-06-ink-aware-width.md`

### Stack
- PR 1: #262 — Ink extent through the display tree (base of this PR)
- **PR 2: this PR** — Label ink-aware sizing + device-pixel rounding (base: `feature/ink-aware-width-pr1`)

### Goal
Route the label's reporting/positioning surface through `inkWidth`, round the reported size up to the device-pixel grid, and re-query when the backing scale becomes known.

### Commits (one per plan item)
16. `[item 16]` Route label sizing/alignment through inkWidth + ceil to the device-pixel grid
17. `[item 17]` Resolve device-pixel scale (contentScaleFactor / backingScaleFactor)
18. `[item 18]` Re-query intrinsic size on window/backing-scale change
19. `[item 19]` Assert ink-clip render guarantees the feature actually provides

### Testing
- New `iosMathTests/MTMathUILabelSizingTest.m` (5 tests): inkWidth routing, device-pixel grid rounding, alignment, and scale-change re-query.
- New `iosMathTests/MTInkClippingRenderTest.m` (2 tests): renders the laid-out display tree and asserts (a) trailing overhang glyphs never clip the right border at any alignment (Cluster A), and (b) tall constructs (`\frac{1}{2}`, `\int_0^1`, …) report a pixel-aligned size with trailing ink contained inside the right border (Cluster B).
- Full suite: 438/438 passing.

### Note on the Cluster B render assertion
The render test asserts the guarantee this feature actually provides — a **pixel-aligned reported size** (frame edges on whole device pixels, so no fractional-size resample) plus right-edge ink containment. It deliberately does **not** assert "zero ink in the top border pixel row": flush, ink-tight tall constructs legitimately place ink against their ink-tight vertical boundary, so that row contains genuine (un-clipped) ink. The true hairline artifact is a fractional-**origin** compositing resample, addressed by snapping the draw origin — deferred per LLD §2.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mathematical label sizing and alignment to reduce right-edge clipping.
  * Updated intrinsic and `sizeThatFits:` calculations to use pixel-rounded measurements for consistent device-pixel rendering.
  * Updated horizontal positioning to align using ink extents, and ensured intrinsic size is invalidated when moving between windows or when backing/display scale changes.

* **Tests**
  * Added unit tests that render labels to CPU bitmaps and verify ink containment and pixel-grid alignment across alignments and scale factors.
  * Added tests covering `sizeThatFits:`, `intrinsicContentSize`, nil-`latex` behavior, and intrinsic invalidation lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->