### PR TITLE
Never fuse atoms across a font-style change

### DIFF
--- a/iosMath/lib/MTMathList.m
+++ b/iosMath/lib/MTMathList.m
@@ -1707,8 +1707,10 @@ static NSString* fractionCommandForDelimiterPair(NSString* leftDelimiter, NSStri
                 break;
                 
             case kMTMathAtomNumber:
-                // combine numbers together
-                if (prevNode && prevNode.type == kMTMathAtomNumber && !prevNode.subScript && !prevNode.superScript) {
+                // combine numbers together, but never across a font-style change:
+                // fuse: keeps the first atom's fontStyle and would corrupt the other's.
+                if (prevNode && prevNode.type == kMTMathAtomNumber && !prevNode.subScript && !prevNode.superScript
+                    && prevNode.fontStyle == newNode.fontStyle) {
                     [prevNode fuse:newNode];
                     // skip the current node, we are done here.
                     continue;

--- a/iosMath/render/internal/MTTypesetter.m
+++ b/iosMath/render/internal/MTTypesetter.m
@@ -550,8 +550,11 @@ static void getBboxDetails(CGRect bbox, CGFloat* ascent, CGFloat* descent)
         
         if (atom.type == kMTMathAtomOrdinary) {
             // This is Rule 14 to merge ordinary characters.
-            // combine ordinary atoms together
+            // combine ordinary atoms together, but only within one font style --
+            // the \mathit face is stamped per single-style run (and TeX's own Rule 14
+            // fuses only within a family).
             if (prevNode && prevNode.type == kMTMathAtomOrdinary && !prevNode.subScript && !prevNode.superScript
+                && prevNode.fontStyle == atom.fontStyle
                 && ![prevNode isKindOfClass:[MTLargeDelimiter class]]
                 && ![atom isKindOfClass:[MTLargeDelimiter class]]) {
                 [prevNode fuse:atom];

--- a/iosMathTests/MTMathListTest.m
+++ b/iosMathTests/MTMathListTest.m
@@ -426,6 +426,48 @@ _XCTPrimitiveAssertNotEqual(test, expression1, @#expression1, expression2, @#exp
     XCTAssertEqualObjects(table.verticalLines, (@[ @1, @0, @0 ]));
 }
 
+- (void) testFinalizedDoesNotFuseDigitsAcrossFontStyles
+{
+    // Without the guard, fuse: keeps the first atom's style: 1\mathit{2}
+    // silently drops the italic, \mathit{1}2 spreads it onto a plain digit.
+    MTMathList* list = [MTMathListBuilder buildFromString:@"1\\mathit{2}"].finalized;
+    XCTAssertEqual(list.atoms.count, 2);
+    XCTAssertEqualObjects(list.atoms[0].nucleus, @"1");
+    XCTAssertEqual(list.atoms[0].fontStyle, kMTFontStyleDefault);
+    XCTAssertEqualObjects(list.atoms[1].nucleus, @"2");
+    XCTAssertEqual(list.atoms[1].fontStyle, kMTFontStyleItalic);
+
+    list = [MTMathListBuilder buildFromString:@"\\mathit{1}2"].finalized;
+    XCTAssertEqual(list.atoms.count, 2);
+    XCTAssertEqual(list.atoms[0].fontStyle, kMTFontStyleItalic);
+    XCTAssertEqual(list.atoms[1].fontStyle, kMTFontStyleDefault);
+
+    // Style boundaries split the run; the uniform-style middle still fuses.
+    list = [MTMathListBuilder buildFromString:@"1\\mathit{23}4"].finalized;
+    XCTAssertEqual(list.atoms.count, 3);
+    XCTAssertEqualObjects(list.atoms[0].nucleus, @"1");
+    XCTAssertEqualObjects(list.atoms[1].nucleus, @"23");
+    XCTAssertEqualObjects(list.atoms[2].nucleus, @"4");
+
+    // The same guard repairs \mathbf on mixed-style digit runs (LLD §2.6).
+    list = [MTMathListBuilder buildFromString:@"1\\mathbf{2}"].finalized;
+    XCTAssertEqual(list.atoms.count, 2);
+    XCTAssertEqual(list.atoms[0].fontStyle, kMTFontStyleDefault);
+    XCTAssertEqual(list.atoms[1].fontStyle, kMTFontStyleBold);
+}
+
+- (void) testFinalizedStillFusesUniformStyleDigits
+{
+    MTMathList* list = [MTMathListBuilder buildFromString:@"1234"].finalized;
+    XCTAssertEqual(list.atoms.count, 1);
+    XCTAssertEqualObjects(list.atoms[0].nucleus, @"1234");
+
+    list = [MTMathListBuilder buildFromString:@"\\mathit{12}"].finalized;
+    XCTAssertEqual(list.atoms.count, 1);
+    XCTAssertEqualObjects(list.atoms[0].nucleus, @"12");
+    XCTAssertEqual(list.atoms[0].fontStyle, kMTFontStyleItalic);
+}
+
 @end
 
 @interface MTMathAtomTest : XCTestCase

--- a/iosMathTests/MTTypesetterTest.m
+++ b/iosMathTests/MTTypesetterTest.m
@@ -17,6 +17,10 @@
 #import "MTMathAtomFactory.h"
 #import "MTMathListBuilder.h"
 
+@interface MTTypesetter (FusionTesting)
++ (NSArray<MTMathAtom*>*) preprocessMathList:(MTMathList*) ml;
+@end
+
 @interface MTTypesetterTest : XCTestCase
 
 @property (nonatomic) MTFont* font;
@@ -3605,6 +3609,56 @@
     }
     XCTAssertEqualWithAccuracy(topLine, contentTop + padding, 0.01);
     XCTAssertEqualWithAccuracy(botLine, contentBot - padding, 0.01);
+}
+
+- (void) testPreprocessDoesNotFuseAcrossFontStyles
+{
+    // f\mathit{x}: without the guard both fuse into one Default atom and the
+    // italic on x is lost (LLD §2.6).
+    NSArray<MTMathAtom*>* atoms = [MTTypesetter preprocessMathList:
+        [MTMathListBuilder buildFromString:@"f\\mathit{x}"].finalized];
+    XCTAssertEqual(atoms.count, 2);
+    XCTAssertEqual(atoms[0].fontStyle, kMTFontStyleDefault);
+    XCTAssertEqual(atoms[1].fontStyle, kMTFontStyleItalic);
+
+    atoms = [MTTypesetter preprocessMathList:
+        [MTMathListBuilder buildFromString:@"\\mathit{f}x"].finalized];
+    XCTAssertEqual(atoms.count, 2);
+    XCTAssertEqual(atoms[0].fontStyle, kMTFontStyleItalic);
+    XCTAssertEqual(atoms[1].fontStyle, kMTFontStyleDefault);
+
+    // The bold digit that site A now preserves reaches its bold code point.
+    atoms = [MTTypesetter preprocessMathList:
+        [MTMathListBuilder buildFromString:@"1\\mathbf{2}"].finalized];
+    XCTAssertEqual(atoms.count, 2);
+    XCTAssertEqualObjects(atoms[0].nucleus, @"1");
+    XCTAssertEqualObjects(atoms[1].nucleus, @"\U0001D7D0");
+}
+
+- (void) testPreprocessStillFusesUniformStyleAtoms
+{
+    // Same style still merges...
+    NSArray<MTMathAtom*>* atoms = [MTTypesetter preprocessMathList:
+        [MTMathListBuilder buildFromString:@"\\mathit{fg}"].finalized];
+    XCTAssertEqual(atoms.count, 1);
+
+    // ...including Variable+Number pairs, which meet only at site B because
+    // site A fuses same-type atoms only (LLD §3.3 B).
+    atoms = [MTTypesetter preprocessMathList:
+        [MTMathListBuilder buildFromString:@"\\mathit{a1}"].finalized];
+    XCTAssertEqual(atoms.count, 1);
+    XCTAssertEqual(atoms[0].type, kMTMathAtomOrdinary);
+    XCTAssertEqual(atoms[0].fontStyle, kMTFontStyleItalic);
+}
+
+- (void) testPreprocessUnstyledListUnchanged
+{
+    NSArray<MTMathAtom*>* atoms = [MTTypesetter preprocessMathList:
+        [MTMathListBuilder buildFromString:@"xyz+1"].finalized];
+    XCTAssertEqual(atoms.count, 3);
+    XCTAssertEqualObjects(atoms[0].nucleus, @"\U0001D465\U0001D466\U0001D467");
+    XCTAssertEqualObjects(atoms[1].nucleus, @"+");
+    XCTAssertEqualObjects(atoms[2].nucleus, @"1");
 }
 
 @end


### PR DESCRIPTION
Plan: `docs/plans/2026-08-04-mathit-text-italic-routing.md` (PR 1 of 3, items 1-2)
LLD: `docs/lld/2026-07-27-mathit-text-italic-routing.md`

## Goal

Both atom-merge sites decline to fuse atoms whose `fontStyle` differs, so a style set on part of a run survives to the typesetter.

`fuse:` keeps the *first* atom's properties, including its `fontStyle`, so an unguarded merge either drops a style or spreads it onto an unstyled atom. Neither site checked style, and they cover disjoint inputs: site A merges only `Number` atoms, site B merges Ordinary atoms after `preprocessMathList:` has rewritten variables and numbers. `1\mathit{2}` is fixed only by A, `f\mathit{x}` only by B.

This independently fixes a live rendering bug: `1\mathbf{2}` renders its `2` non-bold today, because site A's merge discards the bold before `getBold` can map the digit to U+1D7CE (LLD §2.6). Geometrically neutral for uniform-style input.

## Commits

1. `[item 1] Guard digit fusion on fontStyle in MTMathList.finalized`
2. `[item 2] Guard Rule-14 fusion on fontStyle in preprocessMathList`

Full `swift test` green at each commit (451 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed math rendering so adjacent numbers and symbols with different font styles remain separate.
  * Prevented italic, bold, and mixed-style content from being incorrectly merged.
  * Continued combining adjacent content when it uses the same font style, preserving existing formatting behavior.
  * Improved consistency of font-style handling during math layout and rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->